### PR TITLE
fix(fnp-process): add weekend fallback for isWorkingDay when no calen…

### DIFF
--- a/apps/backend/src/modules/pli-cbd/fnp-process.service.ts
+++ b/apps/backend/src/modules/pli-cbd/fnp-process.service.ts
@@ -92,7 +92,17 @@ export async function getPortingRequestProcessSnapshot(
       where: { date: dateForCalendar },
       select: { isWorkingDay: true },
     })
-    isWorkingDay = calendarEntry?.isWorkingDay ?? null
+
+    if (calendarEntry !== null) {
+      // Wynik z bazy — wiazacy
+      isWorkingDay = calendarEntry.isWorkingDay
+    } else {
+      // Brak wpisu w kalendarzu — fallback na dzien tygodnia:
+      // weekend (sobota=6, niedziela=0) na pewno nie jest dniem roboczym;
+      // dni powszednie bez wpisu zostawiamy jako null (moze byc swieto)
+      const dayOfWeek = dateForCalendar.getDay()
+      isWorkingDay = dayOfWeek === 0 || dayOfWeek === 6 ? false : null
+    }
   }
 
   const today = new Date()


### PR DESCRIPTION
## Cel

Naprawa read-modelu snapshotu procesu FNP / PLI CBD dla walidacji daty przeniesienia.

## Problem

Dla terminalnych spraw (np. `REJECTED`, `CANCELLED`) pole `isWorkingDay` mogło pozostawać `null`, nawet jeśli data portowania wypadała w sobotę lub niedzielę. W UI skutkowało to wyświetleniem `—` zamiast jednoznacznego `Nie`.

## Zmiana

W `fnp-process.service.ts` dodano fallback przy budowie danych z `WorkingCalendar`:
- jeśli w bazie istnieje wpis kalendarza, używana jest jego wartość `isWorkingDay`,
- jeśli wpisu brak i data wypada w weekend (`Saturday` / `Sunday`), zwracane jest `false`,
- jeśli wpisu brak i data wypada w dzień powszedni, nadal zwracane jest `null` (bo może to być święto i bez wpisu nie da się tego rozstrzygnąć).

## Efekt

- weekend bez wpisu w `WorkingCalendar` nie jest już prezentowany jako nieznany,
- UI może pokazać czytelne `Nie` zamiast `—`,
- logika nadal nie zgaduje dni roboczych dla dni powszednich bez danych kalendarzowych.

## Zakres

- 1 plik: `apps/backend/src/modules/pli-cbd/fnp-process.service.ts`
- brak zmian w schemacie, DTO, frontendzie i migracjach.

## Weryfikacja

- logika fallbacku sprawdzona dla weekendów i dni powszednich,
- dla soboty/niedzieli bez wpisu wynik = `false`,
- dla dnia powszedniego bez wpisu wynik = `null`.