### PR TITLE
feat(pli-cbd): add E23 draft builder and read-only preview

### DIFF
--- a/apps/backend/src/modules/pli-cbd/__tests__/fnp-process.domain.test.ts
+++ b/apps/backend/src/modules/pli-cbd/__tests__/fnp-process.domain.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { deriveFnpProcessStage, getAllowedNextMessages } from '../fnp-process.domain'
+
+describe('fnp-process domain', () => {
+  describe('getAllowedNextMessages', () => {
+    it('allows E23 on active stages after process start', () => {
+      expect(getAllowedNextMessages('EXPORT_PENDING')).toContain('E23')
+      expect(getAllowedNextMessages('AWAITING_DONOR_E06')).toContain('E23')
+      expect(getAllowedNextMessages('AWAITING_E12')).toContain('E23')
+      expect(getAllowedNextMessages('AWAITING_E13')).toContain('E23')
+      expect(getAllowedNextMessages('READY_TO_PORT')).toContain('E23')
+    })
+
+    it('does not allow E23 before process start or on terminal stages', () => {
+      expect(getAllowedNextMessages('NOT_IN_PROCESS')).not.toContain('E23')
+      expect(getAllowedNextMessages('COMPLETED')).toEqual([])
+      expect(getAllowedNextMessages('REJECTED')).toEqual([])
+      expect(getAllowedNextMessages('CANCELLED')).toEqual([])
+      expect(getAllowedNextMessages('PROCESS_ERROR')).toEqual([])
+    })
+  })
+
+  describe('deriveFnpProcessStage', () => {
+    it('maps last received E23 to cancelled stage', () => {
+      expect(
+        deriveFnpProcessStage({
+          statusInternal: 'CONFIRMED',
+          pliCbdExportStatus: 'EXPORTED',
+          lastExxReceived: 'E23',
+        }),
+      ).toBe('CANCELLED')
+    })
+  })
+})

--- a/apps/backend/src/modules/pli-cbd/fnp-process.service.ts
+++ b/apps/backend/src/modules/pli-cbd/fnp-process.service.ts
@@ -6,6 +6,8 @@ import type {
   FnpMessageReadiness,
   PliCbdE03DraftBuildResultDto,
   PliCbdE03DraftDto,
+  PliCbdE23DraftBuildResultDto,
+  PliCbdE23DraftDto,
   PliCbdProcessSnapshotDto,
 } from '@np-manager/shared'
 import {
@@ -13,6 +15,7 @@ import {
   FNP_EXX_MESSAGE_LABELS,
   FNP_PROCESS_STAGE_LABELS,
   PORTING_MODE_LABELS,
+  PORTING_CASE_STATUS_LABELS,
 } from '@np-manager/shared'
 import { deriveFnpProcessStage, getAllowedNextMessages } from './fnp-process.domain'
 import {
@@ -93,6 +96,42 @@ const E03_DRAFT_SELECT = {
 } as const
 
 type E03DraftRow = Prisma.PortingRequestGetPayload<{ select: typeof E03_DRAFT_SELECT }>
+
+const E23_DRAFT_SELECT = {
+  id: true,
+  caseNumber: true,
+  clientId: true,
+  numberType: true,
+  numberRangeKind: true,
+  primaryNumber: true,
+  rangeStart: true,
+  rangeEnd: true,
+  portingMode: true,
+  statusInternal: true,
+  pliCbdExportStatus: true,
+  lastExxReceived: true,
+  client: {
+    select: {
+      id: true,
+      clientType: true,
+      firstName: true,
+      lastName: true,
+      companyName: true,
+    },
+  },
+  donorOperator: {
+    select: DRAFT_OPERATOR_SELECT,
+  },
+  recipientOperator: {
+    select: DRAFT_OPERATOR_SELECT,
+  },
+  subscriberKind: true,
+  subscriberFirstName: true,
+  subscriberLastName: true,
+  subscriberCompanyName: true,
+} as const
+
+type E23DraftRow = Prisma.PortingRequestGetPayload<{ select: typeof E23_DRAFT_SELECT }>
 
 // ============================================================
 // POMOCNIK — mapowanie PliCbdExxType → FnpExxMessage | null
@@ -263,9 +302,7 @@ export async function buildE03DraftForPortingRequest(
     }
   }
 
-  const e03Readiness = snapshot.draftableMessages.find(
-    (message) => message.messageType === 'E03',
-  )
+  const e03Readiness = snapshot.draftableMessages.find((message) => message.messageType === 'E03')
 
   if (!e03Readiness) {
     return {
@@ -307,6 +344,75 @@ export async function buildE03DraftForPortingRequest(
     isReady: true,
     blockingReasons: [],
     draft: buildE03Draft(row),
+  }
+}
+
+export async function buildE23DraftForPortingRequest(
+  requestId: string,
+): Promise<PliCbdE23DraftBuildResultDto> {
+  const snapshot = await getPortingRequestProcessSnapshot(requestId)
+
+  if (!snapshot.allowedNextMessages.includes('E23')) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons:
+        snapshot.blockingReasons.length > 0
+          ? snapshot.blockingReasons
+          : [
+              {
+                code: 'E23_NOT_ALLOWED_AT_CURRENT_STAGE',
+                message: `Komunikat E23 nie jest dostepny na aktualnym etapie procesu: ${snapshot.currentStageLabel}.`,
+                field: 'currentStage',
+              },
+            ],
+      draft: null,
+    }
+  }
+
+  const e23Readiness = snapshot.draftableMessages.find((message) => message.messageType === 'E23')
+
+  if (!e23Readiness) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons: [
+        {
+          code: 'E23_READINESS_NOT_AVAILABLE',
+          message: 'Nie udalo sie wyznaczyc gotowosci draftu E23 dla tej sprawy.',
+        },
+      ],
+      draft: null,
+    }
+  }
+
+  if (!e23Readiness.ready) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons: e23Readiness.blockingReasons,
+      draft: null,
+    }
+  }
+
+  const row = await prisma.portingRequest.findUnique({
+    where: { id: requestId },
+    select: E23_DRAFT_SELECT,
+  })
+
+  if (!row) {
+    throw AppError.notFound(`Sprawa o id "${requestId}" nie istnieje.`)
+  }
+
+  return {
+    requestId: row.id,
+    caseNumber: row.caseNumber,
+    isReady: true,
+    blockingReasons: [],
+    draft: buildE23Draft(row, snapshot),
   }
 }
 
@@ -372,18 +478,48 @@ function buildE03Draft(row: E03DraftRow): PliCbdE03DraftDto {
     },
     correspondenceAddress: row.correspondenceAddress,
     hasPowerOfAttorney: row.hasPowerOfAttorney,
-    linkedWholesaleServiceOnRecipientSide:
-      row.linkedWholesaleServiceOnRecipientSide,
+    linkedWholesaleServiceOnRecipientSide: row.linkedWholesaleServiceOnRecipientSide,
     contactChannel: row.contactChannel,
     technicalHints: {
       portDateSource:
-        row.portingMode === 'DAY'
-          ? 'REQUESTED_PORT_DATE'
-          : 'EARLIEST_ACCEPTABLE_PORT_DATE',
+        row.portingMode === 'DAY' ? 'REQUESTED_PORT_DATE' : 'EARLIEST_ACCEPTABLE_PORT_DATE',
       numberSelectionSource:
-        row.numberRangeKind === 'DDI_RANGE'
-          ? 'NUMBER_RANGE'
-          : 'PRIMARY_NUMBER',
+        row.numberRangeKind === 'DDI_RANGE' ? 'NUMBER_RANGE' : 'PRIMARY_NUMBER',
+    },
+  }
+}
+
+function buildE23Draft(row: E23DraftRow, snapshot: PliCbdProcessSnapshotDto): PliCbdE23DraftDto {
+  const lastReceivedMessageType = toFnpLastExx(row.lastExxReceived)
+
+  return {
+    messageType: 'E23',
+    serviceType: 'FNP',
+    portingRequestId: row.id,
+    caseNumber: row.caseNumber,
+    clientId: row.clientId,
+    clientDisplayName: getClientDisplayName(row.client),
+    subscriberDisplayName: getSubscriberDisplayName(row),
+    donorOperator: toDraftOperator(row.donorOperator),
+    recipientOperator: toDraftOperator(row.recipientOperator),
+    portingMode: row.portingMode,
+    numberType: row.numberType,
+    numberRangeKind: row.numberRangeKind,
+    numberDisplay: getNumberDisplay(row),
+    cancellationContext: {
+      currentStage: snapshot.currentStage,
+      currentStageLabel: snapshot.currentStageLabel,
+      statusInternal: row.statusInternal,
+      statusInternalLabel: PORTING_CASE_STATUS_LABELS[row.statusInternal],
+      exportStatus: row.pliCbdExportStatus,
+      lastReceivedMessageType,
+    },
+    reasonHints: buildE23ReasonHints(snapshot, lastReceivedMessageType),
+    technicalHints: {
+      dataSource: 'CURRENT_CASE_AND_PROCESS_SNAPSHOT',
+      numberSelectionSource:
+        row.numberRangeKind === 'DDI_RANGE' ? 'NUMBER_RANGE' : 'PRIMARY_NUMBER',
+      allowedMessagesAtStage: snapshot.allowedNextMessages,
     },
   }
 }
@@ -401,6 +537,26 @@ function toDraftOperator(
     shortName: operator.shortName,
     routingNumber: operator.routingNumber,
   }
+}
+
+function buildE23ReasonHints(
+  snapshot: PliCbdProcessSnapshotDto,
+  lastReceivedMessageType: PliCbdE23DraftDto['cancellationContext']['lastReceivedMessageType'],
+): string[] {
+  const hints = [
+    `Proces FNP znajduje sie obecnie na etapie: ${snapshot.currentStageLabel}.`,
+    'Draft E23 reprezentuje anulowanie lub przerwanie procesu po stronie Biorcy.',
+  ]
+
+  if (lastReceivedMessageType) {
+    hints.push(
+      `Ostatni komunikat uwzgledniony w modelu procesu: ${FNP_EXX_MESSAGE_LABELS[lastReceivedMessageType]}.`,
+    )
+  } else {
+    hints.push('Brak komunikatu Exx potwierdzonego jeszcze po stronie modelu procesu.')
+  }
+
+  return hints
 }
 
 function getClientDisplayName(client: E03DraftRow['client']): string {
@@ -422,9 +578,7 @@ function getSubscriberDisplayName(request: {
     return request.subscriberCompanyName ?? 'Firma (brak nazwy)'
   }
 
-  const parts = [request.subscriberFirstName, request.subscriberLastName].filter(
-    Boolean,
-  )
+  const parts = [request.subscriberFirstName, request.subscriberLastName].filter(Boolean)
   return parts.length > 0 ? parts.join(' ') : 'Brak danych'
 }
 

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -19,6 +19,7 @@ import {
 import { getPortingRequestTimeline } from './porting-events.service'
 import {
   buildE03DraftForPortingRequest,
+  buildE23DraftForPortingRequest,
   getPortingRequestProcessSnapshot,
 } from '../pli-cbd/fnp-process.service'
 
@@ -34,15 +35,11 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
   const writeRoles: UserRole[] = ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER']
   const pliCbdRoles: UserRole[] = ['ADMIN']
 
-  app.get(
-    '/',
-    { preHandler: [authenticate, authorize(readRoles)] },
-    async (request, reply) => {
-      const query = portingRequestListQuerySchema.parse(request.query)
-      const result = await listPortingRequests(query)
-      return reply.status(200).send({ success: true, data: result })
-    },
-  )
+  app.get('/', { preHandler: [authenticate, authorize(readRoles)] }, async (request, reply) => {
+    const query = portingRequestListQuerySchema.parse(request.query)
+    const result = await listPortingRequests(query)
+    return reply.status(200).send({ success: true, data: result })
+  })
 
   app.get<{ Params: { id: string } }>(
     '/:id/timeline',
@@ -81,6 +78,15 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
   )
 
   app.get<{ Params: { id: string } }>(
+    '/:id/pli-cbd-drafts/e23',
+    { preHandler: [authenticate, authorize(readRoles)] },
+    async (request, reply) => {
+      const result = await buildE23DraftForPortingRequest(request.params.id)
+      return reply.status(200).send({ success: true, data: result })
+    },
+  )
+
+  app.get<{ Params: { id: string } }>(
     '/:id',
     { preHandler: [authenticate, authorize(readRoles)] },
     async (request, reply) => {
@@ -89,21 +95,17 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
     },
   )
 
-  app.post(
-    '/',
-    { preHandler: [authenticate, authorize(writeRoles)] },
-    async (request, reply) => {
-      const body = createPortingRequestSchema.parse(request.body)
-      const portingRequest = await createPortingRequest(
-        body,
-        request.user.id,
-        request.ip,
-        request.headers['user-agent'],
-      )
+  app.post('/', { preHandler: [authenticate, authorize(writeRoles)] }, async (request, reply) => {
+    const body = createPortingRequestSchema.parse(request.body)
+    const portingRequest = await createPortingRequest(
+      body,
+      request.user.id,
+      request.ip,
+      request.headers['user-agent'],
+    )
 
-      return reply.status(201).send({ success: true, data: { request: portingRequest } })
-    },
-  )
+    return reply.status(201).send({ success: true, data: { request: portingRequest } })
+  })
 
   app.patch<{ Params: { id: string } }>(
     '/:id/status',

--- a/apps/frontend/src/components/PliCbdE23DraftPreview/PliCbdE23DraftPreview.tsx
+++ b/apps/frontend/src/components/PliCbdE23DraftPreview/PliCbdE23DraftPreview.tsx
@@ -1,0 +1,215 @@
+import {
+  NUMBER_TYPE_LABELS,
+  PLI_CBD_EXPORT_STATUS_LABELS,
+  PORTED_NUMBER_KIND_LABELS,
+  PORTING_CASE_STATUS_LABELS,
+  PORTING_MODE_LABELS,
+  FNP_EXX_MESSAGE_LABELS,
+} from '@np-manager/shared'
+import type { PliCbdE23DraftBuildResultDto } from '@np-manager/shared'
+
+interface PliCbdE23DraftPreviewProps {
+  result: PliCbdE23DraftBuildResultDto | null
+  isLoading: boolean
+}
+
+function Field({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: string | null | undefined
+  mono?: boolean
+}) {
+  return (
+    <div>
+      <dt className="text-xs text-gray-500 mb-0.5">{label}</dt>
+      <dd className={`text-sm text-gray-900 ${mono ? 'font-mono' : ''}`}>
+        {value ?? <span className="text-gray-400">-</span>}
+      </dd>
+    </div>
+  )
+}
+
+export function PliCbdE23DraftPreview({ result, isLoading }: PliCbdE23DraftPreviewProps) {
+  return (
+    <div className="card p-5 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-1">
+          Draft E23
+        </h2>
+        <p className="text-sm text-gray-500">
+          Read-only preview danych, ktore weszlyby do komunikatu E23 dla PLI CBD.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+          Ladowanie draftu E23...
+        </div>
+      ) : !result ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+          Nie udalo sie zaladowac draftu E23.
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <span
+              className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                result.isReady ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
+              }`}
+            >
+              {result.isReady ? 'Gotowe do zbudowania E23' : 'Draft E23 zablokowany'}
+            </span>
+            <span className="text-xs text-gray-500">Sprawa: {result.caseNumber}</span>
+          </div>
+
+          {result.blockingReasons.length > 0 && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-amber-800">
+                Blokady draftu
+              </p>
+              <ul className="space-y-1">
+                {result.blockingReasons.map((reason) => (
+                  <li key={reason.code} className="text-sm text-amber-900">
+                    {reason.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {!result.draft ? (
+            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-4 text-sm text-gray-600">
+              Draft E23 nie zostal wygenerowany dla tej sprawy.
+            </div>
+          ) : (
+            <>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field label="Typ komunikatu" value={result.draft.messageType} mono />
+                  <Field label="Serwis" value={result.draft.serviceType} mono />
+                  <Field label="Kartoteka klienta" value={result.draft.clientDisplayName} />
+                  <Field label="Abonent w sprawie" value={result.draft.subscriberDisplayName} />
+                  <Field label="ID sprawy portowania" value={result.draft.portingRequestId} mono />
+                  <Field label="Numer sprawy" value={result.draft.caseNumber} mono />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4">
+                <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                  Numeracja i operatorzy
+                </p>
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field label="Typ uslugi" value={NUMBER_TYPE_LABELS[result.draft.numberType]} />
+                  <Field
+                    label="Typ numeracji"
+                    value={PORTED_NUMBER_KIND_LABELS[result.draft.numberRangeKind]}
+                  />
+                  <Field label="Numer / zakres" value={result.draft.numberDisplay} mono />
+                  <Field
+                    label="Tryb przeniesienia"
+                    value={PORTING_MODE_LABELS[result.draft.portingMode]}
+                  />
+                  <Field label="Operator oddajacy" value={result.draft.donorOperator.name} />
+                  <Field
+                    label="Routing dawcy"
+                    value={result.draft.donorOperator.routingNumber}
+                    mono
+                  />
+                  <Field label="Operator bioracy" value={result.draft.recipientOperator.name} />
+                  <Field
+                    label="Routing biorcy"
+                    value={result.draft.recipientOperator.routingNumber}
+                    mono
+                  />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4">
+                <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                  Kontekst anulowania
+                </p>
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field
+                    label="Etap procesu"
+                    value={result.draft.cancellationContext.currentStageLabel}
+                  />
+                  <Field
+                    label="Status wewnetrzny"
+                    value={
+                      PORTING_CASE_STATUS_LABELS[result.draft.cancellationContext.statusInternal] ??
+                      result.draft.cancellationContext.statusInternalLabel
+                    }
+                  />
+                  <Field
+                    label="Status eksportu"
+                    value={
+                      PLI_CBD_EXPORT_STATUS_LABELS[result.draft.cancellationContext.exportStatus]
+                    }
+                  />
+                  <Field
+                    label="Ostatni komunikat Exx"
+                    value={
+                      result.draft.cancellationContext.lastReceivedMessageType
+                        ? FNP_EXX_MESSAGE_LABELS[
+                            result.draft.cancellationContext.lastReceivedMessageType
+                          ]
+                        : 'Brak'
+                    }
+                  />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4 space-y-4">
+                <div>
+                  <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                    Podpowiedzi domenowe
+                  </p>
+                  <ul className="space-y-2">
+                    {result.draft.reasonHints.map((hint) => (
+                      <li key={hint} className="text-sm text-gray-700">
+                        {hint}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div>
+                  <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                    Wskazowki techniczne
+                  </p>
+                  <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <Field
+                      label="Zrodlo danych"
+                      value={
+                        result.draft.technicalHints.dataSource ===
+                        'CURRENT_CASE_AND_PROCESS_SNAPSHOT'
+                          ? 'Aktualna sprawa i aktualny snapshot procesu'
+                          : result.draft.technicalHints.dataSource
+                      }
+                    />
+                    <Field
+                      label="Zrodlo wyboru numeracji"
+                      value={
+                        result.draft.technicalHints.numberSelectionSource === 'NUMBER_RANGE'
+                          ? 'Zakres numerow'
+                          : 'Numer podstawowy'
+                      }
+                    />
+                    <Field
+                      label="Dozwolone komunikaty na etapie"
+                      value={result.draft.technicalHints.allowedMessagesAtStage.join(', ')}
+                      mono
+                    />
+                  </dl>
+                </div>
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   exportPortingRequest,
   getPortingRequestById,
   getPortingRequestE03Draft,
+  getPortingRequestE23Draft,
   getPortingRequestIntegrationEvents,
   getPortingRequestProcessSnapshot,
   getPortingRequestTimeline,
@@ -26,6 +27,7 @@ import {
 } from '@np-manager/shared'
 import type {
   PliCbdE03DraftBuildResultDto,
+  PliCbdE23DraftBuildResultDto,
   PliCbdIntegrationEventDto,
   PliCbdProcessSnapshotDto,
   PortingCaseStatus,
@@ -37,6 +39,7 @@ import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
 import { PliCbdIntegrationHistory } from '@/components/PliCbdIntegrationHistory/PliCbdIntegrationHistory'
 import { PliCbdProcessSnapshot } from '@/components/PliCbdProcessSnapshot/PliCbdProcessSnapshot'
 import { PliCbdE03DraftPreview } from '@/components/PliCbdE03DraftPreview/PliCbdE03DraftPreview'
+import { PliCbdE23DraftPreview } from '@/components/PliCbdE23DraftPreview/PliCbdE23DraftPreview'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -66,13 +69,7 @@ function Field({
   )
 }
 
-function WideField({
-  label,
-  value,
-}: {
-  label: string
-  value: string | null | undefined
-}) {
+function WideField({ label, value }: { label: string; value: string | null | undefined }) {
   return (
     <div className="sm:col-span-2">
       <dt className="text-xs text-gray-500 mb-0.5">{label}</dt>
@@ -103,22 +100,17 @@ export function RequestDetailPage() {
   const [isIntegrationEventsLoading, setIsIntegrationEventsLoading] = useState(true)
   const [processSnapshot, setProcessSnapshot] = useState<PliCbdProcessSnapshotDto | null>(null)
   const [isProcessSnapshotLoading, setIsProcessSnapshotLoading] = useState(true)
-  const [e03DraftResult, setE03DraftResult] =
-    useState<PliCbdE03DraftBuildResultDto | null>(null)
+  const [e03DraftResult, setE03DraftResult] = useState<PliCbdE03DraftBuildResultDto | null>(null)
   const [isE03DraftLoading, setIsE03DraftLoading] = useState(true)
+  const [e23DraftResult, setE23DraftResult] = useState<PliCbdE23DraftBuildResultDto | null>(null)
+  const [isE23DraftLoading, setIsE23DraftLoading] = useState(true)
 
   const canManageStatus = useMemo(
-    () =>
-      ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER'].includes(
-        user?.role ?? '',
-      ),
+    () => ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER'].includes(user?.role ?? ''),
     [user?.role],
   )
 
-  const canTriggerPliCbdActions = useMemo(
-    () => user?.role === 'ADMIN',
-    [user?.role],
-  )
+  const canTriggerPliCbdActions = useMemo(() => user?.role === 'ADMIN', [user?.role])
 
   const allowedStatusActions = useMemo(
     () => (request ? getAllowedPortingCaseStatusTransitions(request.statusInternal) : []),
@@ -164,6 +156,24 @@ export function RequestDetailPage() {
     }
   }, [id])
 
+  const loadE23Draft = useCallback(async () => {
+    if (!id) return
+    setIsE23DraftLoading(true)
+    try {
+      const result = await getPortingRequestE23Draft(id)
+      setE23DraftResult(result)
+    } catch {
+      setE23DraftResult(null)
+    } finally {
+      setIsE23DraftLoading(false)
+    }
+  }, [id])
+
+  const refreshDraftPreviews = useCallback(() => {
+    void loadE03Draft()
+    void loadE23Draft()
+  }, [loadE03Draft, loadE23Draft])
+
   const loadIntegrationEvents = useCallback(async () => {
     if (!id || !canTriggerPliCbdActions) {
       setIntegrationEvents([])
@@ -202,8 +212,8 @@ export function RequestDetailPage() {
     void loadTimeline()
     void loadIntegrationEvents()
     void loadProcessSnapshot()
-    void loadE03Draft()
-  }, [id, loadE03Draft, loadIntegrationEvents, loadProcessSnapshot, loadTimeline])
+    refreshDraftPreviews()
+  }, [id, loadIntegrationEvents, loadProcessSnapshot, loadTimeline, refreshDraftPreviews])
 
   const formatDateTime = (iso: string) =>
     new Date(iso).toLocaleString('pl-PL', {
@@ -224,12 +234,12 @@ export function RequestDetailPage() {
       void loadTimeline()
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionSuccess('Eksport do PLI CBD zostal wyzwolony pomyslnie.')
     } catch {
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionError('Nie udalo sie uruchomic foundation eksportu do PLI CBD.')
     } finally {
       setIsExporting(false)
@@ -246,12 +256,12 @@ export function RequestDetailPage() {
       void loadTimeline()
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionSuccess('Synchronizacja z PLI CBD zakonczona pomyslnie.')
     } catch {
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionError('Nie udalo sie uruchomic foundation synchronizacji z PLI CBD.')
     } finally {
       setIsSyncing(false)
@@ -262,9 +272,7 @@ export function RequestDetailPage() {
     if (!id || !request || !canManageStatus || isUpdatingStatus) return
 
     if (targetStatus === 'REJECTED') {
-      const isConfirmed = window.confirm(
-        'Czy na pewno chcesz oznaczyc sprawe jako odrzucona?',
-      )
+      const isConfirmed = window.confirm('Czy na pewno chcesz oznaczyc sprawe jako odrzucona?')
       if (!isConfirmed) return
     }
 
@@ -279,9 +287,7 @@ export function RequestDetailPage() {
     }
 
     if (targetStatus === 'PORTED') {
-      const isConfirmed = window.confirm(
-        'Czy na pewno chcesz oznaczyc sprawe jako przeniesiona?',
-      )
+      const isConfirmed = window.confirm('Czy na pewno chcesz oznaczyc sprawe jako przeniesiona?')
       if (!isConfirmed) return
     }
 
@@ -294,7 +300,7 @@ export function RequestDetailPage() {
       setRequest(updatedRequest)
       void loadTimeline()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setStatusActionSuccess('Status sprawy został zmieniony.')
     } catch (err) {
       if (axios.isAxiosError(err)) {
@@ -344,7 +350,9 @@ export function RequestDetailPage() {
             {(() => {
               const meta = getPortingStatusMeta(request.statusInternal)
               return (
-                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${meta.className}`}>
+                <span
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${meta.className}`}
+                >
                   {meta.label}
                 </span>
               )
@@ -365,7 +373,9 @@ export function RequestDetailPage() {
         <Field label="Kartoteka klienta" value={request.client.displayName} />
         <Field
           label="Typ klienta"
-          value={request.client.clientType === 'INDIVIDUAL' ? 'Osoba fizyczna' : 'Firma / podmiot prawny'}
+          value={
+            request.client.clientType === 'INDIVIDUAL' ? 'Osoba fizyczna' : 'Firma / podmiot prawny'
+          }
         />
       </Section>
 
@@ -424,7 +434,10 @@ export function RequestDetailPage() {
       </Section>
 
       <Section title="Meta i status">
-        <Field label="Status wewnętrzny" value={getPortingStatusMeta(request.statusInternal).label} />
+        <Field
+          label="Status wewnętrzny"
+          value={getPortingStatusMeta(request.statusInternal).label}
+        />
         <Field label="Status PLI CBD (legacy)" value={request.statusPliCbd} mono />
         <Field label="Kod odrzucenia" value={request.rejectionCode} mono />
         <WideField label="Powod odrzucenia" value={request.rejectionReason} />
@@ -453,7 +466,8 @@ export function RequestDetailPage() {
                 >
                   {isUpdatingStatus
                     ? 'Zapisywanie...'
-                    : (PORTING_CASE_STATUS_ACTION_LABELS[targetStatus] ?? PORTING_CASE_STATUS_LABELS[targetStatus])}
+                    : (PORTING_CASE_STATUS_ACTION_LABELS[targetStatus] ??
+                      PORTING_CASE_STATUS_LABELS[targetStatus])}
                 </button>
               ))}
             </div>
@@ -515,13 +529,20 @@ export function RequestDetailPage() {
               label="Status eksportu"
               value={PLI_CBD_EXPORT_STATUS_LABELS[request.pliCbdExportStatus]}
             />
-            <Field label="Ostatnia synchronizacja" value={request.pliCbdLastSyncAt ? formatDateTime(request.pliCbdLastSyncAt) : null} />
+            <Field
+              label="Ostatnia synchronizacja"
+              value={request.pliCbdLastSyncAt ? formatDateTime(request.pliCbdLastSyncAt) : null}
+            />
             <Field label="PLI CBD case ID" value={request.pliCbdCaseId} mono />
             <Field label="PLI CBD case number" value={request.pliCbdCaseNumber} mono />
             <Field label="PLI CBD package ID" value={request.pliCbdPackageId} mono />
             <Field label="Ostatni typ komunikatu" value={request.lastPliCbdMessageType} mono />
             <Field label="Ostatni kod statusu" value={request.lastPliCbdStatusCode} mono />
-            <Field label="Godzina wyznaczona przez Dawce" value={request.donorAssignedPortTime} mono />
+            <Field
+              label="Godzina wyznaczona przez Dawce"
+              value={request.donorAssignedPortTime}
+              mono
+            />
             <WideField
               label="Opis ostatniego statusu PLI CBD"
               value={
@@ -551,15 +572,11 @@ export function RequestDetailPage() {
         </div>
       </div>
 
-      <PliCbdProcessSnapshot
-        snapshot={processSnapshot}
-        isLoading={isProcessSnapshotLoading}
-      />
+      <PliCbdProcessSnapshot snapshot={processSnapshot} isLoading={isProcessSnapshotLoading} />
 
-      <PliCbdE03DraftPreview
-        result={e03DraftResult}
-        isLoading={isE03DraftLoading}
-      />
+      <PliCbdE03DraftPreview result={e03DraftResult} isLoading={isE03DraftLoading} />
+
+      <PliCbdE23DraftPreview result={e23DraftResult} isLoading={isE23DraftLoading} />
 
       {canTriggerPliCbdActions && (
         <PliCbdIntegrationHistory

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -2,6 +2,7 @@ import { apiClient } from './api.client'
 import type {
   CreatePortingRequestDto,
   PliCbdE03DraftBuildResultDto,
+  PliCbdE23DraftBuildResultDto,
   PliCbdIntegrationEventsResultDto,
   PliCbdProcessSnapshotDto,
   PortingRequestDetailDto,
@@ -105,13 +106,20 @@ export async function getPortingRequestProcessSnapshot(
   return response.data.data
 }
 
-export async function getPortingRequestE03Draft(
-  id: string,
-): Promise<PliCbdE03DraftBuildResultDto> {
+export async function getPortingRequestE03Draft(id: string): Promise<PliCbdE03DraftBuildResultDto> {
   const response = await apiClient.get<{
     success: true
     data: PliCbdE03DraftBuildResultDto
   }>(`/porting-requests/${id}/pli-cbd-drafts/e03`)
+
+  return response.data.data
+}
+
+export async function getPortingRequestE23Draft(id: string): Promise<PliCbdE23DraftBuildResultDto> {
+  const response = await apiClient.get<{
+    success: true
+    data: PliCbdE23DraftBuildResultDto
+  }>(`/porting-requests/${id}/pli-cbd-drafts/e23`)
 
   return response.data.data
 }

--- a/packages/shared/src/dto/pli-cbd-drafts.dto.ts
+++ b/packages/shared/src/dto/pli-cbd-drafts.dto.ts
@@ -1,7 +1,11 @@
 import type {
   ClientType,
+  FnpExxMessage,
+  FnpProcessStage,
   ContactChannel,
   NumberType,
+  PliCbdExportStatus,
+  PortingCaseStatus,
   PortedNumberKind,
   PortingMode,
   SubscriberIdentityType,
@@ -64,5 +68,36 @@ export interface PliCbdE03DraftDto {
   }
 }
 
-export interface PliCbdE03DraftBuildResultDto
-  extends PliCbdDraftBuildResultDto<PliCbdE03DraftDto> {}
+export interface PliCbdE03DraftBuildResultDto extends PliCbdDraftBuildResultDto<PliCbdE03DraftDto> {}
+
+export interface PliCbdE23DraftDto {
+  messageType: 'E23'
+  serviceType: 'FNP'
+  portingRequestId: string
+  caseNumber: string
+  clientId: string
+  clientDisplayName: string
+  subscriberDisplayName: string
+  donorOperator: PliCbdDraftOperatorDto
+  recipientOperator: PliCbdDraftOperatorDto
+  portingMode: PortingMode
+  numberType: NumberType
+  numberRangeKind: PortedNumberKind
+  numberDisplay: string
+  cancellationContext: {
+    currentStage: FnpProcessStage
+    currentStageLabel: string
+    statusInternal: PortingCaseStatus
+    statusInternalLabel: string
+    exportStatus: PliCbdExportStatus
+    lastReceivedMessageType: FnpExxMessage | null
+  }
+  reasonHints: string[]
+  technicalHints: {
+    dataSource: 'CURRENT_CASE_AND_PROCESS_SNAPSHOT'
+    numberSelectionSource: 'PRIMARY_NUMBER' | 'NUMBER_RANGE'
+    allowedMessagesAtStage: FnpExxMessage[]
+  }
+}
+
+export interface PliCbdE23DraftBuildResultDto extends PliCbdDraftBuildResultDto<PliCbdE23DraftDto> {}


### PR DESCRIPTION
## Cel

Dodanie domenowego draftu komunikatu E23 dla FNP.

## Zakres

* dodanie shared DTO dla draftu E23 i wyniku budowy draftu
* dodanie backendowego buildera draftu E23 z reużyciem istniejącej logiki procesu FNP / PLI CBD
* dodanie read-only endpointu `GET /api/porting-requests/:id/pli-cbd-drafts/e23`
* dodanie lekkiego preview „Draft E23” na detail page sprawy portowania
* odświeżanie preview draftu po akcjach wpływających na stan procesu

## Założenia

* brak XML / SOAP / HTTPS / FTPS
* brak realnej wysyłki do PLI CBD
* draft odzwierciedla aktualny stan sprawy i etapu procesu

## Efekt

* operator widzi, czy sprawa jest gotowa do zbudowania E23
* jeśli nie jest gotowa, dostaje jasne blokady
* jeśli jest gotowa, widzi pełny podgląd danych, które weszłyby do komunikatu E23
* repo jest przygotowane pod kolejny krok: techniczne mapowanie draftu E23 do formatu integracyjnego