### PR TITLE
feat(pli-cbd): add E18 draft builder and read-only preview

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,22 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "backend",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["tsx", "src/app.ts"],
+      "port": 3001,
+      "cwd": "apps/backend",
+      "env": {
+        "NODE_ENV": "development"
+      }
+    },
+    {
+      "name": "frontend",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["vite", "--port", "5173"],
+      "port": 5173,
+      "cwd": "apps/frontend"
+    }
+  ]
+}

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -10,6 +10,11 @@
  *  6. Ustawienia systemowe
  *  7. Kalendarz świąt 2026
  *
+ * Sprawy testowe:
+ *  - FNP-SEED-ACTIVE-001: aktywna, pre-export (SUBMITTED)
+ *  - FNP-SEED-PORTED-001: zakończona po E18 (blocked)
+ *  - FNP-SEED-E18-001:    etap READY_TO_PORT, happy path Draft E18
+ *
  * Seed jest idempotentny — używa upsert, można uruchomić wielokrotnie.
  *
  * Domyślne konto admina:
@@ -875,9 +880,10 @@ async function main() {
       pliCbdPackageId: null,
       pliCbdExportStatus: 'EXPORTED',
       pliCbdLastSyncAt: new Date('2026-03-28T08:15:00.000Z'),
-      lastExxReceived: null,
-      lastPliCbdStatusCode: 'PORTED',
-      lastPliCbdStatusDescription: 'Seed QA: sprawa zakonczona do testu zablokowanego eksportu.',
+      lastExxReceived: 'E18',
+      lastPliCbdStatusCode: 'COMPLETED',
+      lastPliCbdStatusDescription:
+        'Seed QA: sprawa zakonczona po E18 do testu terminalnego stanu procesu.',
       rejectionCode: null,
       rejectionReason: null,
       subscriberKind: 'INDIVIDUAL',
@@ -890,7 +896,7 @@ async function main() {
       hasPowerOfAttorney: false,
       linkedWholesaleServiceOnRecipientSide: false,
       contactChannel: 'EMAIL',
-      internalNotes: 'Seed QA: zakonczona sprawa do testu wpisu ERROR dla zablokowanego eksportu.',
+      internalNotes: 'Seed QA: zakonczona sprawa po E18 do testu terminalnego, zablokowanego preview.',
       createdByUserId: adminUser.id,
     },
     create: {
@@ -917,8 +923,10 @@ async function main() {
       pliCbdCaseNumber: 'PLI-SEED-PORTED-001',
       pliCbdExportStatus: 'EXPORTED',
       pliCbdLastSyncAt: new Date('2026-03-28T08:15:00.000Z'),
-      lastPliCbdStatusCode: 'PORTED',
-      lastPliCbdStatusDescription: 'Seed QA: sprawa zakonczona do testu zablokowanego eksportu.',
+      lastExxReceived: 'E18',
+      lastPliCbdStatusCode: 'COMPLETED',
+      lastPliCbdStatusDescription:
+        'Seed QA: sprawa zakonczona po E18 do testu terminalnego stanu procesu.',
       subscriberKind: 'INDIVIDUAL',
       subscriberFirstName: 'Jan',
       subscriberLastName: 'Testowy',
@@ -928,11 +936,106 @@ async function main() {
       hasPowerOfAttorney: false,
       linkedWholesaleServiceOnRecipientSide: false,
       contactChannel: 'EMAIL',
-      internalNotes: 'Seed QA: zakonczona sprawa do testu wpisu ERROR dla zablokowanego eksportu.',
+      internalNotes: 'Seed QA: zakonczona sprawa po E18 do testu terminalnego, zablokowanego preview.',
       createdByUserId: adminUser.id,
     },
   })
-  console.info('Dodano klienta QA oraz 2 sprawy portowania (aktywna + zakonczona)')
+
+  await prisma.portingRequest.upsert({
+    where: { caseNumber: 'FNP-SEED-E18-001' },
+    update: {
+      clientId: qaClient.id,
+      numberType: 'FIXED_LINE',
+      numberRangeKind: 'SINGLE',
+      primaryNumber: '221234570',
+      rangeStart: null,
+      rangeEnd: null,
+      requestDocumentNumber: 'DOC-SEED-E18-001',
+      donorOperatorId: donorOperator.id,
+      recipientOperatorId: recipientOperator.id,
+      infrastructureOperatorId: null,
+      donorRoutingNumber: donorOperator.routingNumber,
+      recipientRoutingNumber: recipientOperator.routingNumber,
+      requestRegisteredAt: new Date('2026-03-24T08:45:00.000Z'),
+      requestedPortDate: new Date('2026-04-14T00:00:00.000Z'),
+      requestedPortTime: '00:00',
+      earliestAcceptablePortDate: null,
+      confirmedPortDate: new Date('2026-04-14T00:00:00.000Z'),
+      donorAssignedPortDate: new Date('2026-04-14T00:00:00.000Z'),
+      donorAssignedPortTime: '07:00',
+      portingMode: 'DAY',
+      statusInternal: 'PORTED',
+      statusPliCbd: 'READY_TO_PORT',
+      pliCbdCaseId: 'PLI-SEED-E18-001',
+      pliCbdCaseNumber: 'PLI-SEED-E18-001',
+      pliCbdPackageId: null,
+      pliCbdExportStatus: 'EXPORTED',
+      pliCbdLastSyncAt: new Date('2026-04-14T07:15:00.000Z'),
+      lastExxReceived: 'E13',
+      lastPliCbdStatusCode: 'READY_TO_PORT',
+      lastPliCbdStatusDescription:
+        'Seed QA: termin uzgodniony po E13, numer przeniesiony technicznie, oczekuje na potwierdzenie E18.',
+      rejectionCode: null,
+      rejectionReason: null,
+      subscriberKind: 'INDIVIDUAL',
+      subscriberFirstName: 'Maria',
+      subscriberLastName: 'Nowak',
+      subscriberCompanyName: null,
+      identityType: 'PESEL',
+      identityValue: '88080834567',
+      correspondenceAddress: 'ul. Lacznosci 18/4, 00-120 Warszawa',
+      hasPowerOfAttorney: false,
+      linkedWholesaleServiceOnRecipientSide: false,
+      contactChannel: 'EMAIL',
+      internalNotes:
+        'Seed QA: sprawa READY_TO_PORT / PORTED do testu happy path preview Draft E18.',
+      createdByUserId: adminUser.id,
+    },
+    create: {
+      caseNumber: 'FNP-SEED-E18-001',
+      clientId: qaClient.id,
+      numberType: 'FIXED_LINE',
+      numberRangeKind: 'SINGLE',
+      primaryNumber: '221234570',
+      requestDocumentNumber: 'DOC-SEED-E18-001',
+      donorOperatorId: donorOperator.id,
+      recipientOperatorId: recipientOperator.id,
+      donorRoutingNumber: donorOperator.routingNumber,
+      recipientRoutingNumber: recipientOperator.routingNumber,
+      requestRegisteredAt: new Date('2026-03-24T08:45:00.000Z'),
+      requestedPortDate: new Date('2026-04-14T00:00:00.000Z'),
+      requestedPortTime: '00:00',
+      confirmedPortDate: new Date('2026-04-14T00:00:00.000Z'),
+      donorAssignedPortDate: new Date('2026-04-14T00:00:00.000Z'),
+      donorAssignedPortTime: '07:00',
+      portingMode: 'DAY',
+      statusInternal: 'PORTED',
+      statusPliCbd: 'READY_TO_PORT',
+      pliCbdCaseId: 'PLI-SEED-E18-001',
+      pliCbdCaseNumber: 'PLI-SEED-E18-001',
+      pliCbdExportStatus: 'EXPORTED',
+      pliCbdLastSyncAt: new Date('2026-04-14T07:15:00.000Z'),
+      lastExxReceived: 'E13',
+      lastPliCbdStatusCode: 'READY_TO_PORT',
+      lastPliCbdStatusDescription:
+        'Seed QA: termin uzgodniony po E13, numer przeniesiony technicznie, oczekuje na potwierdzenie E18.',
+      subscriberKind: 'INDIVIDUAL',
+      subscriberFirstName: 'Maria',
+      subscriberLastName: 'Nowak',
+      identityType: 'PESEL',
+      identityValue: '88080834567',
+      correspondenceAddress: 'ul. Lacznosci 18/4, 00-120 Warszawa',
+      hasPowerOfAttorney: false,
+      linkedWholesaleServiceOnRecipientSide: false,
+      contactChannel: 'EMAIL',
+      internalNotes:
+        'Seed QA: sprawa READY_TO_PORT / PORTED do testu happy path preview Draft E18.',
+      createdByUserId: adminUser.id,
+    },
+  })
+  console.info(
+    'Dodano klienta QA oraz 3 sprawy portowania (aktywna + zakonczona po E18 + READY_TO_PORT/E18)',
+  )
 
   // ----------------------------------------------------------
   // 7. USTAWIENIA SYSTEMOWE

--- a/apps/backend/src/modules/pli-cbd/__tests__/fnp-process.domain.test.ts
+++ b/apps/backend/src/modules/pli-cbd/__tests__/fnp-process.domain.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import { deriveFnpProcessStage, getAllowedNextMessages } from '../fnp-process.domain'
+
+describe('fnp-process domain', () => {
+  describe('getAllowedNextMessages', () => {
+    it('allows E12 only on awaiting E12 stage', () => {
+      expect(getAllowedNextMessages('AWAITING_E12')).toContain('E12')
+      expect(getAllowedNextMessages('NOT_IN_PROCESS')).not.toContain('E12')
+      expect(getAllowedNextMessages('EXPORT_PENDING')).not.toContain('E12')
+      expect(getAllowedNextMessages('AWAITING_DONOR_E06')).not.toContain('E12')
+      expect(getAllowedNextMessages('AWAITING_E13')).not.toContain('E12')
+      expect(getAllowedNextMessages('READY_TO_PORT')).not.toContain('E12')
+    })
+
+    it('allows E18 only on ready to port stage', () => {
+      expect(getAllowedNextMessages('READY_TO_PORT')).toContain('E18')
+      expect(getAllowedNextMessages('AWAITING_E13')).not.toContain('E18')
+      expect(getAllowedNextMessages('COMPLETED')).not.toContain('E18')
+    })
+  })
+
+  describe('deriveFnpProcessStage', () => {
+    it('maps donor E06 on pending donor status to awaiting E12 stage', () => {
+      expect(
+        deriveFnpProcessStage({
+          statusInternal: 'PENDING_DONOR',
+          pliCbdExportStatus: 'EXPORTED',
+          lastExxReceived: 'E06',
+        }),
+      ).toBe('AWAITING_E12')
+    })
+
+    it('keeps ported request with last donor confirmation on ready to port stage for E18', () => {
+      expect(
+        deriveFnpProcessStage({
+          statusInternal: 'PORTED',
+          pliCbdExportStatus: 'EXPORTED',
+          lastExxReceived: 'E13',
+        }),
+      ).toBe('READY_TO_PORT')
+    })
+
+    it('maps ported request with sent E18 to completed stage', () => {
+      expect(
+        deriveFnpProcessStage({
+          statusInternal: 'PORTED',
+          pliCbdExportStatus: 'EXPORTED',
+          lastExxReceived: 'E18',
+        }),
+      ).toBe('COMPLETED')
+    })
+  })
+})

--- a/apps/backend/src/modules/pli-cbd/fnp-process.domain.ts
+++ b/apps/backend/src/modules/pli-cbd/fnp-process.domain.ts
@@ -14,7 +14,8 @@ import type {
  * Wyprowadza aktualny etap procesu FNP na podstawie pol sprawy.
  *
  * Logika:
- * 1. Statusy terminalne (PORTED, REJECTED, CANCELLED, ERROR) → natychmiast.
+ * 1. Statusy terminalne (REJECTED, CANCELLED, ERROR) → natychmiast.
+ * 1a. PORTED staje sie terminalne dopiero po wyslaniu E18.
  * 2. Niewyeksportowana → NOT_IN_PROCESS.
  * 3. EXPORT_PENDING → czeka na rejestracje w PLI.
  * 4. EXPORTED / SYNC_ERROR → etap zalezy od ostatniego komunikatu Exx.
@@ -27,7 +28,6 @@ export function deriveFnpProcessStage(fields: {
   const { statusInternal, pliCbdExportStatus, lastExxReceived } = fields
 
   // Statusy terminalne — jednoznaczne, niezalezne od PLI CBD
-  if (statusInternal === 'PORTED') return 'COMPLETED'
   if (statusInternal === 'REJECTED') return 'REJECTED'
   if (statusInternal === 'CANCELLED') return 'CANCELLED'
   if (statusInternal === 'ERROR') return 'PROCESS_ERROR'
@@ -67,6 +67,10 @@ export function deriveFnpProcessStage(fields: {
   // E16 — blad walidacyjny, sprawa zawieszona
   if (lastExxReceived === 'E16') return 'PROCESS_ERROR'
 
+  // Po technicznym przeniesieniu numeru, ale przed wyslaniem E18, pozostajemy
+  // w etapie READY_TO_PORT — to stan, w ktorym preview E18 ma byc gotowe.
+  if (statusInternal === 'PORTED') return 'READY_TO_PORT'
+
   // Pozostale Exx (E17, E31, E03 jako echo itp.) — zachowaj etap oparty na statusie
   if (statusInternal === 'CONFIRMED') return 'AWAITING_E13'
   if (statusInternal === 'PENDING_DONOR') return 'AWAITING_E12'
@@ -86,7 +90,8 @@ export function deriveFnpProcessStage(fields: {
  * - E06 i E13 sa wychodzace od Dawcy — nie sa tutaj uwzglednianie.
  * - E23 (anulowanie) jest dostepne na wiekszosci aktywnych etapow.
  * - E03 odpowiada aktualnej operacji "eksport".
- * - E12 i E18 beda zaimplementowane w kolejnych iteracjach.
+ * - E12 odpowiada potwierdzeniu terminu po stronie Biorcy.
+ * - E18 odpowiada potwierdzeniu wykonania przeniesienia po stronie Biorcy.
  */
 export function getAllowedNextMessages(stage: FnpProcessStage): FnpExxMessage[] {
   switch (stage) {

--- a/apps/backend/src/modules/pli-cbd/fnp-process.service.ts
+++ b/apps/backend/src/modules/pli-cbd/fnp-process.service.ts
@@ -6,12 +6,15 @@ import type {
   FnpMessageReadiness,
   PliCbdE03DraftBuildResultDto,
   PliCbdE03DraftDto,
+  PliCbdE18DraftBuildResultDto,
+  PliCbdE18DraftDto,
   PliCbdProcessSnapshotDto,
 } from '@np-manager/shared'
 import {
   FNP_EXX_MESSAGE_DESCRIPTIONS,
   FNP_EXX_MESSAGE_LABELS,
   FNP_PROCESS_STAGE_LABELS,
+  PORTING_CASE_STATUS_LABELS,
   PORTING_MODE_LABELS,
 } from '@np-manager/shared'
 import { deriveFnpProcessStage, getAllowedNextMessages } from './fnp-process.domain'
@@ -93,6 +96,45 @@ const E03_DRAFT_SELECT = {
 } as const
 
 type E03DraftRow = Prisma.PortingRequestGetPayload<{ select: typeof E03_DRAFT_SELECT }>
+
+const E18_DRAFT_SELECT = {
+  id: true,
+  caseNumber: true,
+  clientId: true,
+  numberType: true,
+  numberRangeKind: true,
+  primaryNumber: true,
+  rangeStart: true,
+  rangeEnd: true,
+  portingMode: true,
+  statusInternal: true,
+  pliCbdExportStatus: true,
+  lastExxReceived: true,
+  confirmedPortDate: true,
+  donorAssignedPortDate: true,
+  donorAssignedPortTime: true,
+  client: {
+    select: {
+      id: true,
+      clientType: true,
+      firstName: true,
+      lastName: true,
+      companyName: true,
+    },
+  },
+  donorOperator: {
+    select: DRAFT_OPERATOR_SELECT,
+  },
+  recipientOperator: {
+    select: DRAFT_OPERATOR_SELECT,
+  },
+  subscriberKind: true,
+  subscriberFirstName: true,
+  subscriberLastName: true,
+  subscriberCompanyName: true,
+} as const
+
+type E18DraftRow = Prisma.PortingRequestGetPayload<{ select: typeof E18_DRAFT_SELECT }>
 
 // ============================================================
 // POMOCNIK — mapowanie PliCbdExxType → FnpExxMessage | null
@@ -310,6 +352,75 @@ export async function buildE03DraftForPortingRequest(
   }
 }
 
+export async function buildE18DraftForPortingRequest(
+  requestId: string,
+): Promise<PliCbdE18DraftBuildResultDto> {
+  const snapshot = await getPortingRequestProcessSnapshot(requestId)
+
+  if (!snapshot.allowedNextMessages.includes('E18')) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons:
+        snapshot.blockingReasons.length > 0
+          ? snapshot.blockingReasons
+          : [
+              {
+                code: 'E18_NOT_ALLOWED_AT_CURRENT_STAGE',
+                message: `Komunikat E18 nie jest dostepny na aktualnym etapie procesu: ${snapshot.currentStageLabel}.`,
+                field: 'currentStage',
+              },
+            ],
+      draft: null,
+    }
+  }
+
+  const e18Readiness = snapshot.draftableMessages.find((message) => message.messageType === 'E18')
+
+  if (!e18Readiness) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons: [
+        {
+          code: 'E18_READINESS_NOT_AVAILABLE',
+          message: 'Nie udalo sie wyznaczyc gotowosci draftu E18 dla tej sprawy.',
+        },
+      ],
+      draft: null,
+    }
+  }
+
+  if (!e18Readiness.ready) {
+    return {
+      requestId: snapshot.requestId,
+      caseNumber: snapshot.caseNumber,
+      isReady: false,
+      blockingReasons: e18Readiness.blockingReasons,
+      draft: null,
+    }
+  }
+
+  const row = await prisma.portingRequest.findUnique({
+    where: { id: requestId },
+    select: E18_DRAFT_SELECT,
+  })
+
+  if (!row) {
+    throw AppError.notFound(`Sprawa o id "${requestId}" nie istnieje.`)
+  }
+
+  return {
+    requestId: row.id,
+    caseNumber: row.caseNumber,
+    isReady: true,
+    blockingReasons: [],
+    draft: buildE18Draft(row, snapshot),
+  }
+}
+
 function buildSummaryFields(
   messageType: string,
   row: FnpValidationRequest & { id: string; caseNumber: string },
@@ -386,6 +497,71 @@ function buildE03Draft(row: E03DraftRow): PliCbdE03DraftDto {
           : 'PRIMARY_NUMBER',
     },
   }
+}
+
+function buildE18Draft(row: E18DraftRow, snapshot: PliCbdProcessSnapshotDto): PliCbdE18DraftDto {
+  const lastReceivedMessageType = toFnpLastExx(row.lastExxReceived)
+
+  return {
+    messageType: 'E18',
+    serviceType: 'FNP',
+    requestId: row.id,
+    caseNumber: row.caseNumber,
+    clientId: row.clientId,
+    clientDisplayName: getClientDisplayName(row.client),
+    subscriberDisplayName: getSubscriberDisplayName(row),
+    donorOperator: toDraftOperator(row.donorOperator),
+    recipientOperator: toDraftOperator(row.recipientOperator),
+    portingMode: row.portingMode,
+    numberType: row.numberType,
+    numberRangeKind: row.numberRangeKind,
+    numberDisplay: getNumberDisplay(row),
+    completionContext: {
+      currentStage: snapshot.currentStage,
+      currentStageLabel: snapshot.currentStageLabel,
+      statusInternal: row.statusInternal,
+      statusInternalLabel: PORTING_CASE_STATUS_LABELS[row.statusInternal],
+      exportStatus: row.pliCbdExportStatus,
+      lastReceivedMessageType,
+      confirmedPortDate: toDateOnlyString(row.confirmedPortDate),
+      donorAssignedPortDate: toDateOnlyString(row.donorAssignedPortDate),
+      donorAssignedPortTime: row.donorAssignedPortTime,
+    },
+    reasonHints: buildE18ReasonHints(row, snapshot, lastReceivedMessageType),
+    technicalHints: {
+      dataSource: 'CURRENT_CASE_AND_PROCESS_SNAPSHOT',
+      numberSelectionSource:
+        row.numberRangeKind === 'DDI_RANGE' ? 'NUMBER_RANGE' : 'PRIMARY_NUMBER',
+      allowedMessagesAtStage: snapshot.allowedNextMessages,
+    },
+  }
+}
+
+function buildE18ReasonHints(
+  row: E18DraftRow,
+  snapshot: PliCbdProcessSnapshotDto,
+  lastReceivedMessageType: PliCbdE18DraftDto['completionContext']['lastReceivedMessageType'],
+): string[] {
+  const hints = [
+    `Proces FNP znajduje sie obecnie na etapie: ${snapshot.currentStageLabel}.`,
+    'Draft E18 reprezentuje potwierdzenie wykonania przeniesienia numeru przez Biorce.',
+  ]
+
+  if (lastReceivedMessageType) {
+    hints.push(
+      `Ostatni komunikat uwzgledniony w modelu procesu: ${FNP_EXX_MESSAGE_LABELS[lastReceivedMessageType]}.`,
+    )
+  }
+
+  if (row.confirmedPortDate) {
+    hints.push(`Potwierdzona data przeniesienia: ${toDateOnlyString(row.confirmedPortDate)}.`)
+  }
+
+  if (row.donorAssignedPortDate) {
+    hints.push(`Data wyznaczona przez Dawce: ${toDateOnlyString(row.donorAssignedPortDate)}.`)
+  }
+
+  return hints
 }
 
 function toDateOnlyString(value: Date | null): string | null {

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -19,6 +19,7 @@ import {
 import { getPortingRequestTimeline } from './porting-events.service'
 import {
   buildE03DraftForPortingRequest,
+  buildE18DraftForPortingRequest,
   getPortingRequestProcessSnapshot,
 } from '../pli-cbd/fnp-process.service'
 
@@ -76,6 +77,15 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
     { preHandler: [authenticate, authorize(readRoles)] },
     async (request, reply) => {
       const result = await buildE03DraftForPortingRequest(request.params.id)
+      return reply.status(200).send({ success: true, data: result })
+    },
+  )
+
+  app.get<{ Params: { id: string } }>(
+    '/:id/pli-cbd-drafts/e18',
+    { preHandler: [authenticate, authorize(readRoles)] },
+    async (request, reply) => {
+      const result = await buildE18DraftForPortingRequest(request.params.id)
       return reply.status(200).send({ success: true, data: result })
     },
   )

--- a/apps/frontend/src/components/PliCbdE18DraftPreview/PliCbdE18DraftPreview.tsx
+++ b/apps/frontend/src/components/PliCbdE18DraftPreview/PliCbdE18DraftPreview.tsx
@@ -1,0 +1,230 @@
+import {
+  FNP_EXX_MESSAGE_LABELS,
+  NUMBER_TYPE_LABELS,
+  PLI_CBD_EXPORT_STATUS_LABELS,
+  PORTED_NUMBER_KIND_LABELS,
+  PORTING_CASE_STATUS_LABELS,
+  PORTING_MODE_LABELS,
+} from '@np-manager/shared'
+import type { PliCbdE18DraftBuildResultDto } from '@np-manager/shared'
+
+interface PliCbdE18DraftPreviewProps {
+  result: PliCbdE18DraftBuildResultDto | null
+  isLoading: boolean
+}
+
+function Field({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: string | null | undefined
+  mono?: boolean
+}) {
+  return (
+    <div>
+      <dt className="text-xs text-gray-500 mb-0.5">{label}</dt>
+      <dd className={`text-sm text-gray-900 ${mono ? 'font-mono' : ''}`}>
+        {value ?? <span className="text-gray-400">-</span>}
+      </dd>
+    </div>
+  )
+}
+
+export function PliCbdE18DraftPreview({ result, isLoading }: PliCbdE18DraftPreviewProps) {
+  return (
+    <div className="card p-5 space-y-4">
+      <div>
+        <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide mb-1">
+          Draft E18
+        </h2>
+        <p className="text-sm text-gray-500">
+          Read-only preview danych, ktore weszlyby do komunikatu E18 dla PLI CBD.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+          Ladowanie draftu E18...
+        </div>
+      ) : !result ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-sm text-gray-500">
+          Nie udalo sie zaladowac draftu E18.
+        </div>
+      ) : (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <span
+              className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                result.isReady ? 'bg-green-100 text-green-700' : 'bg-amber-100 text-amber-700'
+              }`}
+            >
+              {result.isReady ? 'Gotowe do zbudowania E18' : 'Draft E18 zablokowany'}
+            </span>
+            <span className="text-xs text-gray-500">Sprawa: {result.caseNumber}</span>
+          </div>
+
+          {result.blockingReasons.length > 0 && (
+            <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-amber-800">
+                Blokady draftu
+              </p>
+              <ul className="space-y-1">
+                {result.blockingReasons.map((reason) => (
+                  <li key={reason.code} className="text-sm text-amber-900">
+                    {reason.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {!result.draft ? (
+            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-4 text-sm text-gray-600">
+              Draft E18 nie zostal wygenerowany dla tej sprawy.
+            </div>
+          ) : (
+            <>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-4">
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field label="Typ komunikatu" value={result.draft.messageType} mono />
+                  <Field label="Serwis" value={result.draft.serviceType} mono />
+                  <Field label="Kartoteka klienta" value={result.draft.clientDisplayName} />
+                  <Field label="Abonent w sprawie" value={result.draft.subscriberDisplayName} />
+                  <Field label="ID sprawy portowania" value={result.draft.requestId} mono />
+                  <Field label="Numer sprawy" value={result.draft.caseNumber} mono />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4">
+                <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                  Numeracja i operatorzy
+                </p>
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field label="Typ uslugi" value={NUMBER_TYPE_LABELS[result.draft.numberType]} />
+                  <Field
+                    label="Typ numeracji"
+                    value={PORTED_NUMBER_KIND_LABELS[result.draft.numberRangeKind]}
+                  />
+                  <Field label="Numer / zakres" value={result.draft.numberDisplay} mono />
+                  <Field
+                    label="Tryb przeniesienia"
+                    value={PORTING_MODE_LABELS[result.draft.portingMode]}
+                  />
+                  <Field label="Operator oddajacy" value={result.draft.donorOperator.name} />
+                  <Field
+                    label="Routing dawcy"
+                    value={result.draft.donorOperator.routingNumber}
+                    mono
+                  />
+                  <Field label="Operator bioracy" value={result.draft.recipientOperator.name} />
+                  <Field
+                    label="Routing biorcy"
+                    value={result.draft.recipientOperator.routingNumber}
+                    mono
+                  />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4">
+                <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                  Kontekst zakonczenia
+                </p>
+                <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                  <Field
+                    label="Etap procesu"
+                    value={result.draft.completionContext.currentStageLabel}
+                  />
+                  <Field
+                    label="Status wewnetrzny"
+                    value={
+                      PORTING_CASE_STATUS_LABELS[result.draft.completionContext.statusInternal] ??
+                      result.draft.completionContext.statusInternalLabel
+                    }
+                  />
+                  <Field
+                    label="Status eksportu"
+                    value={
+                      PLI_CBD_EXPORT_STATUS_LABELS[result.draft.completionContext.exportStatus]
+                    }
+                  />
+                  <Field
+                    label="Ostatni komunikat Exx"
+                    value={
+                      result.draft.completionContext.lastReceivedMessageType
+                        ? FNP_EXX_MESSAGE_LABELS[
+                            result.draft.completionContext.lastReceivedMessageType
+                          ]
+                        : 'Brak'
+                    }
+                  />
+                  <Field
+                    label="Potwierdzona data przeniesienia"
+                    value={result.draft.completionContext.confirmedPortDate}
+                    mono
+                  />
+                  <Field
+                    label="Data od Dawcy"
+                    value={result.draft.completionContext.donorAssignedPortDate}
+                    mono
+                  />
+                  <Field
+                    label="Godzina od Dawcy"
+                    value={result.draft.completionContext.donorAssignedPortTime}
+                    mono
+                  />
+                </dl>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-white p-4 space-y-4">
+                <div>
+                  <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                    Podpowiedzi domenowe
+                  </p>
+                  <ul className="space-y-2">
+                    {result.draft.reasonHints.map((hint) => (
+                      <li key={hint} className="text-sm text-gray-700">
+                        {hint}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div>
+                  <p className="text-xs font-medium text-gray-600 uppercase tracking-wide mb-3">
+                    Wskazowki techniczne
+                  </p>
+                  <dl className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <Field
+                      label="Zrodlo danych"
+                      value={
+                        result.draft.technicalHints.dataSource ===
+                        'CURRENT_CASE_AND_PROCESS_SNAPSHOT'
+                          ? 'Aktualna sprawa i aktualny snapshot procesu'
+                          : result.draft.technicalHints.dataSource
+                      }
+                    />
+                    <Field
+                      label="Zrodlo wyboru numeracji"
+                      value={
+                        result.draft.technicalHints.numberSelectionSource === 'NUMBER_RANGE'
+                          ? 'Zakres numerow'
+                          : 'Numer podstawowy'
+                      }
+                    />
+                    <Field
+                      label="Dozwolone komunikaty na etapie"
+                      value={result.draft.technicalHints.allowedMessagesAtStage.join(', ')}
+                      mono
+                    />
+                  </dl>
+                </div>
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -7,6 +7,7 @@ import {
   exportPortingRequest,
   getPortingRequestById,
   getPortingRequestE03Draft,
+  getPortingRequestE18Draft,
   getPortingRequestIntegrationEvents,
   getPortingRequestProcessSnapshot,
   getPortingRequestTimeline,
@@ -26,6 +27,7 @@ import {
 } from '@np-manager/shared'
 import type {
   PliCbdE03DraftBuildResultDto,
+  PliCbdE18DraftBuildResultDto,
   PliCbdIntegrationEventDto,
   PliCbdProcessSnapshotDto,
   PortingCaseStatus,
@@ -37,6 +39,7 @@ import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
 import { PliCbdIntegrationHistory } from '@/components/PliCbdIntegrationHistory/PliCbdIntegrationHistory'
 import { PliCbdProcessSnapshot } from '@/components/PliCbdProcessSnapshot/PliCbdProcessSnapshot'
 import { PliCbdE03DraftPreview } from '@/components/PliCbdE03DraftPreview/PliCbdE03DraftPreview'
+import { PliCbdE18DraftPreview } from '@/components/PliCbdE18DraftPreview/PliCbdE18DraftPreview'
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -106,6 +109,9 @@ export function RequestDetailPage() {
   const [e03DraftResult, setE03DraftResult] =
     useState<PliCbdE03DraftBuildResultDto | null>(null)
   const [isE03DraftLoading, setIsE03DraftLoading] = useState(true)
+  const [e18DraftResult, setE18DraftResult] =
+    useState<PliCbdE18DraftBuildResultDto | null>(null)
+  const [isE18DraftLoading, setIsE18DraftLoading] = useState(true)
 
   const canManageStatus = useMemo(
     () =>
@@ -164,6 +170,24 @@ export function RequestDetailPage() {
     }
   }, [id])
 
+  const loadE18Draft = useCallback(async () => {
+    if (!id) return
+    setIsE18DraftLoading(true)
+    try {
+      const result = await getPortingRequestE18Draft(id)
+      setE18DraftResult(result)
+    } catch {
+      setE18DraftResult(null)
+    } finally {
+      setIsE18DraftLoading(false)
+    }
+  }, [id])
+
+  const refreshDraftPreviews = useCallback(() => {
+    void loadE03Draft()
+    void loadE18Draft()
+  }, [loadE03Draft, loadE18Draft])
+
   const loadIntegrationEvents = useCallback(async () => {
     if (!id || !canTriggerPliCbdActions) {
       setIntegrationEvents([])
@@ -202,8 +226,8 @@ export function RequestDetailPage() {
     void loadTimeline()
     void loadIntegrationEvents()
     void loadProcessSnapshot()
-    void loadE03Draft()
-  }, [id, loadE03Draft, loadIntegrationEvents, loadProcessSnapshot, loadTimeline])
+    refreshDraftPreviews()
+  }, [id, loadIntegrationEvents, loadProcessSnapshot, loadTimeline, refreshDraftPreviews])
 
   const formatDateTime = (iso: string) =>
     new Date(iso).toLocaleString('pl-PL', {
@@ -224,12 +248,12 @@ export function RequestDetailPage() {
       void loadTimeline()
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionSuccess('Eksport do PLI CBD zostal wyzwolony pomyslnie.')
     } catch {
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionError('Nie udalo sie uruchomic foundation eksportu do PLI CBD.')
     } finally {
       setIsExporting(false)
@@ -246,12 +270,12 @@ export function RequestDetailPage() {
       void loadTimeline()
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionSuccess('Synchronizacja z PLI CBD zakonczona pomyslnie.')
     } catch {
       void loadIntegrationEvents()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setActionError('Nie udalo sie uruchomic foundation synchronizacji z PLI CBD.')
     } finally {
       setIsSyncing(false)
@@ -294,7 +318,7 @@ export function RequestDetailPage() {
       setRequest(updatedRequest)
       void loadTimeline()
       void loadProcessSnapshot()
-      void loadE03Draft()
+      refreshDraftPreviews()
       setStatusActionSuccess('Status sprawy został zmieniony.')
     } catch (err) {
       if (axios.isAxiosError(err)) {
@@ -559,6 +583,11 @@ export function RequestDetailPage() {
       <PliCbdE03DraftPreview
         result={e03DraftResult}
         isLoading={isE03DraftLoading}
+      />
+
+      <PliCbdE18DraftPreview
+        result={e18DraftResult}
+        isLoading={isE18DraftLoading}
       />
 
       {canTriggerPliCbdActions && (

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -2,6 +2,7 @@ import { apiClient } from './api.client'
 import type {
   CreatePortingRequestDto,
   PliCbdE03DraftBuildResultDto,
+  PliCbdE18DraftBuildResultDto,
   PliCbdIntegrationEventsResultDto,
   PliCbdProcessSnapshotDto,
   PortingRequestDetailDto,
@@ -112,6 +113,17 @@ export async function getPortingRequestE03Draft(
     success: true
     data: PliCbdE03DraftBuildResultDto
   }>(`/porting-requests/${id}/pli-cbd-drafts/e03`)
+
+  return response.data.data
+}
+
+export async function getPortingRequestE18Draft(
+  id: string,
+): Promise<PliCbdE18DraftBuildResultDto> {
+  const response = await apiClient.get<{
+    success: true
+    data: PliCbdE18DraftBuildResultDto
+  }>(`/porting-requests/${id}/pli-cbd-drafts/e18`)
 
   return response.data.data
 }

--- a/packages/shared/src/dto/pli-cbd-drafts.dto.ts
+++ b/packages/shared/src/dto/pli-cbd-drafts.dto.ts
@@ -1,8 +1,12 @@
 import type {
   ClientType,
   ContactChannel,
+  FnpExxMessage,
+  FnpProcessStage,
   NumberType,
+  PliCbdExportStatus,
   PortedNumberKind,
+  PortingCaseStatus,
   PortingMode,
   SubscriberIdentityType,
 } from '../constants'
@@ -66,3 +70,39 @@ export interface PliCbdE03DraftDto {
 
 export interface PliCbdE03DraftBuildResultDto
   extends PliCbdDraftBuildResultDto<PliCbdE03DraftDto> {}
+
+export interface PliCbdE18DraftDto {
+  messageType: 'E18'
+  serviceType: 'FNP'
+  requestId: string
+  caseNumber: string
+  clientId: string
+  clientDisplayName: string
+  subscriberDisplayName: string
+  donorOperator: PliCbdDraftOperatorDto
+  recipientOperator: PliCbdDraftOperatorDto
+  portingMode: PortingMode
+  numberType: NumberType
+  numberRangeKind: PortedNumberKind
+  numberDisplay: string
+  completionContext: {
+    currentStage: FnpProcessStage
+    currentStageLabel: string
+    statusInternal: PortingCaseStatus
+    statusInternalLabel: string
+    exportStatus: PliCbdExportStatus
+    lastReceivedMessageType: FnpExxMessage | null
+    confirmedPortDate: string | null
+    donorAssignedPortDate: string | null
+    donorAssignedPortTime: string | null
+  }
+  reasonHints: string[]
+  technicalHints: {
+    dataSource: 'CURRENT_CASE_AND_PROCESS_SNAPSHOT'
+    numberSelectionSource: 'PRIMARY_NUMBER' | 'NUMBER_RANGE'
+    allowedMessagesAtStage: FnpExxMessage[]
+  }
+}
+
+export interface PliCbdE18DraftBuildResultDto
+  extends PliCbdDraftBuildResultDto<PliCbdE18DraftDto> {}


### PR DESCRIPTION
## Cel

Dodanie domenowego draftu komunikatu E18 dla FNP.

## Zakres

- dodanie shared DTO dla draftu E18 i wyniku budowy draftu
- dodanie backendowego buildera draftu E18 z reużyciem istniejącej logiki procesu FNP / PLI CBD
- dodanie read-only endpointu `GET /api/porting-requests/:id/pli-cbd-drafts/e18`
- dodanie lekkiego preview „Draft E18” na detail page sprawy portowania
- odświeżanie preview draftu po akcjach wpływających na stan procesu
- dodanie seeda `FNP-SEED-E18-001` dla happy path oraz doprecyzowanie terminalnego seeda po E18
- dodanie minimalnego testu domenowego dla happy path E18

## Założenia

- brak XML / SOAP / HTTPS / FTPS
- brak realnej wysyłki do PLI CBD
- draft odzwierciedla aktualny stan sprawy i etapu procesu

## Efekt

- operator widzi, czy sprawa jest gotowa do zbudowania E18
- jeśli nie jest gotowa, dostaje jasne blokady
- jeśli jest gotowa, widzi pełny podgląd danych, które weszłyby do komunikatu E18
- repo jest przygotowane pod kolejny krok: techniczne mapowanie draftu E18 do formatu integracyjnego

## Walidacja

- `npm run test -w apps/backend -- src/modules/pli-cbd/__tests__/fnp-process.domain.test.ts`
- `npm run build -w packages/shared`
- `npm run build -w apps/backend`
- `npm run build -w apps/frontend`
- `npm run db:seed`
- sanity check API:
  - `FNP-SEED-ACTIVE-001` -> `isReady=false`, blokada `E18_NOT_ALLOWED_AT_CURRENT_STAGE`, `draft=null`
  - `FNP-SEED-E18-001` -> `isReady=true`, pełny draft E18 obecny
- frontend dev server uruchamia się poprawnie na `http://localhost:5173`
- backend health check przechodzi na `http://localhost:3001/health`

## Uwagi

- etap `READY_TO_PORT` pozostaje dostępny także dla `statusInternal=PORTED` do momentu wysłania E18; po `lastExxReceived=E18` proces przechodzi do stanu terminalnego `COMPLETED`