### PR TITLE
PR 4: Historia integracji PLI CBD i ujednolicenie operacji eksportu/synchronizacji

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "tsx watch src/app.ts",
     "build": "tsc",
-    "start": "node dist/app.js",
+    "start": "node dist/apps/backend/src/app.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/apps/backend/prisma/migrations/20260401153000_pr4_pli_cbd_integration_history/migration.sql
+++ b/apps/backend/prisma/migrations/20260401153000_pr4_pli_cbd_integration_history/migration.sql
@@ -1,0 +1,44 @@
+-- CreateEnum
+DO $$
+BEGIN
+    CREATE TYPE "PliCbdIntegrationDirection" AS ENUM ('EXPORT', 'SYNC');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateEnum
+DO $$
+BEGIN
+    CREATE TYPE "PliCbdIntegrationStatus" AS ENUM ('PENDING', 'SUCCESS', 'ERROR');
+EXCEPTION
+    WHEN duplicate_object THEN NULL;
+END $$;
+
+-- CreateTable
+CREATE TABLE "pli_cbd_integration_events" (
+    "id" TEXT NOT NULL,
+    "portingRequestId" TEXT NOT NULL,
+    "operationType" "PliCbdIntegrationDirection" NOT NULL,
+    "operationStatus" "PliCbdIntegrationStatus" NOT NULL,
+    "actionName" VARCHAR(100),
+    "requestPayloadJson" JSONB,
+    "responsePayloadJson" JSONB,
+    "errorMessage" TEXT,
+    "triggeredByUserId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completedAt" TIMESTAMP(3),
+
+    CONSTRAINT "pli_cbd_integration_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "pli_cbd_integration_events_portingRequestId_idx" ON "pli_cbd_integration_events"("portingRequestId");
+
+-- CreateIndex
+CREATE INDEX "pli_cbd_integration_events_portingRequestId_createdAt_idx" ON "pli_cbd_integration_events"("portingRequestId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "pli_cbd_integration_events" ADD CONSTRAINT "pli_cbd_integration_events_portingRequestId_fkey" FOREIGN KEY ("portingRequestId") REFERENCES "porting_requests"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "pli_cbd_integration_events" ADD CONSTRAINT "pli_cbd_integration_events_triggeredByUserId_fkey" FOREIGN KEY ("triggeredByUserId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -152,6 +152,17 @@ enum PortingEventType {
   NOTE
 }
 
+enum PliCbdIntegrationDirection {
+  EXPORT
+  SYNC
+}
+
+enum PliCbdIntegrationStatus {
+  PENDING
+  SUCCESS
+  ERROR
+}
+
 // ============================================================
 // USERS — Użytkownicy systemu
 // ============================================================
@@ -168,16 +179,17 @@ model User {
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 
-  auditLogs              AuditLog[]
-  comments               Comment[]
-  uploadedDocuments      Document[]            @relation("UploadedBy")
-  verifiedDocuments      Document[]            @relation("VerifiedBy")
-  createdTasks           Task[]                @relation("TaskCreatedBy")
-  assignedTasks          Task[]                @relation("TaskAssignedTo")
-  statusHistories        StatusHistory[]
-  notifications          Notification[]
-  createdPortingRequests PortingRequest[]      @relation("PortingRequestCreatedBy")
-  portingRequestEvents   PortingRequestEvent[] @relation("PortingEventCreatedBy")
+  auditLogs               AuditLog[]
+  comments                Comment[]
+  uploadedDocuments       Document[]               @relation("UploadedBy")
+  verifiedDocuments       Document[]               @relation("VerifiedBy")
+  createdTasks            Task[]                   @relation("TaskCreatedBy")
+  assignedTasks           Task[]                   @relation("TaskAssignedTo")
+  statusHistories         StatusHistory[]
+  notifications           Notification[]
+  createdPortingRequests  PortingRequest[]         @relation("PortingRequestCreatedBy")
+  portingRequestEvents    PortingRequestEvent[]    @relation("PortingEventCreatedBy")
+  pliCbdIntegrationEvents PliCbdIntegrationEvent[] @relation("PliCbdIntegrationTriggeredBy")
 
   @@map("users")
 }
@@ -348,13 +360,14 @@ model PortingRequest {
   infrastructureOperator Operator? @relation("InfrastructureOperator", fields: [infrastructureOperatorId], references: [id])
   createdByUser          User      @relation("PortingRequestCreatedBy", fields: [createdByUserId], references: [id])
 
-  phoneNumbers  PhoneNumber[]
-  documents     Document[]
-  comments      Comment[]
-  statusHistory StatusHistory[]
-  tasks         Task[]
-  auditLogs     AuditLog[]
-  events        PortingRequestEvent[]
+  phoneNumbers            PhoneNumber[]
+  documents               Document[]
+  comments                Comment[]
+  statusHistory           StatusHistory[]
+  tasks                   Task[]
+  auditLogs               AuditLog[]
+  events                  PortingRequestEvent[]
+  pliCbdIntegrationEvents PliCbdIntegrationEvent[]
 
   @@index([clientId])
   @@index([statusInternal])
@@ -597,6 +610,27 @@ model PortingRequestEvent {
 // ============================================================
 // SYSTEM SETTINGS — Konfiguracja systemu
 // ============================================================
+
+model PliCbdIntegrationEvent {
+  id                  String                     @id @default(uuid())
+  portingRequestId    String
+  operationType       PliCbdIntegrationDirection
+  operationStatus     PliCbdIntegrationStatus
+  actionName          String?                    @db.VarChar(100)
+  requestPayloadJson  Json?
+  responsePayloadJson Json?
+  errorMessage        String?                    @db.Text
+  triggeredByUserId   String?
+  createdAt           DateTime                   @default(now())
+  completedAt         DateTime?
+
+  portingRequest PortingRequest @relation(fields: [portingRequestId], references: [id], onDelete: Cascade)
+  triggeredBy    User?          @relation("PliCbdIntegrationTriggeredBy", fields: [triggeredByUserId], references: [id])
+
+  @@index([portingRequestId])
+  @@index([portingRequestId, createdAt])
+  @@map("pli_cbd_integration_events")
+}
 
 model SystemSetting {
   id        String   @id @default(uuid())

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -672,7 +672,7 @@ async function main() {
   const adminPassword = 'Admin@NP2026!'
   const adminPasswordHash = await bcrypt.hash(adminPassword, 12)
 
-  await prisma.user.upsert({
+  const adminUser = await prisma.user.upsert({
     where: { email: 'admin@np-manager.local' },
     update: {
       passwordHash: adminPasswordHash,
@@ -721,7 +721,221 @@ async function main() {
   console.info('   🔑  Hasło:   Bok@NP2026!')
 
   // ----------------------------------------------------------
-  // 6. USTAWIENIA SYSTEMOWE
+  // 6. DANE QA â€” klient i sprawy portowania
+  // ----------------------------------------------------------
+  console.info('Tworzenie minimalnych danych QA dla portowania...')
+
+  const qaClient = await prisma.client.upsert({
+    where: { pesel: '90010112345' },
+    update: {
+      clientType: 'INDIVIDUAL',
+      firstName: 'Jan',
+      lastName: 'Testowy',
+      pesel: '90010112345',
+      companyName: null,
+      nip: null,
+      krs: null,
+      proxyName: null,
+      proxyPesel: null,
+      email: 'jan.testowy@np-manager.local',
+      phoneContact: '600700800',
+      addressStreet: 'ul. Testowa 10/5',
+      addressCity: 'Warszawa',
+      addressZip: '00-001',
+      createdById: adminUser.id,
+    },
+    create: {
+      clientType: 'INDIVIDUAL',
+      firstName: 'Jan',
+      lastName: 'Testowy',
+      pesel: '90010112345',
+      email: 'jan.testowy@np-manager.local',
+      phoneContact: '600700800',
+      addressStreet: 'ul. Testowa 10/5',
+      addressCity: 'Warszawa',
+      addressZip: '00-001',
+      createdById: adminUser.id,
+    },
+  })
+
+  const recipientOperator = await prisma.operator.findUniqueOrThrow({
+    where: { routingNumber: 'GNET' },
+  })
+
+  const donorOperator = await prisma.operator.findUniqueOrThrow({
+    where: { routingNumber: 'ORANGE' },
+  })
+
+  await prisma.portingRequest.upsert({
+    where: { caseNumber: 'FNP-SEED-ACTIVE-001' },
+    update: {
+      clientId: qaClient.id,
+      numberType: 'FIXED_LINE',
+      numberRangeKind: 'SINGLE',
+      primaryNumber: '221234567',
+      rangeStart: null,
+      rangeEnd: null,
+      requestDocumentNumber: 'DOC-SEED-ACT-001',
+      donorOperatorId: donorOperator.id,
+      recipientOperatorId: recipientOperator.id,
+      infrastructureOperatorId: null,
+      donorRoutingNumber: donorOperator.routingNumber,
+      recipientRoutingNumber: recipientOperator.routingNumber,
+      requestRegisteredAt: new Date('2026-04-01T09:00:00.000Z'),
+      requestedPortDate: new Date('2026-04-15T00:00:00.000Z'),
+      requestedPortTime: '00:00',
+      earliestAcceptablePortDate: null,
+      confirmedPortDate: null,
+      donorAssignedPortDate: null,
+      donorAssignedPortTime: null,
+      portingMode: 'DAY',
+      statusInternal: 'SUBMITTED',
+      statusPliCbd: null,
+      pliCbdCaseId: null,
+      pliCbdCaseNumber: null,
+      pliCbdPackageId: null,
+      pliCbdExportStatus: 'NOT_EXPORTED',
+      pliCbdLastSyncAt: null,
+      lastExxReceived: null,
+      lastPliCbdStatusCode: null,
+      lastPliCbdStatusDescription: null,
+      rejectionCode: null,
+      rejectionReason: null,
+      subscriberKind: 'INDIVIDUAL',
+      subscriberFirstName: 'Jan',
+      subscriberLastName: 'Testowy',
+      subscriberCompanyName: null,
+      identityType: 'PESEL',
+      identityValue: '90010112345',
+      correspondenceAddress: 'ul. Testowa 10/5, 00-001 Warszawa',
+      hasPowerOfAttorney: false,
+      linkedWholesaleServiceOnRecipientSide: false,
+      contactChannel: 'EMAIL',
+      internalNotes: 'Seed QA: aktywna sprawa do testu eksportu i synchronizacji PLI CBD.',
+      createdByUserId: adminUser.id,
+    },
+    create: {
+      caseNumber: 'FNP-SEED-ACTIVE-001',
+      clientId: qaClient.id,
+      numberType: 'FIXED_LINE',
+      numberRangeKind: 'SINGLE',
+      primaryNumber: '221234567',
+      requestDocumentNumber: 'DOC-SEED-ACT-001',
+      donorOperatorId: donorOperator.id,
+      recipientOperatorId: recipientOperator.id,
+      donorRoutingNumber: donorOperator.routingNumber,
+      recipientRoutingNumber: recipientOperator.routingNumber,
+      requestRegisteredAt: new Date('2026-04-01T09:00:00.000Z'),
+      requestedPortDate: new Date('2026-04-15T00:00:00.000Z'),
+      requestedPortTime: '00:00',
+      portingMode: 'DAY',
+      statusInternal: 'SUBMITTED',
+      pliCbdExportStatus: 'NOT_EXPORTED',
+      subscriberKind: 'INDIVIDUAL',
+      subscriberFirstName: 'Jan',
+      subscriberLastName: 'Testowy',
+      identityType: 'PESEL',
+      identityValue: '90010112345',
+      correspondenceAddress: 'ul. Testowa 10/5, 00-001 Warszawa',
+      hasPowerOfAttorney: false,
+      linkedWholesaleServiceOnRecipientSide: false,
+      contactChannel: 'EMAIL',
+      internalNotes: 'Seed QA: aktywna sprawa do testu eksportu i synchronizacji PLI CBD.',
+      createdByUserId: adminUser.id,
+    },
+  })
+
+  await prisma.portingRequest.upsert({
+    where: { caseNumber: 'FNP-SEED-PORTED-001' },
+    update: {
+      clientId: qaClient.id,
+      numberType: 'FIXED_LINE',
+      numberRangeKind: 'SINGLE',
+      primaryNumber: '221234568',
+      rangeStart: null,
+      rangeEnd: null,
+      requestDocumentNumber: 'DOC-SEED-PRT-001',
+      donorOperatorId: donorOperator.id,
+      recipientOperatorId: recipientOperator.id,
+      infrastructureOperatorId: null,
+      donorRoutingNumber: donorOperator.routingNumber,
+      recipientRoutingNumber: recipientOperator.routingNumber,
+      requestRegisteredAt: new Date('2026-03-20T08:30:00.000Z'),
+      requestedPortDate: new Date('2026-03-28T00:00:00.000Z'),
+      requestedPortTime: '00:00',
+      earliestAcceptablePortDate: null,
+      confirmedPortDate: new Date('2026-03-28T00:00:00.000Z'),
+      donorAssignedPortDate: new Date('2026-03-28T00:00:00.000Z'),
+      donorAssignedPortTime: '08:00',
+      portingMode: 'DAY',
+      statusInternal: 'PORTED',
+      statusPliCbd: 'PORTED',
+      pliCbdCaseId: 'PLI-SEED-PORTED-001',
+      pliCbdCaseNumber: 'PLI-SEED-PORTED-001',
+      pliCbdPackageId: null,
+      pliCbdExportStatus: 'EXPORTED',
+      pliCbdLastSyncAt: new Date('2026-03-28T08:15:00.000Z'),
+      lastExxReceived: null,
+      lastPliCbdStatusCode: 'PORTED',
+      lastPliCbdStatusDescription: 'Seed QA: sprawa zakonczona do testu zablokowanego eksportu.',
+      rejectionCode: null,
+      rejectionReason: null,
+      subscriberKind: 'INDIVIDUAL',
+      subscriberFirstName: 'Jan',
+      subscriberLastName: 'Testowy',
+      subscriberCompanyName: null,
+      identityType: 'PESEL',
+      identityValue: '90010112345',
+      correspondenceAddress: 'ul. Testowa 10/5, 00-001 Warszawa',
+      hasPowerOfAttorney: false,
+      linkedWholesaleServiceOnRecipientSide: false,
+      contactChannel: 'EMAIL',
+      internalNotes: 'Seed QA: zakonczona sprawa do testu wpisu ERROR dla zablokowanego eksportu.',
+      createdByUserId: adminUser.id,
+    },
+    create: {
+      caseNumber: 'FNP-SEED-PORTED-001',
+      clientId: qaClient.id,
+      numberType: 'FIXED_LINE',
+      numberRangeKind: 'SINGLE',
+      primaryNumber: '221234568',
+      requestDocumentNumber: 'DOC-SEED-PRT-001',
+      donorOperatorId: donorOperator.id,
+      recipientOperatorId: recipientOperator.id,
+      donorRoutingNumber: donorOperator.routingNumber,
+      recipientRoutingNumber: recipientOperator.routingNumber,
+      requestRegisteredAt: new Date('2026-03-20T08:30:00.000Z'),
+      requestedPortDate: new Date('2026-03-28T00:00:00.000Z'),
+      requestedPortTime: '00:00',
+      confirmedPortDate: new Date('2026-03-28T00:00:00.000Z'),
+      donorAssignedPortDate: new Date('2026-03-28T00:00:00.000Z'),
+      donorAssignedPortTime: '08:00',
+      portingMode: 'DAY',
+      statusInternal: 'PORTED',
+      statusPliCbd: 'PORTED',
+      pliCbdCaseId: 'PLI-SEED-PORTED-001',
+      pliCbdCaseNumber: 'PLI-SEED-PORTED-001',
+      pliCbdExportStatus: 'EXPORTED',
+      pliCbdLastSyncAt: new Date('2026-03-28T08:15:00.000Z'),
+      lastPliCbdStatusCode: 'PORTED',
+      lastPliCbdStatusDescription: 'Seed QA: sprawa zakonczona do testu zablokowanego eksportu.',
+      subscriberKind: 'INDIVIDUAL',
+      subscriberFirstName: 'Jan',
+      subscriberLastName: 'Testowy',
+      identityType: 'PESEL',
+      identityValue: '90010112345',
+      correspondenceAddress: 'ul. Testowa 10/5, 00-001 Warszawa',
+      hasPowerOfAttorney: false,
+      linkedWholesaleServiceOnRecipientSide: false,
+      contactChannel: 'EMAIL',
+      internalNotes: 'Seed QA: zakonczona sprawa do testu wpisu ERROR dla zablokowanego eksportu.',
+      createdByUserId: adminUser.id,
+    },
+  })
+  console.info('Dodano klienta QA oraz 2 sprawy portowania (aktywna + zakonczona)')
+
+  // ----------------------------------------------------------
+  // 7. USTAWIENIA SYSTEMOWE
   // ----------------------------------------------------------
   console.info('⚙️  Tworzenie ustawień systemowych...')
 
@@ -780,7 +994,7 @@ async function main() {
   console.info(`   ✓ Utworzono ${settings.length} ustawień systemowych`)
 
   // ----------------------------------------------------------
-  // 7. KALENDARZ ŚWIĄT 2026
+  // 8. KALENDARZ ŚWIĄT 2026
   // ----------------------------------------------------------
   console.info('📅 Tworzenie kalendarza dni wolnych 2026...')
 

--- a/apps/backend/src/modules/pli-cbd/pli-cbd.adapter.ts
+++ b/apps/backend/src/modules/pli-cbd/pli-cbd.adapter.ts
@@ -1,0 +1,72 @@
+import { Prisma, type PliCbdExportStatus } from '@prisma/client'
+import type { PliCbdExxType } from '@np-manager/shared'
+
+export const PLI_CBD_TRIGGER_SELECT = {
+  id: true,
+  caseNumber: true,
+  numberType: true,
+  numberRangeKind: true,
+  primaryNumber: true,
+  rangeStart: true,
+  rangeEnd: true,
+  portingMode: true,
+  requestedPortDate: true,
+  earliestAcceptablePortDate: true,
+  statusInternal: true,
+  pliCbdCaseId: true,
+  pliCbdCaseNumber: true,
+  pliCbdExportStatus: true,
+  donorAssignedPortDate: true,
+  donorAssignedPortTime: true,
+  lastExxReceived: true,
+  lastPliCbdStatusCode: true,
+  lastPliCbdStatusDescription: true,
+  donorOperator: {
+    select: { id: true, name: true, routingNumber: true },
+  },
+  recipientOperator: {
+    select: { id: true, name: true, routingNumber: true },
+  },
+} as const
+
+export type PliCbdTriggerRow = Prisma.PortingRequestGetPayload<{
+  select: typeof PLI_CBD_TRIGGER_SELECT
+}>
+
+export interface PortingRequestPliCbdAdapterResult {
+  exportStatus?: PliCbdExportStatus
+  pliCbdCaseId?: string | null
+  pliCbdCaseNumber?: string | null
+  pliCbdLastSyncAt?: Date | null
+  donorAssignedPortDate?: Date | null
+  donorAssignedPortTime?: string | null
+  lastPliCbdMessageType?: PliCbdExxType | null
+  lastPliCbdStatusCode?: string | null
+  lastPliCbdStatusDescription?: string | null
+}
+
+export interface PortingRequestPliCbdAdapter {
+  exportPortingRequestToPliCbd(
+    request: PliCbdTriggerRow,
+  ): Promise<PortingRequestPliCbdAdapterResult>
+  syncPortingRequestFromPliCbd(
+    request: PliCbdTriggerRow,
+  ): Promise<PortingRequestPliCbdAdapterResult>
+}
+
+class ManualPliCbdAdapter implements PortingRequestPliCbdAdapter {
+  async exportPortingRequestToPliCbd(): Promise<PortingRequestPliCbdAdapterResult> {
+    return {
+      exportStatus: 'EXPORT_PENDING',
+    }
+  }
+
+  async syncPortingRequestFromPliCbd(): Promise<PortingRequestPliCbdAdapterResult> {
+    return {
+      pliCbdLastSyncAt: new Date(),
+    }
+  }
+}
+
+export const portingRequestPliCbdAdapter: PortingRequestPliCbdAdapter =
+  new ManualPliCbdAdapter()

--- a/apps/backend/src/modules/pli-cbd/pli-cbd.integration-tracker.ts
+++ b/apps/backend/src/modules/pli-cbd/pli-cbd.integration-tracker.ts
@@ -108,6 +108,28 @@ export async function withPliCbdIntegrationTracking(
   }
 }
 
+export async function createFailedIntegrationAttempt(
+  portingRequestId: string,
+  triggeredByUserId: string | null,
+  operationType: IntegrationOperationType,
+  requestPayload: PliCbdTriggerRow,
+  actionName: string,
+  errorMessage: string,
+): Promise<void> {
+  await prisma.pliCbdIntegrationEvent.create({
+    data: {
+      portingRequestId,
+      operationType,
+      operationStatus: 'ERROR',
+      actionName,
+      requestPayloadJson: toSerializableJsonValue(requestPayload),
+      errorMessage,
+      triggeredByUserId,
+      completedAt: new Date(),
+    },
+  })
+}
+
 export async function getPliCbdIntegrationEvents(
   portingRequestId: string,
 ): Promise<PliCbdIntegrationEventsResultDto> {

--- a/apps/backend/src/modules/pli-cbd/pli-cbd.integration-tracker.ts
+++ b/apps/backend/src/modules/pli-cbd/pli-cbd.integration-tracker.ts
@@ -1,0 +1,141 @@
+import { Prisma } from '@prisma/client'
+import { prisma } from '../../config/database'
+import type {
+  PliCbdIntegrationEventDto,
+  PliCbdIntegrationEventsResultDto,
+} from '@np-manager/shared'
+import type {
+  PliCbdTriggerRow,
+  PortingRequestPliCbdAdapterResult,
+} from './pli-cbd.adapter'
+
+type IntegrationOperationType = 'EXPORT' | 'SYNC'
+
+function toSerializableJsonValue(value: unknown): Prisma.InputJsonValue | undefined {
+  if (value === null || value === undefined) {
+    return undefined
+  }
+
+  return JSON.parse(
+    JSON.stringify(value, (_key, nestedValue: unknown) => {
+      if (nestedValue instanceof Date) {
+        return nestedValue.toISOString()
+      }
+
+      return nestedValue
+    }),
+  ) as Prisma.InputJsonValue
+}
+
+function toIntegrationEventDto(row: {
+  id: string
+  portingRequestId: string
+  operationType: 'EXPORT' | 'SYNC'
+  operationStatus: 'PENDING' | 'SUCCESS' | 'ERROR'
+  actionName: string | null
+  requestPayloadJson: Prisma.JsonValue | null
+  responsePayloadJson: Prisma.JsonValue | null
+  errorMessage: string | null
+  triggeredByUserId: string | null
+  createdAt: Date
+  completedAt: Date | null
+  triggeredBy: { firstName: string; lastName: string } | null
+}): PliCbdIntegrationEventDto {
+  return {
+    id: row.id,
+    portingRequestId: row.portingRequestId,
+    operationType: row.operationType,
+    operationStatus: row.operationStatus,
+    actionName: row.actionName,
+    requestPayloadJson: row.requestPayloadJson,
+    responsePayloadJson: row.responsePayloadJson,
+    errorMessage: row.errorMessage,
+    triggeredByUserId: row.triggeredByUserId,
+    triggeredByDisplayName: row.triggeredBy
+      ? `${row.triggeredBy.firstName} ${row.triggeredBy.lastName}`
+      : null,
+    createdAt: row.createdAt.toISOString(),
+    completedAt: row.completedAt?.toISOString() ?? null,
+  }
+}
+
+export async function withPliCbdIntegrationTracking(
+  portingRequestId: string,
+  triggeredByUserId: string | null,
+  operationType: IntegrationOperationType,
+  requestPayload: PliCbdTriggerRow,
+  actionName: string,
+  run: () => Promise<PortingRequestPliCbdAdapterResult>,
+): Promise<PortingRequestPliCbdAdapterResult> {
+  const integrationEvent = await prisma.pliCbdIntegrationEvent.create({
+    data: {
+      portingRequestId,
+      operationType,
+      operationStatus: 'PENDING',
+      actionName,
+      requestPayloadJson: toSerializableJsonValue(requestPayload),
+      triggeredByUserId,
+    },
+    select: { id: true, createdAt: true },
+  })
+
+  try {
+    const result = await run()
+
+    await prisma.pliCbdIntegrationEvent.update({
+      where: { id: integrationEvent.id },
+      data: {
+        operationStatus: 'SUCCESS',
+        responsePayloadJson: toSerializableJsonValue(result),
+        completedAt: new Date(),
+      },
+    })
+
+    return result
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Nieznany blad integracji PLI CBD.'
+
+    await prisma.pliCbdIntegrationEvent.update({
+      where: { id: integrationEvent.id },
+      data: {
+        operationStatus: 'ERROR',
+        errorMessage: message,
+        completedAt: new Date(),
+      },
+    })
+
+    throw error
+  }
+}
+
+export async function getPliCbdIntegrationEvents(
+  portingRequestId: string,
+): Promise<PliCbdIntegrationEventsResultDto> {
+  const rows = await prisma.pliCbdIntegrationEvent.findMany({
+    where: { portingRequestId },
+    orderBy: { createdAt: 'desc' },
+    select: {
+      id: true,
+      portingRequestId: true,
+      operationType: true,
+      operationStatus: true,
+      actionName: true,
+      requestPayloadJson: true,
+      responsePayloadJson: true,
+      errorMessage: true,
+      triggeredByUserId: true,
+      createdAt: true,
+      completedAt: true,
+      triggeredBy: {
+        select: {
+          firstName: true,
+          lastName: true,
+        },
+      },
+    },
+  })
+
+  return {
+    items: rows.map(toIntegrationEventDto),
+  }
+}

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -10,6 +10,7 @@ import {
 import {
   createPortingRequest,
   exportPortingRequestToPliCbd,
+  getPortingRequestIntegrationEvents,
   getPortingRequest,
   listPortingRequests,
   syncPortingRequestFromPliCbd,
@@ -44,6 +45,15 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
     { preHandler: [authenticate, authorize(readRoles)] },
     async (request, reply) => {
       const result = await getPortingRequestTimeline(request.params.id)
+      return reply.status(200).send({ success: true, data: result })
+    },
+  )
+
+  app.get<{ Params: { id: string } }>(
+    '/:id/integration-events',
+    { preHandler: [authenticate, authorize(pliCbdRoles)] },
+    async (request, reply) => {
+      const result = await getPortingRequestIntegrationEvents(request.params.id)
       return reply.status(200).send({ success: true, data: result })
     },
   )

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -25,11 +25,13 @@ import {
   portingRequestPliCbdAdapter,
 } from '../pli-cbd/pli-cbd.adapter'
 import {
+  createFailedIntegrationAttempt,
   getPliCbdIntegrationEvents,
   withPliCbdIntegrationTracking,
 } from '../pli-cbd/pli-cbd.integration-tracker'
 
 const CLOSED_STATUSES: PortingCaseStatus[] = ['REJECTED', 'CANCELLED', 'PORTED']
+const PLI_CBD_MANUAL_TRIGGER_ACTION = 'MANUAL_FOUNDATION_TRIGGER'
 
 const CLIENT_SELECT = {
   id: true,
@@ -378,6 +380,28 @@ function assertStatusTransitionAllowed(
   }
 }
 
+async function throwBlockedPliCbdIntegrationAttempt(
+  request: PliCbdTriggerRow,
+  userId: string,
+  operationType: 'EXPORT' | 'SYNC',
+  error: AppError,
+): Promise<never> {
+  try {
+    await createFailedIntegrationAttempt(
+      request.id,
+      userId,
+      operationType,
+      request,
+      PLI_CBD_MANUAL_TRIGGER_ACTION,
+      error.message,
+    )
+  } catch {
+    // Audit failure must not mask the original business error returned to UI/API.
+  }
+
+  throw error
+}
+
 function toListItem(row: ListRow): PortingRequestListItemDto {
   return {
     id: row.id,
@@ -688,23 +712,15 @@ export async function exportPortingRequestToPliCbd(
   const request = await getPortingRequestForPliCbdOrThrow(requestId)
 
   if (CLOSED_STATUSES.includes(request.statusInternal)) {
-    const error = AppError.badRequest(
-      'Nie mozna eksportowac do PLI CBD sprawy zakonczonej lub zamknietej.',
-      'PORTING_REQUEST_ALREADY_CLOSED',
+    await throwBlockedPliCbdIntegrationAttempt(
+      request,
+      userId,
+      'EXPORT',
+      AppError.badRequest(
+        'Nie mozna eksportowac do PLI CBD sprawy zakonczonej lub zamknietej.',
+        'PORTING_REQUEST_ALREADY_CLOSED',
+      ),
     )
-
-    await prisma.pliCbdIntegrationEvent.create({
-      data: {
-        portingRequestId: request.id,
-        operationType: 'EXPORT',
-        operationStatus: 'ERROR',
-        actionName: PLI_CBD_MANUAL_TRIGGER_ACTION,
-        errorMessage: error.message,
-        triggeredByUserId: userId,
-      },
-    })
-
-    throw error
   }
 
   await PortingEvents.exportTriggered(requestId, userId)
@@ -714,7 +730,7 @@ export async function exportPortingRequestToPliCbd(
     userId,
     'EXPORT',
     request,
-    'MANUAL_FOUNDATION_TRIGGER',
+    PLI_CBD_MANUAL_TRIGGER_ACTION,
     () => portingRequestPliCbdAdapter.exportPortingRequestToPliCbd(request),
   )
 
@@ -778,23 +794,15 @@ export async function syncPortingRequestFromPliCbd(
   const request = await getPortingRequestForPliCbdOrThrow(requestId)
 
   if (request.pliCbdExportStatus === 'NOT_EXPORTED') {
-    const error = AppError.badRequest(
-      'Nie mozna synchronizowac sprawy, ktora nie zostala jeszcze wyeksportowana do PLI CBD.',
-      'PORTING_REQUEST_NOT_EXPORTED',
+    await throwBlockedPliCbdIntegrationAttempt(
+      request,
+      userId,
+      'SYNC',
+      AppError.badRequest(
+        'Nie mozna synchronizowac sprawy, ktora nie zostala jeszcze wyeksportowana do PLI CBD.',
+        'PORTING_REQUEST_NOT_EXPORTED',
+      ),
     )
-
-    await prisma.pliCbdIntegrationEvent.create({
-      data: {
-        portingRequestId: request.id,
-        operationType: 'SYNC',
-        operationStatus: 'ERROR',
-        actionName: PLI_CBD_MANUAL_TRIGGER_ACTION,
-        errorMessage: error.message,
-        triggeredByUserId: userId,
-      },
-    })
-
-    throw error
   }
 
   await PortingEvents.syncTriggered(requestId, userId)
@@ -804,7 +812,7 @@ export async function syncPortingRequestFromPliCbd(
     userId,
     'SYNC',
     request,
-    'MANUAL_FOUNDATION_TRIGGER',
+    PLI_CBD_MANUAL_TRIGGER_ACTION,
     () => portingRequestPliCbdAdapter.syncPortingRequestFromPliCbd(request),
   )
 

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -1,4 +1,4 @@
-import { Prisma, type PliCbdExportStatus, type PortingCaseStatus } from '@prisma/client'
+import { Prisma, type PortingCaseStatus } from '@prisma/client'
 import { prisma } from '../../config/database'
 import { AppError } from '../../shared/errors/app-error'
 import { logAuditEvent } from '../../shared/audit/audit.service'
@@ -6,9 +6,9 @@ import { PortingEvents } from './porting-events.service'
 import type {
   CreatePortingRequestDto,
   PortingRequestDetailDto,
+  PliCbdIntegrationEventsResultDto,
   PortingRequestListItemDto,
   PortingRequestListResultDto,
-  PliCbdExxType,
 } from '@np-manager/shared'
 import {
   getAllowedPortingCaseStatusTransitions,
@@ -19,6 +19,15 @@ import type {
   PortingRequestListQuery,
   UpdatePortingRequestStatusBody,
 } from './porting-requests.schema'
+import {
+  PLI_CBD_TRIGGER_SELECT,
+  type PliCbdTriggerRow,
+  portingRequestPliCbdAdapter,
+} from '../pli-cbd/pli-cbd.adapter'
+import {
+  getPliCbdIntegrationEvents,
+  withPliCbdIntegrationTracking,
+} from '../pli-cbd/pli-cbd.integration-tracker'
 
 const CLOSED_STATUSES: PortingCaseStatus[] = ['REJECTED', 'CANCELLED', 'PORTED']
 
@@ -110,39 +119,10 @@ const DETAIL_SELECT = {
   infrastructureOperator: { select: OPERATOR_SELECT },
 } as const
 
-const PLI_CBD_TRIGGER_SELECT = {
-  id: true,
-  caseNumber: true,
-  numberType: true,
-  numberRangeKind: true,
-  primaryNumber: true,
-  rangeStart: true,
-  rangeEnd: true,
-  portingMode: true,
-  requestedPortDate: true,
-  earliestAcceptablePortDate: true,
-  statusInternal: true,
-  pliCbdCaseId: true,
-  pliCbdCaseNumber: true,
-  pliCbdExportStatus: true,
-  donorAssignedPortDate: true,
-  donorAssignedPortTime: true,
-  lastExxReceived: true,
-  lastPliCbdStatusCode: true,
-  lastPliCbdStatusDescription: true,
-  donorOperator: {
-    select: { id: true, name: true, routingNumber: true },
-  },
-  recipientOperator: {
-    select: { id: true, name: true, routingNumber: true },
-  },
-} as const
-
 type ClientRow = Prisma.ClientGetPayload<{ select: typeof CLIENT_SELECT }>
 type OperatorRow = Prisma.OperatorGetPayload<{ select: typeof OPERATOR_SELECT }>
 type ListRow = Prisma.PortingRequestGetPayload<{ select: typeof LIST_SELECT }>
 type DetailRow = Prisma.PortingRequestGetPayload<{ select: typeof DETAIL_SELECT }>
-type PliCbdTriggerRow = Prisma.PortingRequestGetPayload<{ select: typeof PLI_CBD_TRIGGER_SELECT }>
 type StatusChangeRow = Prisma.PortingRequestGetPayload<{
   select: {
     id: true
@@ -150,39 +130,6 @@ type StatusChangeRow = Prisma.PortingRequestGetPayload<{
     statusInternal: true
   }
 }>
-
-interface PortingRequestPliCbdAdapterResult {
-  exportStatus?: PliCbdExportStatus
-  pliCbdCaseId?: string | null
-  pliCbdCaseNumber?: string | null
-  pliCbdLastSyncAt?: Date | null
-  donorAssignedPortDate?: Date | null
-  donorAssignedPortTime?: string | null
-  lastPliCbdMessageType?: PliCbdExxType | null
-  lastPliCbdStatusCode?: string | null
-  lastPliCbdStatusDescription?: string | null
-}
-
-interface PortingRequestPliCbdAdapter {
-  exportPortingRequestToPliCbd(request: PliCbdTriggerRow): Promise<PortingRequestPliCbdAdapterResult>
-  syncPortingRequestFromPliCbd(request: PliCbdTriggerRow): Promise<PortingRequestPliCbdAdapterResult>
-}
-
-class ManualPliCbdAdapter implements PortingRequestPliCbdAdapter {
-  async exportPortingRequestToPliCbd(): Promise<PortingRequestPliCbdAdapterResult> {
-    return {
-      exportStatus: 'EXPORT_PENDING',
-    }
-  }
-
-  async syncPortingRequestFromPliCbd(): Promise<PortingRequestPliCbdAdapterResult> {
-    return {
-      pliCbdLastSyncAt: new Date(),
-    }
-  }
-}
-
-const portingRequestPliCbdAdapter: PortingRequestPliCbdAdapter = new ManualPliCbdAdapter()
 
 function getClientDisplayName(client: {
   clientType: string
@@ -676,6 +623,13 @@ export async function getPortingRequest(id: string): Promise<PortingRequestDetai
   return toDetailDto(request)
 }
 
+export async function getPortingRequestIntegrationEvents(
+  requestId: string,
+): Promise<PliCbdIntegrationEventsResultDto> {
+  await getPortingRequestForPliCbdOrThrow(requestId)
+  return getPliCbdIntegrationEvents(requestId)
+}
+
 export async function updatePortingRequestStatus(
   requestId: string,
   body: UpdatePortingRequestStatusBody,
@@ -742,7 +696,14 @@ export async function exportPortingRequestToPliCbd(
 
   await PortingEvents.exportTriggered(requestId, userId)
 
-  const adapterResult = await portingRequestPliCbdAdapter.exportPortingRequestToPliCbd(request)
+  const adapterResult = await withPliCbdIntegrationTracking(
+    requestId,
+    userId,
+    'EXPORT',
+    request,
+    'MANUAL_FOUNDATION_TRIGGER',
+    () => portingRequestPliCbdAdapter.exportPortingRequestToPliCbd(request),
+  )
 
   const resolvedExportStatus = adapterResult.exportStatus ?? request.pliCbdExportStatus
 
@@ -812,7 +773,14 @@ export async function syncPortingRequestFromPliCbd(
 
   await PortingEvents.syncTriggered(requestId, userId)
 
-  const adapterResult = await portingRequestPliCbdAdapter.syncPortingRequestFromPliCbd(request)
+  const adapterResult = await withPliCbdIntegrationTracking(
+    requestId,
+    userId,
+    'SYNC',
+    request,
+    'MANUAL_FOUNDATION_TRIGGER',
+    () => portingRequestPliCbdAdapter.syncPortingRequestFromPliCbd(request),
+  )
 
   const resolvedSyncAt = adapterResult.pliCbdLastSyncAt ?? new Date()
 

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -688,10 +688,23 @@ export async function exportPortingRequestToPliCbd(
   const request = await getPortingRequestForPliCbdOrThrow(requestId)
 
   if (CLOSED_STATUSES.includes(request.statusInternal)) {
-    throw AppError.badRequest(
+    const error = AppError.badRequest(
       'Nie mozna eksportowac do PLI CBD sprawy zakonczonej lub zamknietej.',
       'PORTING_REQUEST_ALREADY_CLOSED',
     )
+
+    await prisma.pliCbdIntegrationEvent.create({
+      data: {
+        portingRequestId: request.id,
+        operationType: 'EXPORT',
+        operationStatus: 'ERROR',
+        actionName: PLI_CBD_MANUAL_TRIGGER_ACTION,
+        errorMessage: error.message,
+        triggeredByUserId: userId,
+      },
+    })
+
+    throw error
   }
 
   await PortingEvents.exportTriggered(requestId, userId)
@@ -765,10 +778,23 @@ export async function syncPortingRequestFromPliCbd(
   const request = await getPortingRequestForPliCbdOrThrow(requestId)
 
   if (request.pliCbdExportStatus === 'NOT_EXPORTED') {
-    throw AppError.badRequest(
+    const error = AppError.badRequest(
       'Nie mozna synchronizowac sprawy, ktora nie zostala jeszcze wyeksportowana do PLI CBD.',
       'PORTING_REQUEST_NOT_EXPORTED',
     )
+
+    await prisma.pliCbdIntegrationEvent.create({
+      data: {
+        portingRequestId: request.id,
+        operationType: 'SYNC',
+        operationStatus: 'ERROR',
+        actionName: PLI_CBD_MANUAL_TRIGGER_ACTION,
+        errorMessage: error.message,
+        triggeredByUserId: userId,
+      },
+    })
+
+    throw error
   }
 
   await PortingEvents.syncTriggered(requestId, userId)

--- a/apps/frontend/src/components/PliCbdIntegrationHistory/PliCbdIntegrationHistory.tsx
+++ b/apps/frontend/src/components/PliCbdIntegrationHistory/PliCbdIntegrationHistory.tsx
@@ -1,0 +1,99 @@
+import {
+  PLI_CBD_INTEGRATION_DIRECTION_LABELS,
+  PLI_CBD_INTEGRATION_STATUS_LABELS,
+} from '@np-manager/shared'
+import type { PliCbdIntegrationEventDto } from '@np-manager/shared'
+
+interface PliCbdIntegrationHistoryProps {
+  items: PliCbdIntegrationEventDto[]
+  isLoading: boolean
+}
+
+function getStatusClassName(status: PliCbdIntegrationEventDto['operationStatus']): string {
+  if (status === 'SUCCESS') {
+    return 'bg-green-100 text-green-700'
+  }
+
+  if (status === 'ERROR') {
+    return 'bg-red-100 text-red-700'
+  }
+
+  return 'bg-amber-100 text-amber-700'
+}
+
+function formatDateTime(value: string): string {
+  return new Date(value).toLocaleString('pl-PL', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function PliCbdIntegrationHistory({
+  items,
+  isLoading,
+}: PliCbdIntegrationHistoryProps) {
+  return (
+    <div className="card p-5 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-1">
+          Historia integracji PLI CBD
+        </h2>
+        <p className="text-sm text-gray-500">
+          Rejestr eksportow i synchronizacji wykonywanych dla tej sprawy.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+          Ladowanie historii integracji...
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+          Brak zapisanych operacji integracyjnych dla tej sprawy.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className="rounded-lg border border-gray-200 bg-white px-4 py-3"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-medium text-gray-900">
+                      {PLI_CBD_INTEGRATION_DIRECTION_LABELS[item.operationType]}
+                    </span>
+                    <span
+                      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${getStatusClassName(item.operationStatus)}`}
+                    >
+                      {PLI_CBD_INTEGRATION_STATUS_LABELS[item.operationStatus]}
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-600">
+                    {item.errorMessage ??
+                      item.actionName ??
+                      'Operacja foundation PLI CBD zostala zapisana.'}
+                  </p>
+                  <p className="text-xs text-gray-500">
+                    {item.triggeredByDisplayName
+                      ? `Wyzwolil: ${item.triggeredByDisplayName}`
+                      : 'Wyzwolono bez przypisanego uzytkownika'}
+                  </p>
+                </div>
+
+                <div className="text-xs text-gray-500 sm:text-right">
+                  <p>{formatDateTime(item.createdAt)}</p>
+                  {item.completedAt && <p>Zakonczono: {formatDateTime(item.completedAt)}</p>}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/Clients/ClientDetailPage.tsx
+++ b/apps/frontend/src/pages/Clients/ClientDetailPage.tsx
@@ -50,6 +50,7 @@ export function ClientDetailPage() {
   }
 
   const editPath = buildPath(ROUTES.CLIENT_EDIT, client.id)
+  const requestNewPath = `${ROUTES.REQUEST_NEW}?clientId=${encodeURIComponent(client.id)}`
   const isIndividual = client.clientType === 'INDIVIDUAL'
   const hasProxy = client.proxyName || client.proxyPesel
 
@@ -59,7 +60,7 @@ export function ClientDetailPage() {
   return (
     <div className="p-6 space-y-4 max-w-4xl">
       {/* Nagłówek */}
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div>
           <button
             onClick={() => void navigate(ROUTES.CLIENTS)}
@@ -86,9 +87,14 @@ export function ClientDetailPage() {
             )}
           </div>
         </div>
-        <Link to={editPath} className="btn-primary flex-shrink-0">
-          Edytuj klienta
-        </Link>
+        <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-start">
+          <Link to={requestNewPath} className="btn-secondary text-center">
+            Nowa sprawa portowania
+          </Link>
+          <Link to={editPath} className="btn-primary text-center">
+            Edytuj klienta
+          </Link>
+        </div>
       </div>
 
       {/* Dane podstawowe */}

--- a/apps/frontend/src/pages/Clients/ClientNewPage.tsx
+++ b/apps/frontend/src/pages/Clients/ClientNewPage.tsx
@@ -1,5 +1,5 @@
 import { useState, type FormEvent, type ChangeEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import axios from 'axios'
 import { ROUTES, buildPath } from '@/constants/routes'
 import { createClient, type CreateClientPayload } from '@/services/clients.api'
@@ -38,10 +38,14 @@ const EMPTY_FORM: FormFields = {
 
 export function ClientNewPage() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
   const [clientType, setClientType] = useState<ClientType>('INDIVIDUAL')
   const [fields, setFields] = useState<FormFields>(EMPTY_FORM)
   const [errors, setErrors] = useState<FieldErrors>({})
   const [isLoading, setIsLoading] = useState(false)
+  const returnTo = searchParams.get('returnTo')
+  const isRequestCreationFlow = returnTo === ROUTES.REQUEST_NEW
+  const cancelTarget = isRequestCreationFlow ? ROUTES.REQUEST_NEW : ROUTES.CLIENTS
 
   const setField = (key: keyof FormFields) => (e: ChangeEvent<HTMLInputElement>) => {
     setFields((prev) => ({ ...prev, [key]: e.target.value }))
@@ -143,7 +147,15 @@ export function ClientNewPage() {
 
     try {
       const client = await createClient(payload)
-      void navigate(buildPath(ROUTES.CLIENT_DETAIL, client.id))
+      if (isRequestCreationFlow) {
+        const nextParams = new URLSearchParams({
+          clientId: client.id,
+          requestCreatedClient: '1',
+        })
+        void navigate(`${ROUTES.REQUEST_NEW}?${nextParams.toString()}`)
+      } else {
+        void navigate(buildPath(ROUTES.CLIENT_DETAIL, client.id))
+      }
     } catch (err) {
       if (axios.isAxiosError(err)) {
         if (err.response?.status === 409) {
@@ -185,12 +197,17 @@ export function ClientNewPage() {
       {/* Nagłówek */}
       <div className="mb-6">
         <button
-          onClick={() => void navigate(ROUTES.CLIENTS)}
+          onClick={() => void navigate(cancelTarget)}
           className="text-sm text-gray-500 hover:text-gray-700 mb-2 flex items-center gap-1"
         >
           ← Kartoteka klientów
         </button>
         <h1 className="text-2xl font-bold text-gray-900">Nowy klient</h1>
+        {isRequestCreationFlow && (
+          <p className="mt-2 text-sm text-gray-500">
+            Po zapisaniu klient zostanie automatycznie podpiety do nowej sprawy portowania.
+          </p>
+        )}
       </div>
 
       <form onSubmit={(e) => void handleSubmit(e)} noValidate className="space-y-5">
@@ -334,7 +351,7 @@ export function ClientNewPage() {
         <div className="flex gap-3 justify-end pt-2">
           <button
             type="button"
-            onClick={() => void navigate(ROUTES.CLIENTS)}
+            onClick={() => void navigate(cancelTarget)}
             className="btn-secondary"
             disabled={isLoading}
           >

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/stores/auth.store'
 import {
   exportPortingRequest,
   getPortingRequestById,
+  getPortingRequestIntegrationEvents,
   getPortingRequestTimeline,
   syncPortingRequest,
   updatePortingRequestStatus,
@@ -23,11 +24,13 @@ import {
 } from '@np-manager/shared'
 import type {
   PortingCaseStatus,
+  PliCbdIntegrationEventDto,
   PortingRequestDetailDto,
   PortingTimelineItemDto,
 } from '@np-manager/shared'
 import { PortingTimeline } from '@/components/PortingTimeline/PortingTimeline'
 import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
+import { PliCbdIntegrationHistory } from '@/components/PliCbdIntegrationHistory/PliCbdIntegrationHistory'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -90,6 +93,8 @@ export function RequestDetailPage() {
   const [isSyncing, setIsSyncing] = useState(false)
   const [timelineItems, setTimelineItems] = useState<PortingTimelineItemDto[]>([])
   const [isTimelineLoading, setIsTimelineLoading] = useState(true)
+  const [integrationEvents, setIntegrationEvents] = useState<PliCbdIntegrationEventDto[]>([])
+  const [isIntegrationEventsLoading, setIsIntegrationEventsLoading] = useState(true)
 
   const canManageStatus = useMemo(
     () =>
@@ -122,6 +127,24 @@ export function RequestDetailPage() {
     }
   }, [id])
 
+  const loadIntegrationEvents = useCallback(async () => {
+    if (!id || !canTriggerPliCbdActions) {
+      setIntegrationEvents([])
+      setIsIntegrationEventsLoading(false)
+      return
+    }
+
+    setIsIntegrationEventsLoading(true)
+    try {
+      const result = await getPortingRequestIntegrationEvents(id)
+      setIntegrationEvents(result.items)
+    } catch {
+      setIntegrationEvents([])
+    } finally {
+      setIsIntegrationEventsLoading(false)
+    }
+  }, [canTriggerPliCbdActions, id])
+
   useEffect(() => {
     if (!id) return
 
@@ -140,7 +163,8 @@ export function RequestDetailPage() {
 
     void load()
     void loadTimeline()
-  }, [id, loadTimeline])
+    void loadIntegrationEvents()
+  }, [id, loadIntegrationEvents, loadTimeline])
 
   const formatDateTime = (iso: string) =>
     new Date(iso).toLocaleString('pl-PL', {
@@ -159,8 +183,10 @@ export function RequestDetailPage() {
     try {
       setRequest(await exportPortingRequest(id))
       void loadTimeline()
+      void loadIntegrationEvents()
       setActionSuccess('Eksport do PLI CBD zostal wyzwolony pomyslnie.')
     } catch {
+      void loadIntegrationEvents()
       setActionError('Nie udalo sie uruchomic foundation eksportu do PLI CBD.')
     } finally {
       setIsExporting(false)
@@ -175,8 +201,10 @@ export function RequestDetailPage() {
     try {
       setRequest(await syncPortingRequest(id))
       void loadTimeline()
+      void loadIntegrationEvents()
       setActionSuccess('Synchronizacja z PLI CBD zakonczona pomyslnie.')
     } catch {
+      void loadIntegrationEvents()
       setActionError('Nie udalo sie uruchomic foundation synchronizacji z PLI CBD.')
     } finally {
       setIsSyncing(false)
@@ -473,6 +501,13 @@ export function RequestDetailPage() {
           integracji SOAP/XML z PLI CBD.
         </div>
       </div>
+
+      {canTriggerPliCbdActions && (
+        <PliCbdIntegrationHistory
+          items={integrationEvents}
+          isLoading={isIntegrationEventsLoading}
+        />
+      )}
 
       <PortingTimeline items={timelineItems} isLoading={isTimelineLoading} />
 

--- a/apps/frontend/src/pages/Requests/RequestNewPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestNewPage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from 'react'
+import { useCallback, useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from 'react'
 import axios from 'axios'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { buildPath, ROUTES } from '@/constants/routes'
 import { useOperators } from '@/hooks/useOperators'
 import { getClientById, searchClients } from '@/services/clients.api'
@@ -140,6 +140,7 @@ function FormField({
 
 export function RequestNewPage() {
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const { operators, isLoading: operatorsLoading, error: operatorsError } = useOperators()
   const [clientQuery, setClientQuery] = useState('')
   const [clientResults, setClientResults] = useState<ClientSearchItemDto[]>([])
@@ -147,12 +148,33 @@ export function RequestNewPage() {
   const [clientSearchError, setClientSearchError] = useState<string | null>(null)
   const [selectedClient, setSelectedClient] = useState<ClientDetailDto | null>(null)
   const [isLoadingClient, setIsLoadingClient] = useState(false)
+  const [initializedClientId, setInitializedClientId] = useState<string | null>(null)
   const [fields, setFields] = useState<FormFields>(EMPTY_FORM)
   const [errors, setErrors] = useState<FormErrors>({})
   const [isSaving, setIsSaving] = useState(false)
   const isBusiness = selectedClient?.clientType === 'BUSINESS'
+  const selectedClientIdFromQuery = searchParams.get('clientId')
+  const showCreatedClientSuccess = searchParams.get('requestCreatedClient') === '1'
   const donorOptions = useMemo(() => operators.filter((operator) => operator.isActive), [operators])
   const infrastructureOptions = donorOptions
+  const createClientHref = `${ROUTES.CLIENT_NEW}?returnTo=${encodeURIComponent(ROUTES.REQUEST_NEW)}`
+
+  const syncSelectedClientParams = useCallback(
+    (clientId: string | null, showSuccessMessage = false) => {
+      const nextParams = new URLSearchParams(searchParams)
+
+      if (clientId) nextParams.set('clientId', clientId)
+      else nextParams.delete('clientId')
+
+      if (showSuccessMessage) nextParams.set('requestCreatedClient', '1')
+      else nextParams.delete('requestCreatedClient')
+
+      if (nextParams.toString() !== searchParams.toString()) {
+        setSearchParams(nextParams, { replace: true })
+      }
+    },
+    [searchParams, setSearchParams],
+  )
 
   useEffect(() => {
     if (selectedClient || clientQuery.trim().length < 2) {
@@ -205,7 +227,10 @@ export function RequestNewPage() {
     }))
   }
 
-  const handleSelectClient = async (clientId: string) => {
+  const handleSelectClient = useCallback(async (
+    clientId: string,
+    options?: { showSuccessMessage?: boolean },
+  ) => {
     setIsLoadingClient(true)
     setClientSearchError(null)
     try {
@@ -215,15 +240,41 @@ export function RequestNewPage() {
       setClientResults([])
       setErrors((previous) => ({ ...previous, clientId: undefined }))
       applyClientSnapshot(client)
+      syncSelectedClientParams(client.id, options?.showSuccessMessage ?? false)
     } catch {
       setClientSearchError('Nie udalo sie pobrac pelnych danych wybranego klienta.')
     } finally {
       setIsLoadingClient(false)
     }
-  }
+  }, [syncSelectedClientParams])
+
+  useEffect(() => {
+    if (
+      !selectedClientIdFromQuery ||
+      initializedClientId === selectedClientIdFromQuery ||
+      selectedClient?.id === selectedClientIdFromQuery ||
+      isLoadingClient
+    ) {
+      return
+    }
+
+    setInitializedClientId(selectedClientIdFromQuery)
+    void handleSelectClient(selectedClientIdFromQuery, {
+      showSuccessMessage: showCreatedClientSuccess,
+    })
+  }, [
+    handleSelectClient,
+    initializedClientId,
+    isLoadingClient,
+    selectedClient?.id,
+    selectedClientIdFromQuery,
+    showCreatedClientSuccess,
+  ])
 
   const resetSelectedClient = () => {
     setSelectedClient(null)
+    setInitializedClientId(null)
+    syncSelectedClientParams(null)
     setFields((previous) => ({
       ...EMPTY_FORM,
       donorOperatorId: previous.donorOperatorId,
@@ -388,6 +439,11 @@ export function RequestNewPage() {
               <div>
                 <p className="text-sm font-semibold text-gray-900">{selectedClient.displayName}</p>
                 <p className="text-sm text-gray-500 mt-1">{selectedClient.clientType === 'BUSINESS' ? 'Firma / podmiot prawny' : 'Osoba fizyczna'}</p>
+                {showCreatedClientSuccess && (
+                  <p className="mt-2 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-xs text-green-700">
+                    Klient zostal utworzony i zostal podpiety do nowej sprawy portowania.
+                  </p>
+                )}
                 <p className="text-xs text-gray-500 mt-1">Dane abonenta zostaly wstepnie uzupelnione z kartoteki i mozna je doprecyzowac ponizej.</p>
               </div>
               <button type="button" onClick={resetSelectedClient} className="btn-secondary">Zmien klienta</button>
@@ -397,6 +453,13 @@ export function RequestNewPage() {
               <FormField label="Wyszukaj klienta" error={errors.clientId || clientSearchError || undefined}>
                 <input type="search" value={clientQuery} onChange={(event) => setClientQuery(event.target.value)} className={`input-field ${errors.clientId || clientSearchError ? 'input-error' : ''}`} placeholder="Wpisz nazwisko, firme, PESEL albo NIP..." disabled={isLoadingClient} />
               </FormField>
+              <button
+                type="button"
+                onClick={() => void navigate(createClientHref)}
+                className="text-sm font-medium text-blue-600 hover:text-blue-700"
+              >
+                Nie ma klienta? Dodaj nowego klienta
+              </button>
               {isSearchingClients && <p className="text-xs text-gray-400">Wyszukiwanie klientow...</p>}
               {clientResults.length > 0 && (
                 <div className="rounded-lg border border-gray-200 overflow-hidden">

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -1,6 +1,7 @@
 import { apiClient } from './api.client'
 import type {
   CreatePortingRequestDto,
+  PliCbdIntegrationEventsResultDto,
   PortingRequestDetailDto,
   PortingRequestListQueryDto,
   PortingRequestListResultDto,
@@ -87,6 +88,17 @@ export async function getPortingRequestTimeline(id: string): Promise<PortingTime
     success: true
     data: PortingTimelineResultDto
   }>(`/porting-requests/${id}/timeline`)
+
+  return response.data.data
+}
+
+export async function getPortingRequestIntegrationEvents(
+  id: string,
+): Promise<PliCbdIntegrationEventsResultDto> {
+  const response = await apiClient.get<{
+    success: true
+    data: PliCbdIntegrationEventsResultDto
+  }>(`/porting-requests/${id}/integration-events`)
 
   return response.data.data
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "description": "Wspólne typy, walidatory i stałe dla NP-Manager",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -191,6 +191,40 @@ export const PLI_CBD_EXPORT_STATUS_LABELS: Record<PliCbdExportStatus, string> = 
   SYNC_ERROR: 'Blad synchronizacji z PLI CBD',
 }
 
+export const PLI_CBD_INTEGRATION_DIRECTIONS = {
+  EXPORT: 'EXPORT',
+  SYNC: 'SYNC',
+} as const
+
+export type PliCbdIntegrationDirection =
+  (typeof PLI_CBD_INTEGRATION_DIRECTIONS)[keyof typeof PLI_CBD_INTEGRATION_DIRECTIONS]
+
+export const PLI_CBD_INTEGRATION_DIRECTION_LABELS: Record<
+  PliCbdIntegrationDirection,
+  string
+> = {
+  EXPORT: 'Eksport',
+  SYNC: 'Synchronizacja',
+}
+
+export const PLI_CBD_INTEGRATION_STATUSES = {
+  PENDING: 'PENDING',
+  SUCCESS: 'SUCCESS',
+  ERROR: 'ERROR',
+} as const
+
+export type PliCbdIntegrationStatus =
+  (typeof PLI_CBD_INTEGRATION_STATUSES)[keyof typeof PLI_CBD_INTEGRATION_STATUSES]
+
+export const PLI_CBD_INTEGRATION_STATUS_LABELS: Record<
+  PliCbdIntegrationStatus,
+  string
+> = {
+  PENDING: 'W toku',
+  SUCCESS: 'Sukces',
+  ERROR: 'Blad',
+}
+
 // ============================================================
 // STATUSY WEWNETRZNE SPRAWY PORTOWANIA
 // ============================================================

--- a/packages/shared/src/dto/pli-cbd-integration.dto.ts
+++ b/packages/shared/src/dto/pli-cbd-integration.dto.ts
@@ -1,0 +1,23 @@
+import type {
+  PliCbdIntegrationDirection,
+  PliCbdIntegrationStatus,
+} from '../constants'
+
+export interface PliCbdIntegrationEventDto {
+  id: string
+  portingRequestId: string
+  operationType: PliCbdIntegrationDirection
+  operationStatus: PliCbdIntegrationStatus
+  actionName: string | null
+  requestPayloadJson: unknown | null
+  responsePayloadJson: unknown | null
+  errorMessage: string | null
+  triggeredByUserId: string | null
+  triggeredByDisplayName: string | null
+  createdAt: string
+  completedAt: string | null
+}
+
+export interface PliCbdIntegrationEventsResultDto {
+  items: PliCbdIntegrationEventDto[]
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,5 +9,6 @@ export * from './types'
 
 // DTOs
 export * from './dto/operators.dto'
+export * from './dto/pli-cbd-integration.dto'
 export * from './dto/porting-requests.dto'
 export * from './dto/porting-timeline.dto'


### PR DESCRIPTION
## Cel

Uporządkowanie warstwy operacji integracyjnych PLI CBD oraz zapewnienie spójnej, audytowalnej historii eksportu i synchronizacji.

## Zakres

- Wydzielenie modułu `pli-cbd/` z adapterem i trackerem operacji
- Dodanie modelu `PliCbdIntegrationEvent` w Prisma (enumy `PliCbdIntegrationDirection`, `PliCbdIntegrationStatus`)
- Ujednolicenie rejestrowania `SUCCESS` / `ERROR` przez `withPliCbdIntegrationTracking()`
- Objęcie historią także błędów biznesowych (zamknięta sprawa, brak eksportu) przez `throwBlockedPliCbdIntegrationAttempt()`
- Dodanie endpointu `GET /api/porting-requests/:id/integration-events` (tylko ADMIN)
- Dodanie sekcji „Historia integracji PLI CBD" na stronie szczegółów sprawy
- Odświeżanie historii integracji po eksporcie i synchronizacji (sukces i błąd)

## Efekt

- Każda operacja integracyjna zostawia ślad w historii
- Brak cichych błędów bez wpisu — zarówno błędy walidacji biznesowej jak i błędy adaptera są rejestrowane
- Awaria logowania historii nie maskuje błędu biznesowego zwracanego do UI
- Kod przygotowany pod przyszły adapter realnego PLI CBD (interface `PortingRequestPliCbdAdapter`)
- Historia integracji oddzielona od ogólnego timeline sprawy (`PortingRequestEvent`)

## Plan testowy

- [ ] Eksport sprawy DRAFT → wpis SUCCESS w historii integracji
- [ ] Eksport sprawy REJECTED/CANCELLED/PORTED → wpis ERROR + komunikat, 400 na API
- [ ] Sync sprawy NOT_EXPORTED → wpis ERROR + komunikat, 400 na API
- [ ] Sync sprawy EXPORT_PENDING → wpis SUCCESS
- [ ] Historia integracji odświeża się po każdej operacji (sukces i błąd)
- [ ] Sekcja „Historia integracji PLI CBD" widoczna tylko dla ADMIN
- [ ] `GET /:id/integration-events` zwraca 403 dla nie-ADMIN

## Uwagi

Nie wdrażamy jeszcze realnej komunikacji HTTPS/FTPS z PLI CBD. To krok architektoniczny i porządkujący pod kolejne etapy integracji.
