### PR TITLE
feat(pli-cbd): add E03 draft builder and read-only preview

### DIFF
--- a/apps/backend/src/modules/pli-cbd/fnp-process.service.ts
+++ b/apps/backend/src/modules/pli-cbd/fnp-process.service.ts
@@ -1,8 +1,11 @@
+import type { Prisma } from '@prisma/client'
 import { prisma } from '../../config/database'
 import { AppError } from '../../shared/errors/app-error'
 import type {
   FnpBlockingReason,
   FnpMessageReadiness,
+  PliCbdE03DraftBuildResultDto,
+  PliCbdE03DraftDto,
   PliCbdProcessSnapshotDto,
 } from '@np-manager/shared'
 import {
@@ -38,6 +41,58 @@ const FNP_PROCESS_SELECT = {
   requestedPortDate: true,
   donorAssignedPortDate: true,
 } as const
+
+const DRAFT_OPERATOR_SELECT = {
+  id: true,
+  name: true,
+  shortName: true,
+  routingNumber: true,
+} as const
+
+const E03_DRAFT_SELECT = {
+  id: true,
+  caseNumber: true,
+  clientId: true,
+  numberType: true,
+  numberRangeKind: true,
+  primaryNumber: true,
+  rangeStart: true,
+  rangeEnd: true,
+  requestDocumentNumber: true,
+  portingMode: true,
+  requestedPortDate: true,
+  earliestAcceptablePortDate: true,
+  subscriberKind: true,
+  subscriberFirstName: true,
+  subscriberLastName: true,
+  subscriberCompanyName: true,
+  identityType: true,
+  identityValue: true,
+  correspondenceAddress: true,
+  hasPowerOfAttorney: true,
+  linkedWholesaleServiceOnRecipientSide: true,
+  contactChannel: true,
+  client: {
+    select: {
+      id: true,
+      clientType: true,
+      firstName: true,
+      lastName: true,
+      companyName: true,
+    },
+  },
+  donorOperator: {
+    select: DRAFT_OPERATOR_SELECT,
+  },
+  recipientOperator: {
+    select: DRAFT_OPERATOR_SELECT,
+  },
+  infrastructureOperator: {
+    select: DRAFT_OPERATOR_SELECT,
+  },
+} as const
+
+type E03DraftRow = Prisma.PortingRequestGetPayload<{ select: typeof E03_DRAFT_SELECT }>
 
 // ============================================================
 // POMOCNIK — mapowanie PliCbdExxType → FnpExxMessage | null
@@ -184,6 +239,77 @@ export async function getPortingRequestProcessSnapshot(
 // POMOCNIK — podglad pol dla konkretnego komunikatu
 // ============================================================
 
+export async function buildE03DraftForPortingRequest(
+  requestId: string,
+): Promise<PliCbdE03DraftBuildResultDto> {
+  const snapshot = await getPortingRequestProcessSnapshot(requestId)
+
+  if (!snapshot.allowedNextMessages.includes('E03')) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons:
+        snapshot.blockingReasons.length > 0
+          ? snapshot.blockingReasons
+          : [
+              {
+                code: 'E03_NOT_ALLOWED_AT_CURRENT_STAGE',
+                message: `Komunikat E03 nie jest dostepny na aktualnym etapie procesu: ${snapshot.currentStageLabel}.`,
+                field: 'currentStage',
+              },
+            ],
+      draft: null,
+    }
+  }
+
+  const e03Readiness = snapshot.draftableMessages.find(
+    (message) => message.messageType === 'E03',
+  )
+
+  if (!e03Readiness) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons: [
+        {
+          code: 'E03_READINESS_NOT_AVAILABLE',
+          message: 'Nie udalo sie wyznaczyc gotowosci draftu E03 dla tej sprawy.',
+        },
+      ],
+      draft: null,
+    }
+  }
+
+  if (!e03Readiness.ready) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons: e03Readiness.blockingReasons,
+      draft: null,
+    }
+  }
+
+  const row = await prisma.portingRequest.findUnique({
+    where: { id: requestId },
+    select: E03_DRAFT_SELECT,
+  })
+
+  if (!row) {
+    throw AppError.notFound(`Sprawa o id "${requestId}" nie istnieje.`)
+  }
+
+  return {
+    requestId: row.id,
+    caseNumber: row.caseNumber,
+    isReady: true,
+    blockingReasons: [],
+    draft: buildE03Draft(row),
+  }
+}
+
 function buildSummaryFields(
   messageType: string,
   row: FnpValidationRequest & { id: string; caseNumber: string },
@@ -210,4 +336,107 @@ function buildSummaryFields(
     default:
       return {}
   }
+}
+
+function buildE03Draft(row: E03DraftRow): PliCbdE03DraftDto {
+  return {
+    messageType: 'E03',
+    serviceType: 'FNP',
+    requestId: row.id,
+    caseNumber: row.caseNumber,
+    clientId: row.clientId,
+    clientDisplayName: getClientDisplayName(row.client),
+    subscriberKind: row.subscriberKind,
+    subscriberDisplayName: getSubscriberDisplayName(row),
+    subscriberFirstName: row.subscriberFirstName,
+    subscriberLastName: row.subscriberLastName,
+    subscriberCompanyName: row.subscriberCompanyName,
+    numberType: row.numberType,
+    portedNumberKind: row.numberRangeKind,
+    primaryNumber: row.primaryNumber,
+    rangeStart: row.rangeStart,
+    rangeEnd: row.rangeEnd,
+    numberDisplay: getNumberDisplay(row),
+    portingMode: row.portingMode,
+    requestedPortDate: toDateOnlyString(row.requestedPortDate),
+    earliestAcceptablePortDate: toDateOnlyString(row.earliestAcceptablePortDate),
+    requestDocumentNumber: row.requestDocumentNumber ?? '',
+    donorOperator: toDraftOperator(row.donorOperator),
+    recipientOperator: toDraftOperator(row.recipientOperator),
+    infrastructureOperator: row.infrastructureOperator
+      ? toDraftOperator(row.infrastructureOperator)
+      : null,
+    identity: {
+      type: row.identityType,
+      value: row.identityValue,
+    },
+    correspondenceAddress: row.correspondenceAddress,
+    hasPowerOfAttorney: row.hasPowerOfAttorney,
+    linkedWholesaleServiceOnRecipientSide:
+      row.linkedWholesaleServiceOnRecipientSide,
+    contactChannel: row.contactChannel,
+    technicalHints: {
+      portDateSource:
+        row.portingMode === 'DAY'
+          ? 'REQUESTED_PORT_DATE'
+          : 'EARLIEST_ACCEPTABLE_PORT_DATE',
+      numberSelectionSource:
+        row.numberRangeKind === 'DDI_RANGE'
+          ? 'NUMBER_RANGE'
+          : 'PRIMARY_NUMBER',
+    },
+  }
+}
+
+function toDateOnlyString(value: Date | null): string | null {
+  return value ? value.toISOString().slice(0, 10) : null
+}
+
+function toDraftOperator(
+  operator: E03DraftRow['donorOperator'],
+): PliCbdE03DraftDto['donorOperator'] {
+  return {
+    id: operator.id,
+    name: operator.name,
+    shortName: operator.shortName,
+    routingNumber: operator.routingNumber,
+  }
+}
+
+function getClientDisplayName(client: E03DraftRow['client']): string {
+  if (client.clientType === 'BUSINESS') {
+    return client.companyName ?? 'Firma (brak nazwy)'
+  }
+
+  const parts = [client.firstName, client.lastName].filter(Boolean)
+  return parts.length > 0 ? parts.join(' ') : 'Brak danych'
+}
+
+function getSubscriberDisplayName(request: {
+  subscriberKind: string
+  subscriberFirstName: string | null
+  subscriberLastName: string | null
+  subscriberCompanyName: string | null
+}): string {
+  if (request.subscriberKind === 'BUSINESS') {
+    return request.subscriberCompanyName ?? 'Firma (brak nazwy)'
+  }
+
+  const parts = [request.subscriberFirstName, request.subscriberLastName].filter(
+    Boolean,
+  )
+  return parts.length > 0 ? parts.join(' ') : 'Brak danych'
+}
+
+function getNumberDisplay(request: {
+  numberRangeKind: string
+  primaryNumber: string | null
+  rangeStart: string | null
+  rangeEnd: string | null
+}): string {
+  if (request.numberRangeKind === 'DDI_RANGE') {
+    return `${request.rangeStart ?? '-'} - ${request.rangeEnd ?? '-'}`
+  }
+
+  return request.primaryNumber ?? '-'
 }

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -17,7 +17,10 @@ import {
   updatePortingRequestStatus,
 } from './porting-requests.service'
 import { getPortingRequestTimeline } from './porting-events.service'
-import { getPortingRequestProcessSnapshot } from '../pli-cbd/fnp-process.service'
+import {
+  buildE03DraftForPortingRequest,
+  getPortingRequestProcessSnapshot,
+} from '../pli-cbd/fnp-process.service'
 
 export async function portingRequestsRouter(app: FastifyInstance): Promise<void> {
   const readRoles: UserRole[] = [
@@ -65,6 +68,15 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
     async (request, reply) => {
       const snapshot = await getPortingRequestProcessSnapshot(request.params.id)
       return reply.status(200).send({ success: true, data: snapshot })
+    },
+  )
+
+  app.get<{ Params: { id: string } }>(
+    '/:id/pli-cbd-drafts/e03',
+    { preHandler: [authenticate, authorize(readRoles)] },
+    async (request, reply) => {
+      const result = await buildE03DraftForPortingRequest(request.params.id)
+      return reply.status(200).send({ success: true, data: result })
     },
   )
 

--- a/apps/frontend/src/components/PliCbdE03DraftPreview/PliCbdE03DraftPreview.tsx
+++ b/apps/frontend/src/components/PliCbdE03DraftPreview/PliCbdE03DraftPreview.tsx
@@ -1,0 +1,235 @@
+import {
+  CLIENT_TYPE_LABELS,
+  CONTACT_CHANNEL_LABELS,
+  NUMBER_TYPE_LABELS,
+  PORTED_NUMBER_KIND_LABELS,
+  PORTING_MODE_LABELS,
+  SUBSCRIBER_IDENTITY_TYPE_LABELS,
+} from '@np-manager/shared'
+import type { PliCbdE03DraftBuildResultDto } from '@np-manager/shared'
+
+interface PliCbdE03DraftPreviewProps {
+  result: PliCbdE03DraftBuildResultDto | null
+  isLoading: boolean
+}
+
+const PORT_DATE_SOURCE_LABELS = {
+  REQUESTED_PORT_DATE: 'Wnioskowany dzien przeniesienia',
+  EARLIEST_ACCEPTABLE_PORT_DATE: 'Najwczesniejsza akceptowalna data',
+} as const
+
+function Field({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: string | null | undefined
+  mono?: boolean
+}) {
+  return (
+    <div>
+      <dt className="text-xs text-gray-500 mb-0.5">{label}</dt>
+      <dd className={`text-sm text-gray-900 ${mono ? 'font-mono' : ''}`}>
+        {value ?? <span className="text-gray-400">-</span>}
+      </dd>
+    </div>
+  )
+}
+
+function WideField({
+  label,
+  value,
+}: {
+  label: string
+  value: string | null | undefined
+}) {
+  return (
+    <div className="sm:col-span-2">
+      <dt className="text-xs text-gray-500 mb-0.5">{label}</dt>
+      <dd className="text-sm text-gray-900 whitespace-pre-wrap">
+        {value ?? <span className="text-gray-400">-</span>}
+      </dd>
+    </div>
+  )
+}
+
+export function PliCbdE03DraftPreview({
+  result,
+  isLoading,
+}: PliCbdE03DraftPreviewProps) {
+  return (
+    <div className="card p-5 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-1">
+          Draft E03
+        </h2>
+        <p className="text-sm text-gray-500">
+          Read-only preview danych, ktore weszlyby do komunikatu E03 dla PLI CBD.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+          Ladowanie draftu E03...
+        </div>
+      ) : !result ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+          Nie udalo sie zaladowac draftu E03.
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <span
+              className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                result.isReady
+                  ? 'bg-green-100 text-green-700'
+                  : 'bg-amber-100 text-amber-700'
+              }`}
+            >
+              {result.isReady ? 'Gotowe do zbudowania E03' : 'Draft E03 zablokowany'}
+            </span>
+            <span className="text-xs text-gray-500">Sprawa: {result.caseNumber}</span>
+          </div>
+
+          {result.blockingReasons.length > 0 && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-amber-800">
+                Blokady draftu
+              </p>
+              <ul className="space-y-1">
+                {result.blockingReasons.map((reason) => (
+                  <li key={reason.code} className="text-sm text-amber-900">
+                    {reason.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {!result.draft ? (
+            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-4 text-sm text-gray-600">
+              Draft E03 nie zostal wygenerowany dla tej sprawy.
+            </div>
+          ) : (
+            <>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field label="Typ komunikatu" value={result.draft.messageType} mono />
+                  <Field label="Serwis" value={result.draft.serviceType} mono />
+                  <Field label="Kartoteka klienta" value={result.draft.clientDisplayName} />
+                  <Field
+                    label="Typ abonenta"
+                    value={CLIENT_TYPE_LABELS[result.draft.subscriberKind]}
+                  />
+                  <Field label="Abonent w sprawie" value={result.draft.subscriberDisplayName} />
+                  <Field
+                    label="Numer dokumentu / wniosku"
+                    value={result.draft.requestDocumentNumber}
+                    mono
+                  />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4">
+                <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                  Numeracja i terminy
+                </p>
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field label="Typ uslugi" value={NUMBER_TYPE_LABELS[result.draft.numberType]} />
+                  <Field
+                    label="Typ numeracji"
+                    value={PORTED_NUMBER_KIND_LABELS[result.draft.portedNumberKind]}
+                  />
+                  <Field label="Numer / zakres" value={result.draft.numberDisplay} mono />
+                  <Field
+                    label="Tryb przeniesienia"
+                    value={PORTING_MODE_LABELS[result.draft.portingMode]}
+                  />
+                  <Field
+                    label="Wnioskowany dzien przeniesienia"
+                    value={result.draft.requestedPortDate}
+                    mono
+                  />
+                  <Field
+                    label="Najwczesniejsza akceptowalna data"
+                    value={result.draft.earliestAcceptablePortDate}
+                    mono
+                  />
+                  <Field
+                    label="Zrodlo daty w draftcie"
+                    value={
+                      PORT_DATE_SOURCE_LABELS[result.draft.technicalHints.portDateSource]
+                    }
+                  />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4">
+                <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                  Operatorzy i proces
+                </p>
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field label="Operator oddajacy" value={result.draft.donorOperator.name} />
+                  <Field
+                    label="Routing dawcy"
+                    value={result.draft.donorOperator.routingNumber}
+                    mono
+                  />
+                  <Field
+                    label="Operator bioracy"
+                    value={result.draft.recipientOperator.name}
+                  />
+                  <Field
+                    label="Routing biorcy"
+                    value={result.draft.recipientOperator.routingNumber}
+                    mono
+                  />
+                  <Field
+                    label="Operator infrastrukturalny"
+                    value={result.draft.infrastructureOperator?.name}
+                  />
+                  <Field
+                    label="Kanal kontaktu"
+                    value={CONTACT_CHANNEL_LABELS[result.draft.contactChannel]}
+                  />
+                  <Field
+                    label="Pelnomocnictwo"
+                    value={result.draft.hasPowerOfAttorney ? 'Tak' : 'Nie'}
+                  />
+                  <Field
+                    label="Usluga Hurtowa po stronie Biorcy"
+                    value={
+                      result.draft.linkedWholesaleServiceOnRecipientSide ? 'Tak' : 'Nie'
+                    }
+                  />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4">
+                <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                  Tozsamosc abonenta
+                </p>
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field
+                    label="Rodzaj identyfikatora"
+                    value={SUBSCRIBER_IDENTITY_TYPE_LABELS[result.draft.identity.type]}
+                  />
+                  <Field
+                    label="Wartosc identyfikatora"
+                    value={result.draft.identity.value}
+                    mono
+                  />
+                  <WideField
+                    label="Adres korespondencyjny"
+                    value={result.draft.correspondenceAddress}
+                  />
+                </dl>
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '@/stores/auth.store'
 import {
   exportPortingRequest,
   getPortingRequestById,
+  getPortingRequestE03Draft,
   getPortingRequestIntegrationEvents,
   getPortingRequestProcessSnapshot,
   getPortingRequestTimeline,
@@ -24,6 +25,7 @@ import {
   SUBSCRIBER_IDENTITY_TYPE_LABELS,
 } from '@np-manager/shared'
 import type {
+  PliCbdE03DraftBuildResultDto,
   PliCbdIntegrationEventDto,
   PliCbdProcessSnapshotDto,
   PortingCaseStatus,
@@ -34,6 +36,7 @@ import { PortingTimeline } from '@/components/PortingTimeline/PortingTimeline'
 import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
 import { PliCbdIntegrationHistory } from '@/components/PliCbdIntegrationHistory/PliCbdIntegrationHistory'
 import { PliCbdProcessSnapshot } from '@/components/PliCbdProcessSnapshot/PliCbdProcessSnapshot'
+import { PliCbdE03DraftPreview } from '@/components/PliCbdE03DraftPreview/PliCbdE03DraftPreview'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -100,6 +103,9 @@ export function RequestDetailPage() {
   const [isIntegrationEventsLoading, setIsIntegrationEventsLoading] = useState(true)
   const [processSnapshot, setProcessSnapshot] = useState<PliCbdProcessSnapshotDto | null>(null)
   const [isProcessSnapshotLoading, setIsProcessSnapshotLoading] = useState(true)
+  const [e03DraftResult, setE03DraftResult] =
+    useState<PliCbdE03DraftBuildResultDto | null>(null)
+  const [isE03DraftLoading, setIsE03DraftLoading] = useState(true)
 
   const canManageStatus = useMemo(
     () =>
@@ -145,6 +151,19 @@ export function RequestDetailPage() {
     }
   }, [id])
 
+  const loadE03Draft = useCallback(async () => {
+    if (!id) return
+    setIsE03DraftLoading(true)
+    try {
+      const result = await getPortingRequestE03Draft(id)
+      setE03DraftResult(result)
+    } catch {
+      setE03DraftResult(null)
+    } finally {
+      setIsE03DraftLoading(false)
+    }
+  }, [id])
+
   const loadIntegrationEvents = useCallback(async () => {
     if (!id || !canTriggerPliCbdActions) {
       setIntegrationEvents([])
@@ -183,7 +202,8 @@ export function RequestDetailPage() {
     void loadTimeline()
     void loadIntegrationEvents()
     void loadProcessSnapshot()
-  }, [id, loadIntegrationEvents, loadProcessSnapshot, loadTimeline])
+    void loadE03Draft()
+  }, [id, loadE03Draft, loadIntegrationEvents, loadProcessSnapshot, loadTimeline])
 
   const formatDateTime = (iso: string) =>
     new Date(iso).toLocaleString('pl-PL', {
@@ -203,9 +223,13 @@ export function RequestDetailPage() {
       setRequest(await exportPortingRequest(id))
       void loadTimeline()
       void loadIntegrationEvents()
+      void loadProcessSnapshot()
+      void loadE03Draft()
       setActionSuccess('Eksport do PLI CBD zostal wyzwolony pomyslnie.')
     } catch {
       void loadIntegrationEvents()
+      void loadProcessSnapshot()
+      void loadE03Draft()
       setActionError('Nie udalo sie uruchomic foundation eksportu do PLI CBD.')
     } finally {
       setIsExporting(false)
@@ -221,9 +245,13 @@ export function RequestDetailPage() {
       setRequest(await syncPortingRequest(id))
       void loadTimeline()
       void loadIntegrationEvents()
+      void loadProcessSnapshot()
+      void loadE03Draft()
       setActionSuccess('Synchronizacja z PLI CBD zakonczona pomyslnie.')
     } catch {
       void loadIntegrationEvents()
+      void loadProcessSnapshot()
+      void loadE03Draft()
       setActionError('Nie udalo sie uruchomic foundation synchronizacji z PLI CBD.')
     } finally {
       setIsSyncing(false)
@@ -265,6 +293,8 @@ export function RequestDetailPage() {
       const updatedRequest = await updatePortingRequestStatus(id, { targetStatus })
       setRequest(updatedRequest)
       void loadTimeline()
+      void loadProcessSnapshot()
+      void loadE03Draft()
       setStatusActionSuccess('Status sprawy został zmieniony.')
     } catch (err) {
       if (axios.isAxiosError(err)) {
@@ -524,6 +554,11 @@ export function RequestDetailPage() {
       <PliCbdProcessSnapshot
         snapshot={processSnapshot}
         isLoading={isProcessSnapshotLoading}
+      />
+
+      <PliCbdE03DraftPreview
+        result={e03DraftResult}
+        isLoading={isE03DraftLoading}
       />
 
       {canTriggerPliCbdActions && (

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -1,6 +1,7 @@
 import { apiClient } from './api.client'
 import type {
   CreatePortingRequestDto,
+  PliCbdE03DraftBuildResultDto,
   PliCbdIntegrationEventsResultDto,
   PliCbdProcessSnapshotDto,
   PortingRequestDetailDto,
@@ -100,6 +101,17 @@ export async function getPortingRequestProcessSnapshot(
     success: true
     data: PliCbdProcessSnapshotDto
   }>(`/porting-requests/${id}/pli-cbd-process`)
+
+  return response.data.data
+}
+
+export async function getPortingRequestE03Draft(
+  id: string,
+): Promise<PliCbdE03DraftBuildResultDto> {
+  const response = await apiClient.get<{
+    success: true
+    data: PliCbdE03DraftBuildResultDto
+  }>(`/porting-requests/${id}/pli-cbd-drafts/e03`)
 
   return response.data.data
 }

--- a/packages/shared/src/dto/pli-cbd-drafts.dto.ts
+++ b/packages/shared/src/dto/pli-cbd-drafts.dto.ts
@@ -1,0 +1,68 @@
+import type {
+  ClientType,
+  ContactChannel,
+  NumberType,
+  PortedNumberKind,
+  PortingMode,
+  SubscriberIdentityType,
+} from '../constants'
+import type { FnpBlockingReason } from './pli-cbd-process.dto'
+
+export interface PliCbdDraftOperatorDto {
+  id: string
+  name: string
+  shortName: string
+  routingNumber: string
+}
+
+export interface PliCbdDraftIdentityDto {
+  type: SubscriberIdentityType
+  value: string
+}
+
+export interface PliCbdDraftBuildResultDto<TDraft> {
+  requestId: string
+  caseNumber: string
+  isReady: boolean
+  blockingReasons: FnpBlockingReason[]
+  draft: TDraft | null
+}
+
+export interface PliCbdE03DraftDto {
+  messageType: 'E03'
+  serviceType: 'FNP'
+  requestId: string
+  caseNumber: string
+  clientId: string
+  clientDisplayName: string
+  subscriberKind: ClientType
+  subscriberDisplayName: string
+  subscriberFirstName: string | null
+  subscriberLastName: string | null
+  subscriberCompanyName: string | null
+  numberType: NumberType
+  portedNumberKind: PortedNumberKind
+  primaryNumber: string | null
+  rangeStart: string | null
+  rangeEnd: string | null
+  numberDisplay: string
+  portingMode: PortingMode
+  requestedPortDate: string | null
+  earliestAcceptablePortDate: string | null
+  requestDocumentNumber: string
+  donorOperator: PliCbdDraftOperatorDto
+  recipientOperator: PliCbdDraftOperatorDto
+  infrastructureOperator: PliCbdDraftOperatorDto | null
+  identity: PliCbdDraftIdentityDto
+  correspondenceAddress: string
+  hasPowerOfAttorney: boolean
+  linkedWholesaleServiceOnRecipientSide: boolean
+  contactChannel: ContactChannel
+  technicalHints: {
+    portDateSource: 'REQUESTED_PORT_DATE' | 'EARLIEST_ACCEPTABLE_PORT_DATE'
+    numberSelectionSource: 'PRIMARY_NUMBER' | 'NUMBER_RANGE'
+  }
+}
+
+export interface PliCbdE03DraftBuildResultDto
+  extends PliCbdDraftBuildResultDto<PliCbdE03DraftDto> {}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,7 @@ export * from './types'
 
 // DTOs
 export * from './dto/operators.dto'
+export * from './dto/pli-cbd-drafts.dto'
 export * from './dto/pli-cbd-integration.dto'
 export * from './dto/porting-requests.dto'
 export * from './dto/porting-timeline.dto'


### PR DESCRIPTION
## Cel

Dodanie domenowego draftu komunikatu E03 dla FNP.

## Zakres

* dodanie shared DTO dla draftu E03 i wyniku budowy draftu
* dodanie backendowego buildera draftu E03 z reużyciem istniejącej walidacji gotowości procesu FNP / PLI CBD
* dodanie read-only endpointu `GET /api/porting-requests/:id/pli-cbd-drafts/e03`
* dodanie lekkiego preview „Draft E03” na detail page sprawy portowania
* odświeżanie preview draftu po akcjach eksportu, synchronizacji i zmianie statusu

## Założenia

* brak XML / SOAP / HTTPS / FTPS
* brak realnej wysyłki do PLI CBD
* draft odzwierciedla aktualny stan sprawy i nie koryguje danych numeracji

## Efekt

* operator widzi, czy sprawa jest gotowa do zbudowania E03
* jeśli nie jest gotowa, dostaje jasne blokady
* jeśli jest gotowa, widzi pełny podgląd danych, które weszłyby do komunikatu E03
* repo jest przygotowane pod kolejny krok: techniczne mapowanie draftu E03 do formatu integracyjnego