### PR TITLE
feat(pli-cbd): add E12 draft builder and read-only preview

### DIFF
--- a/apps/backend/src/modules/pli-cbd/__tests__/fnp-process.domain.test.ts
+++ b/apps/backend/src/modules/pli-cbd/__tests__/fnp-process.domain.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { deriveFnpProcessStage, getAllowedNextMessages } from '../fnp-process.domain'
+
+describe('fnp-process domain', () => {
+  describe('getAllowedNextMessages', () => {
+    it('allows E12 only on awaiting E12 stage', () => {
+      expect(getAllowedNextMessages('AWAITING_E12')).toContain('E12')
+      expect(getAllowedNextMessages('NOT_IN_PROCESS')).not.toContain('E12')
+      expect(getAllowedNextMessages('EXPORT_PENDING')).not.toContain('E12')
+      expect(getAllowedNextMessages('AWAITING_DONOR_E06')).not.toContain('E12')
+      expect(getAllowedNextMessages('AWAITING_E13')).not.toContain('E12')
+      expect(getAllowedNextMessages('READY_TO_PORT')).not.toContain('E12')
+    })
+  })
+
+  describe('deriveFnpProcessStage', () => {
+    it('maps donor E06 on pending donor status to awaiting E12 stage', () => {
+      expect(
+        deriveFnpProcessStage({
+          statusInternal: 'PENDING_DONOR',
+          pliCbdExportStatus: 'EXPORTED',
+          lastExxReceived: 'E06',
+        }),
+      ).toBe('AWAITING_E12')
+    })
+  })
+})

--- a/apps/backend/src/modules/pli-cbd/fnp-process.domain.ts
+++ b/apps/backend/src/modules/pli-cbd/fnp-process.domain.ts
@@ -86,7 +86,8 @@ export function deriveFnpProcessStage(fields: {
  * - E06 i E13 sa wychodzace od Dawcy — nie sa tutaj uwzglednianie.
  * - E23 (anulowanie) jest dostepne na wiekszosci aktywnych etapow.
  * - E03 odpowiada aktualnej operacji "eksport".
- * - E12 i E18 beda zaimplementowane w kolejnych iteracjach.
+ * - E12 odpowiada potwierdzeniu terminu po stronie Biorcy.
+ * - E18 pozostaje poza zakresem biezacej iteracji draftow.
  */
 export function getAllowedNextMessages(stage: FnpProcessStage): FnpExxMessage[] {
   switch (stage) {

--- a/apps/backend/src/modules/pli-cbd/fnp-process.service.ts
+++ b/apps/backend/src/modules/pli-cbd/fnp-process.service.ts
@@ -6,6 +6,8 @@ import type {
   FnpMessageReadiness,
   PliCbdE03DraftBuildResultDto,
   PliCbdE03DraftDto,
+  PliCbdE12DraftBuildResultDto,
+  PliCbdE12DraftDto,
   PliCbdProcessSnapshotDto,
 } from '@np-manager/shared'
 import {
@@ -13,6 +15,7 @@ import {
   FNP_EXX_MESSAGE_LABELS,
   FNP_PROCESS_STAGE_LABELS,
   PORTING_MODE_LABELS,
+  PORTING_CASE_STATUS_LABELS,
 } from '@np-manager/shared'
 import { deriveFnpProcessStage, getAllowedNextMessages } from './fnp-process.domain'
 import {
@@ -93,6 +96,44 @@ const E03_DRAFT_SELECT = {
 } as const
 
 type E03DraftRow = Prisma.PortingRequestGetPayload<{ select: typeof E03_DRAFT_SELECT }>
+
+const E12_DRAFT_SELECT = {
+  id: true,
+  caseNumber: true,
+  clientId: true,
+  numberType: true,
+  numberRangeKind: true,
+  primaryNumber: true,
+  rangeStart: true,
+  rangeEnd: true,
+  portingMode: true,
+  statusInternal: true,
+  pliCbdExportStatus: true,
+  lastExxReceived: true,
+  donorAssignedPortDate: true,
+  donorAssignedPortTime: true,
+  client: {
+    select: {
+      id: true,
+      clientType: true,
+      firstName: true,
+      lastName: true,
+      companyName: true,
+    },
+  },
+  donorOperator: {
+    select: DRAFT_OPERATOR_SELECT,
+  },
+  recipientOperator: {
+    select: DRAFT_OPERATOR_SELECT,
+  },
+  subscriberKind: true,
+  subscriberFirstName: true,
+  subscriberLastName: true,
+  subscriberCompanyName: true,
+} as const
+
+type E12DraftRow = Prisma.PortingRequestGetPayload<{ select: typeof E12_DRAFT_SELECT }>
 
 // ============================================================
 // POMOCNIK — mapowanie PliCbdExxType → FnpExxMessage | null
@@ -263,9 +304,7 @@ export async function buildE03DraftForPortingRequest(
     }
   }
 
-  const e03Readiness = snapshot.draftableMessages.find(
-    (message) => message.messageType === 'E03',
-  )
+  const e03Readiness = snapshot.draftableMessages.find((message) => message.messageType === 'E03')
 
   if (!e03Readiness) {
     return {
@@ -307,6 +346,75 @@ export async function buildE03DraftForPortingRequest(
     isReady: true,
     blockingReasons: [],
     draft: buildE03Draft(row),
+  }
+}
+
+export async function buildE12DraftForPortingRequest(
+  requestId: string,
+): Promise<PliCbdE12DraftBuildResultDto> {
+  const snapshot = await getPortingRequestProcessSnapshot(requestId)
+
+  if (!snapshot.allowedNextMessages.includes('E12')) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons:
+        snapshot.blockingReasons.length > 0
+          ? snapshot.blockingReasons
+          : [
+              {
+                code: 'E12_NOT_ALLOWED_AT_CURRENT_STAGE',
+                message: `Komunikat E12 nie jest dostepny na aktualnym etapie procesu: ${snapshot.currentStageLabel}.`,
+                field: 'currentStage',
+              },
+            ],
+      draft: null,
+    }
+  }
+
+  const e12Readiness = snapshot.draftableMessages.find((message) => message.messageType === 'E12')
+
+  if (!e12Readiness) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons: [
+        {
+          code: 'E12_READINESS_NOT_AVAILABLE',
+          message: 'Nie udalo sie wyznaczyc gotowosci draftu E12 dla tej sprawy.',
+        },
+      ],
+      draft: null,
+    }
+  }
+
+  if (!e12Readiness.ready) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons: e12Readiness.blockingReasons,
+      draft: null,
+    }
+  }
+
+  const row = await prisma.portingRequest.findUnique({
+    where: { id: requestId },
+    select: E12_DRAFT_SELECT,
+  })
+
+  if (!row) {
+    throw AppError.notFound(`Sprawa o id "${requestId}" nie istnieje.`)
+  }
+
+  return {
+    requestId: row.id,
+    caseNumber: row.caseNumber,
+    isReady: true,
+    blockingReasons: [],
+    draft: buildE12Draft(row, snapshot),
   }
 }
 
@@ -372,18 +480,51 @@ function buildE03Draft(row: E03DraftRow): PliCbdE03DraftDto {
     },
     correspondenceAddress: row.correspondenceAddress,
     hasPowerOfAttorney: row.hasPowerOfAttorney,
-    linkedWholesaleServiceOnRecipientSide:
-      row.linkedWholesaleServiceOnRecipientSide,
+    linkedWholesaleServiceOnRecipientSide: row.linkedWholesaleServiceOnRecipientSide,
     contactChannel: row.contactChannel,
     technicalHints: {
       portDateSource:
-        row.portingMode === 'DAY'
-          ? 'REQUESTED_PORT_DATE'
-          : 'EARLIEST_ACCEPTABLE_PORT_DATE',
+        row.portingMode === 'DAY' ? 'REQUESTED_PORT_DATE' : 'EARLIEST_ACCEPTABLE_PORT_DATE',
       numberSelectionSource:
-        row.numberRangeKind === 'DDI_RANGE'
-          ? 'NUMBER_RANGE'
-          : 'PRIMARY_NUMBER',
+        row.numberRangeKind === 'DDI_RANGE' ? 'NUMBER_RANGE' : 'PRIMARY_NUMBER',
+    },
+  }
+}
+
+function buildE12Draft(row: E12DraftRow, snapshot: PliCbdProcessSnapshotDto): PliCbdE12DraftDto {
+  const lastReceivedMessageType = toFnpLastExx(row.lastExxReceived)
+
+  return {
+    messageType: 'E12',
+    serviceType: 'FNP',
+    portingRequestId: row.id,
+    caseNumber: row.caseNumber,
+    clientId: row.clientId,
+    clientDisplayName: getClientDisplayName(row.client),
+    subscriberDisplayName: getSubscriberDisplayName(row),
+    donorOperator: toDraftOperator(row.donorOperator),
+    recipientOperator: toDraftOperator(row.recipientOperator),
+    portingMode: row.portingMode,
+    numberType: row.numberType,
+    numberRangeKind: row.numberRangeKind,
+    numberDisplay: getNumberDisplay(row),
+    confirmationContext: {
+      currentStage: snapshot.currentStage,
+      currentStageLabel: snapshot.currentStageLabel,
+      statusInternal: row.statusInternal,
+      statusInternalLabel: PORTING_CASE_STATUS_LABELS[row.statusInternal],
+      exportStatus: row.pliCbdExportStatus,
+      lastReceivedMessageType,
+      donorAssignedPortDate: toDateOnlyString(row.donorAssignedPortDate),
+      donorAssignedPortTime: row.donorAssignedPortTime,
+    },
+    reasonHints: buildE12ReasonHints(row, snapshot, lastReceivedMessageType),
+    technicalHints: {
+      dataSource: 'CURRENT_CASE_AND_PROCESS_SNAPSHOT',
+      portDateSource: 'DONOR_ASSIGNED_PORT_DATE',
+      numberSelectionSource:
+        row.numberRangeKind === 'DDI_RANGE' ? 'NUMBER_RANGE' : 'PRIMARY_NUMBER',
+      allowedMessagesAtStage: snapshot.allowedNextMessages,
     },
   }
 }
@@ -401,6 +542,30 @@ function toDraftOperator(
     shortName: operator.shortName,
     routingNumber: operator.routingNumber,
   }
+}
+
+function buildE12ReasonHints(
+  row: E12DraftRow,
+  snapshot: PliCbdProcessSnapshotDto,
+  lastReceivedMessageType: PliCbdE12DraftDto['confirmationContext']['lastReceivedMessageType'],
+): string[] {
+  const hints = [
+    `Proces FNP znajduje sie obecnie na etapie: ${snapshot.currentStageLabel}.`,
+    'Draft E12 reprezentuje potwierdzenie terminu po stronie Biorcy.',
+  ]
+
+  if (lastReceivedMessageType) {
+    hints.push(
+      `Ostatni komunikat uwzgledniony w modelu procesu: ${FNP_EXX_MESSAGE_LABELS[lastReceivedMessageType]}.`,
+    )
+  }
+
+  if (row.donorAssignedPortDate) {
+    const date = toDateOnlyString(row.donorAssignedPortDate)
+    hints.push(`Termin przekazany przez Dawce do potwierdzenia: ${date}.`)
+  }
+
+  return hints
 }
 
 function getClientDisplayName(client: E03DraftRow['client']): string {
@@ -422,9 +587,7 @@ function getSubscriberDisplayName(request: {
     return request.subscriberCompanyName ?? 'Firma (brak nazwy)'
   }
 
-  const parts = [request.subscriberFirstName, request.subscriberLastName].filter(
-    Boolean,
-  )
+  const parts = [request.subscriberFirstName, request.subscriberLastName].filter(Boolean)
   return parts.length > 0 ? parts.join(' ') : 'Brak danych'
 }
 

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -19,6 +19,7 @@ import {
 import { getPortingRequestTimeline } from './porting-events.service'
 import {
   buildE03DraftForPortingRequest,
+  buildE12DraftForPortingRequest,
   getPortingRequestProcessSnapshot,
 } from '../pli-cbd/fnp-process.service'
 
@@ -76,6 +77,15 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
     { preHandler: [authenticate, authorize(readRoles)] },
     async (request, reply) => {
       const result = await buildE03DraftForPortingRequest(request.params.id)
+      return reply.status(200).send({ success: true, data: result })
+    },
+  )
+
+  app.get<{ Params: { id: string } }>(
+    '/:id/pli-cbd-drafts/e12',
+    { preHandler: [authenticate, authorize(readRoles)] },
+    async (request, reply) => {
+      const result = await buildE12DraftForPortingRequest(request.params.id)
       return reply.status(200).send({ success: true, data: result })
     },
   )

--- a/apps/frontend/src/components/PliCbdE12DraftPreview/PliCbdE12DraftPreview.tsx
+++ b/apps/frontend/src/components/PliCbdE12DraftPreview/PliCbdE12DraftPreview.tsx
@@ -1,0 +1,233 @@
+import {
+  FNP_EXX_MESSAGE_LABELS,
+  NUMBER_TYPE_LABELS,
+  PLI_CBD_EXPORT_STATUS_LABELS,
+  PORTED_NUMBER_KIND_LABELS,
+  PORTING_CASE_STATUS_LABELS,
+  PORTING_MODE_LABELS,
+} from '@np-manager/shared'
+import type { PliCbdE12DraftBuildResultDto } from '@np-manager/shared'
+
+interface PliCbdE12DraftPreviewProps {
+  result: PliCbdE12DraftBuildResultDto | null
+  isLoading: boolean
+}
+
+function Field({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: string | null | undefined
+  mono?: boolean
+}) {
+  return (
+    <div>
+      <dt className="text-xs text-gray-500 mb-0.5">{label}</dt>
+      <dd className={`text-sm text-gray-900 ${mono ? 'font-mono' : ''}`}>
+        {value ?? <span className="text-gray-400">-</span>}
+      </dd>
+    </div>
+  )
+}
+
+export function PliCbdE12DraftPreview({ result, isLoading }: PliCbdE12DraftPreviewProps) {
+  return (
+    <div className="card p-5 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-1">
+          Draft E12
+        </h2>
+        <p className="text-sm text-gray-500">
+          Read-only preview danych, ktore weszlyby do komunikatu E12 dla PLI CBD.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+          Ladowanie draftu E12...
+        </div>
+      ) : !result ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+          Nie udalo sie zaladowac draftu E12.
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <span
+              className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                result.isReady ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
+              }`}
+            >
+              {result.isReady ? 'Gotowe do zbudowania E12' : 'Draft E12 zablokowany'}
+            </span>
+            <span className="text-xs text-gray-500">Sprawa: {result.caseNumber}</span>
+          </div>
+
+          {result.blockingReasons.length > 0 && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-amber-800">
+                Blokady draftu
+              </p>
+              <ul className="space-y-1">
+                {result.blockingReasons.map((reason) => (
+                  <li key={reason.code} className="text-sm text-amber-900">
+                    {reason.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {!result.draft ? (
+            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-4 text-sm text-gray-600">
+              Draft E12 nie zostal wygenerowany dla tej sprawy.
+            </div>
+          ) : (
+            <>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field label="Typ komunikatu" value={result.draft.messageType} mono />
+                  <Field label="Serwis" value={result.draft.serviceType} mono />
+                  <Field label="Kartoteka klienta" value={result.draft.clientDisplayName} />
+                  <Field label="Abonent w sprawie" value={result.draft.subscriberDisplayName} />
+                  <Field label="ID sprawy portowania" value={result.draft.portingRequestId} mono />
+                  <Field label="Numer sprawy" value={result.draft.caseNumber} mono />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4">
+                <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                  Numeracja i operatorzy
+                </p>
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field label="Typ uslugi" value={NUMBER_TYPE_LABELS[result.draft.numberType]} />
+                  <Field
+                    label="Typ numeracji"
+                    value={PORTED_NUMBER_KIND_LABELS[result.draft.numberRangeKind]}
+                  />
+                  <Field label="Numer / zakres" value={result.draft.numberDisplay} mono />
+                  <Field
+                    label="Tryb przeniesienia"
+                    value={PORTING_MODE_LABELS[result.draft.portingMode]}
+                  />
+                  <Field label="Operator oddajacy" value={result.draft.donorOperator.name} />
+                  <Field
+                    label="Routing dawcy"
+                    value={result.draft.donorOperator.routingNumber}
+                    mono
+                  />
+                  <Field label="Operator bioracy" value={result.draft.recipientOperator.name} />
+                  <Field
+                    label="Routing biorcy"
+                    value={result.draft.recipientOperator.routingNumber}
+                    mono
+                  />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4">
+                <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                  Kontekst potwierdzenia
+                </p>
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field
+                    label="Etap procesu"
+                    value={result.draft.confirmationContext.currentStageLabel}
+                  />
+                  <Field
+                    label="Status wewnetrzny"
+                    value={
+                      PORTING_CASE_STATUS_LABELS[result.draft.confirmationContext.statusInternal] ??
+                      result.draft.confirmationContext.statusInternalLabel
+                    }
+                  />
+                  <Field
+                    label="Status eksportu"
+                    value={
+                      PLI_CBD_EXPORT_STATUS_LABELS[result.draft.confirmationContext.exportStatus]
+                    }
+                  />
+                  <Field
+                    label="Ostatni komunikat Exx"
+                    value={
+                      result.draft.confirmationContext.lastReceivedMessageType
+                        ? FNP_EXX_MESSAGE_LABELS[
+                            result.draft.confirmationContext.lastReceivedMessageType
+                          ]
+                        : 'Brak'
+                    }
+                  />
+                  <Field
+                    label="Data od Dawcy do potwierdzenia"
+                    value={result.draft.confirmationContext.donorAssignedPortDate}
+                    mono
+                  />
+                  <Field
+                    label="Godzina od Dawcy"
+                    value={result.draft.confirmationContext.donorAssignedPortTime}
+                    mono
+                  />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4 space-y-4">
+                <div>
+                  <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                    Podpowiedzi domenowe
+                  </p>
+                  <ul className="space-y-2">
+                    {result.draft.reasonHints.map((hint) => (
+                      <li key={hint} className="text-sm text-gray-700">
+                        {hint}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div>
+                  <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                    Wskazowki techniczne
+                  </p>
+                  <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <Field
+                      label="Zrodlo danych"
+                      value={
+                        result.draft.technicalHints.dataSource ===
+                        'CURRENT_CASE_AND_PROCESS_SNAPSHOT'
+                          ? 'Aktualna sprawa i aktualny snapshot procesu'
+                          : result.draft.technicalHints.dataSource
+                      }
+                    />
+                    <Field
+                      label="Zrodlo daty potwierdzenia"
+                      value={
+                        result.draft.technicalHints.portDateSource === 'DONOR_ASSIGNED_PORT_DATE'
+                          ? 'Data wyznaczona przez Dawce'
+                          : result.draft.technicalHints.portDateSource
+                      }
+                    />
+                    <Field
+                      label="Zrodlo wyboru numeracji"
+                      value={
+                        result.draft.technicalHints.numberSelectionSource === 'NUMBER_RANGE'
+                          ? 'Zakres numerow'
+                          : 'Numer podstawowy'
+                      }
+                    />
+                    <Field
+                      label="Dozwolone komunikaty na etapie"
+                      value={result.draft.technicalHints.allowedMessagesAtStage.join(', ')}
+                      mono
+                    />
+                  </dl>
+                </div>
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   exportPortingRequest,
   getPortingRequestById,
   getPortingRequestE03Draft,
+  getPortingRequestE12Draft,
   getPortingRequestIntegrationEvents,
   getPortingRequestProcessSnapshot,
   getPortingRequestTimeline,
@@ -26,6 +27,7 @@ import {
 } from '@np-manager/shared'
 import type {
   PliCbdE03DraftBuildResultDto,
+  PliCbdE12DraftBuildResultDto,
   PliCbdIntegrationEventDto,
   PliCbdProcessSnapshotDto,
   PortingCaseStatus,
@@ -37,6 +39,7 @@ import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
 import { PliCbdIntegrationHistory } from '@/components/PliCbdIntegrationHistory/PliCbdIntegrationHistory'
 import { PliCbdProcessSnapshot } from '@/components/PliCbdProcessSnapshot/PliCbdProcessSnapshot'
 import { PliCbdE03DraftPreview } from '@/components/PliCbdE03DraftPreview/PliCbdE03DraftPreview'
+import { PliCbdE12DraftPreview } from '@/components/PliCbdE12DraftPreview/PliCbdE12DraftPreview'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -66,13 +69,7 @@ function Field({
   )
 }
 
-function WideField({
-  label,
-  value,
-}: {
-  label: string
-  value: string | null | undefined
-}) {
+function WideField({ label, value }: { label: string; value: string | null | undefined }) {
   return (
     <div className="sm:col-span-2">
       <dt className="text-xs text-gray-500 mb-0.5">{label}</dt>
@@ -103,22 +100,17 @@ export function RequestDetailPage() {
   const [isIntegrationEventsLoading, setIsIntegrationEventsLoading] = useState(true)
   const [processSnapshot, setProcessSnapshot] = useState<PliCbdProcessSnapshotDto | null>(null)
   const [isProcessSnapshotLoading, setIsProcessSnapshotLoading] = useState(true)
-  const [e03DraftResult, setE03DraftResult] =
-    useState<PliCbdE03DraftBuildResultDto | null>(null)
+  const [e03DraftResult, setE03DraftResult] = useState<PliCbdE03DraftBuildResultDto | null>(null)
   const [isE03DraftLoading, setIsE03DraftLoading] = useState(true)
+  const [e12DraftResult, setE12DraftResult] = useState<PliCbdE12DraftBuildResultDto | null>(null)
+  const [isE12DraftLoading, setIsE12DraftLoading] = useState(true)
 
   const canManageStatus = useMemo(
-    () =>
-      ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER'].includes(
-        user?.role ?? '',
-      ),
+    () => ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER'].includes(user?.role ?? ''),
     [user?.role],
   )
 
-  const canTriggerPliCbdActions = useMemo(
-    () => user?.role === 'ADMIN',
-    [user?.role],
-  )
+  const canTriggerPliCbdActions = useMemo(() => user?.role === 'ADMIN', [user?.role])
 
   const allowedStatusActions = useMemo(
     () => (request ? getAllowedPortingCaseStatusTransitions(request.statusInternal) : []),
@@ -164,6 +156,24 @@ export function RequestDetailPage() {
     }
   }, [id])
 
+  const loadE12Draft = useCallback(async () => {
+    if (!id) return
+    setIsE12DraftLoading(true)
+    try {
+      const result = await getPortingRequestE12Draft(id)
+      setE12DraftResult(result)
+    } catch {
+      setE12DraftResult(null)
+    } finally {
+      setIsE12DraftLoading(false)
+    }
+  }, [id])
+
+  const refreshDraftPreviews = useCallback(() => {
+    void loadE03Draft()
+    void loadE12Draft()
+  }, [loadE03Draft, loadE12Draft])
+
   const loadIntegrationEvents = useCallback(async () => {
     if (!id || !canTriggerPliCbdActions) {
       setIntegrationEvents([])
@@ -202,8 +212,8 @@ export function RequestDetailPage() {
     void loadTimeline()
     void loadIntegrationEvents()
     void loadProcessSnapshot()
-    void loadE03Draft()
-  }, [id, loadE03Draft, loadIntegrationEvents, loadProcessSnapshot, loadTimeline])
+    refreshDraftPreviews()
+  }, [id, loadIntegrationEvents, loadProcessSnapshot, loadTimeline, refreshDraftPreviews])
 
   const formatDateTime = (iso: string) =>
     new Date(iso).toLocaleString('pl-PL', {
@@ -224,12 +234,12 @@ export function RequestDetailPage() {
       void loadTimeline()
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionSuccess('Eksport do PLI CBD zostal wyzwolony pomyslnie.')
     } catch {
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionError('Nie udalo sie uruchomic foundation eksportu do PLI CBD.')
     } finally {
       setIsExporting(false)
@@ -246,12 +256,12 @@ export function RequestDetailPage() {
       void loadTimeline()
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionSuccess('Synchronizacja z PLI CBD zakonczona pomyslnie.')
     } catch {
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionError('Nie udalo sie uruchomic foundation synchronizacji z PLI CBD.')
     } finally {
       setIsSyncing(false)
@@ -262,9 +272,7 @@ export function RequestDetailPage() {
     if (!id || !request || !canManageStatus || isUpdatingStatus) return
 
     if (targetStatus === 'REJECTED') {
-      const isConfirmed = window.confirm(
-        'Czy na pewno chcesz oznaczyc sprawe jako odrzucona?',
-      )
+      const isConfirmed = window.confirm('Czy na pewno chcesz oznaczyc sprawe jako odrzucona?')
       if (!isConfirmed) return
     }
 
@@ -279,9 +287,7 @@ export function RequestDetailPage() {
     }
 
     if (targetStatus === 'PORTED') {
-      const isConfirmed = window.confirm(
-        'Czy na pewno chcesz oznaczyc sprawe jako przeniesiona?',
-      )
+      const isConfirmed = window.confirm('Czy na pewno chcesz oznaczyc sprawe jako przeniesiona?')
       if (!isConfirmed) return
     }
 
@@ -294,7 +300,7 @@ export function RequestDetailPage() {
       setRequest(updatedRequest)
       void loadTimeline()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setStatusActionSuccess('Status sprawy został zmieniony.')
     } catch (err) {
       if (axios.isAxiosError(err)) {
@@ -344,7 +350,9 @@ export function RequestDetailPage() {
             {(() => {
               const meta = getPortingStatusMeta(request.statusInternal)
               return (
-                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${meta.className}`}>
+                <span
+                  className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${meta.className}`}
+                >
                   {meta.label}
                 </span>
               )
@@ -365,7 +373,9 @@ export function RequestDetailPage() {
         <Field label="Kartoteka klienta" value={request.client.displayName} />
         <Field
           label="Typ klienta"
-          value={request.client.clientType === 'INDIVIDUAL' ? 'Osoba fizyczna' : 'Firma / podmiot prawny'}
+          value={
+            request.client.clientType === 'INDIVIDUAL' ? 'Osoba fizyczna' : 'Firma / podmiot prawny'
+          }
         />
       </Section>
 
@@ -424,7 +434,10 @@ export function RequestDetailPage() {
       </Section>
 
       <Section title="Meta i status">
-        <Field label="Status wewnętrzny" value={getPortingStatusMeta(request.statusInternal).label} />
+        <Field
+          label="Status wewnętrzny"
+          value={getPortingStatusMeta(request.statusInternal).label}
+        />
         <Field label="Status PLI CBD (legacy)" value={request.statusPliCbd} mono />
         <Field label="Kod odrzucenia" value={request.rejectionCode} mono />
         <WideField label="Powod odrzucenia" value={request.rejectionReason} />
@@ -453,7 +466,8 @@ export function RequestDetailPage() {
                 >
                   {isUpdatingStatus
                     ? 'Zapisywanie...'
-                    : (PORTING_CASE_STATUS_ACTION_LABELS[targetStatus] ?? PORTING_CASE_STATUS_LABELS[targetStatus])}
+                    : (PORTING_CASE_STATUS_ACTION_LABELS[targetStatus] ??
+                      PORTING_CASE_STATUS_LABELS[targetStatus])}
                 </button>
               ))}
             </div>
@@ -515,13 +529,20 @@ export function RequestDetailPage() {
               label="Status eksportu"
               value={PLI_CBD_EXPORT_STATUS_LABELS[request.pliCbdExportStatus]}
             />
-            <Field label="Ostatnia synchronizacja" value={request.pliCbdLastSyncAt ? formatDateTime(request.pliCbdLastSyncAt) : null} />
+            <Field
+              label="Ostatnia synchronizacja"
+              value={request.pliCbdLastSyncAt ? formatDateTime(request.pliCbdLastSyncAt) : null}
+            />
             <Field label="PLI CBD case ID" value={request.pliCbdCaseId} mono />
             <Field label="PLI CBD case number" value={request.pliCbdCaseNumber} mono />
             <Field label="PLI CBD package ID" value={request.pliCbdPackageId} mono />
             <Field label="Ostatni typ komunikatu" value={request.lastPliCbdMessageType} mono />
             <Field label="Ostatni kod statusu" value={request.lastPliCbdStatusCode} mono />
-            <Field label="Godzina wyznaczona przez Dawce" value={request.donorAssignedPortTime} mono />
+            <Field
+              label="Godzina wyznaczona przez Dawce"
+              value={request.donorAssignedPortTime}
+              mono
+            />
             <WideField
               label="Opis ostatniego statusu PLI CBD"
               value={
@@ -551,15 +572,11 @@ export function RequestDetailPage() {
         </div>
       </div>
 
-      <PliCbdProcessSnapshot
-        snapshot={processSnapshot}
-        isLoading={isProcessSnapshotLoading}
-      />
+      <PliCbdProcessSnapshot snapshot={processSnapshot} isLoading={isProcessSnapshotLoading} />
 
-      <PliCbdE03DraftPreview
-        result={e03DraftResult}
-        isLoading={isE03DraftLoading}
-      />
+      <PliCbdE03DraftPreview result={e03DraftResult} isLoading={isE03DraftLoading} />
+
+      <PliCbdE12DraftPreview result={e12DraftResult} isLoading={isE12DraftLoading} />
 
       {canTriggerPliCbdActions && (
         <PliCbdIntegrationHistory

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -2,6 +2,7 @@ import { apiClient } from './api.client'
 import type {
   CreatePortingRequestDto,
   PliCbdE03DraftBuildResultDto,
+  PliCbdE12DraftBuildResultDto,
   PliCbdIntegrationEventsResultDto,
   PliCbdProcessSnapshotDto,
   PortingRequestDetailDto,
@@ -105,13 +106,20 @@ export async function getPortingRequestProcessSnapshot(
   return response.data.data
 }
 
-export async function getPortingRequestE03Draft(
-  id: string,
-): Promise<PliCbdE03DraftBuildResultDto> {
+export async function getPortingRequestE03Draft(id: string): Promise<PliCbdE03DraftBuildResultDto> {
   const response = await apiClient.get<{
     success: true
     data: PliCbdE03DraftBuildResultDto
   }>(`/porting-requests/${id}/pli-cbd-drafts/e03`)
+
+  return response.data.data
+}
+
+export async function getPortingRequestE12Draft(id: string): Promise<PliCbdE12DraftBuildResultDto> {
+  const response = await apiClient.get<{
+    success: true
+    data: PliCbdE12DraftBuildResultDto
+  }>(`/porting-requests/${id}/pli-cbd-drafts/e12`)
 
   return response.data.data
 }

--- a/packages/shared/src/dto/pli-cbd-drafts.dto.ts
+++ b/packages/shared/src/dto/pli-cbd-drafts.dto.ts
@@ -1,7 +1,11 @@
 import type {
   ClientType,
+  FnpExxMessage,
+  FnpProcessStage,
   ContactChannel,
   NumberType,
+  PliCbdExportStatus,
+  PortingCaseStatus,
   PortedNumberKind,
   PortingMode,
   SubscriberIdentityType,
@@ -64,5 +68,39 @@ export interface PliCbdE03DraftDto {
   }
 }
 
-export interface PliCbdE03DraftBuildResultDto
-  extends PliCbdDraftBuildResultDto<PliCbdE03DraftDto> {}
+export interface PliCbdE03DraftBuildResultDto extends PliCbdDraftBuildResultDto<PliCbdE03DraftDto> {}
+
+export interface PliCbdE12DraftDto {
+  messageType: 'E12'
+  serviceType: 'FNP'
+  portingRequestId: string
+  caseNumber: string
+  clientId: string
+  clientDisplayName: string
+  subscriberDisplayName: string
+  donorOperator: PliCbdDraftOperatorDto
+  recipientOperator: PliCbdDraftOperatorDto
+  portingMode: PortingMode
+  numberType: NumberType
+  numberRangeKind: PortedNumberKind
+  numberDisplay: string
+  confirmationContext: {
+    currentStage: FnpProcessStage
+    currentStageLabel: string
+    statusInternal: PortingCaseStatus
+    statusInternalLabel: string
+    exportStatus: PliCbdExportStatus
+    lastReceivedMessageType: FnpExxMessage | null
+    donorAssignedPortDate: string | null
+    donorAssignedPortTime: string | null
+  }
+  reasonHints: string[]
+  technicalHints: {
+    dataSource: 'CURRENT_CASE_AND_PROCESS_SNAPSHOT'
+    portDateSource: 'DONOR_ASSIGNED_PORT_DATE'
+    numberSelectionSource: 'PRIMARY_NUMBER' | 'NUMBER_RANGE'
+    allowedMessagesAtStage: FnpExxMessage[]
+  }
+}
+
+export interface PliCbdE12DraftBuildResultDto extends PliCbdDraftBuildResultDto<PliCbdE12DraftDto> {}


### PR DESCRIPTION
## Cel

Dodanie domenowego draftu komunikatu E12 dla FNP.

## Zakres

* dodanie shared DTO dla draftu E12 i wyniku budowy draftu
* dodanie backendowego buildera draftu E12 z reużyciem istniejącej logiki procesu FNP / PLI CBD
* dodanie read-only endpointu `GET /api/porting-requests/:id/pli-cbd-drafts/e12`
* dodanie lekkiego preview „Draft E12” na detail page sprawy portowania
* odświeżanie preview draftu po akcjach wpływających na stan procesu

## Założenia

* brak XML / SOAP / HTTPS / FTPS
* brak realnej wysyłki do PLI CBD
* draft odzwierciedla aktualny stan sprawy i etapu procesu

## Efekt

* operator widzi, czy sprawa jest gotowa do zbudowania E12
* jeśli nie jest gotowa, dostaje jasne blokady
* jeśli jest gotowa, widzi pełny podgląd danych, które weszłyby do komunikatu E12
* repo jest przygotowane pod kolejny krok: techniczne mapowanie draftu E12 do formatu integracyjnego

## Weryfikacja

* `npm run build`
* `npm run test -w apps/backend -- src/modules/pli-cbd/__tests__/fnp-process.domain.test.ts`