### PR TITLE
feat(pr12c): add assignment-users endpoint and enable BOK reassignment

### DIFF
--- a/apps/backend/src/__tests__/app.porting-assignment.routes.test.ts
+++ b/apps/backend/src/__tests__/app.porting-assignment.routes.test.ts
@@ -12,6 +12,7 @@ const {
   mockUpdatePortingRequestAssignment,
   mockAssignPortingRequestToMe,
   mockGetPortingRequestAssignmentHistory,
+  mockListAssignablePortingRequestUsers,
 } = vi.hoisted(() => ({
   mockListPortingRequests: vi.fn(),
   mockGetPortingRequest: vi.fn(),
@@ -24,6 +25,7 @@ const {
   mockUpdatePortingRequestAssignment: vi.fn(),
   mockAssignPortingRequestToMe: vi.fn(),
   mockGetPortingRequestAssignmentHistory: vi.fn(),
+  mockListAssignablePortingRequestUsers: vi.fn(),
 }))
 
 vi.mock('../modules/auth/auth.router', () => ({ authRouter: async () => {} }))
@@ -46,6 +48,8 @@ vi.mock('../modules/porting-requests/porting-requests.service', () => ({
     mockGetPortingRequestIntegrationEvents(...args),
   getPortingRequest: (...args: unknown[]) => mockGetPortingRequest(...args),
   listPortingRequests: (...args: unknown[]) => mockListPortingRequests(...args),
+  listAssignablePortingRequestUsers: (...args: unknown[]) =>
+    mockListAssignablePortingRequestUsers(...args),
   syncPortingRequestFromPliCbd: (...args: unknown[]) => mockSyncPortingRequestFromPliCbd(...args),
   updatePortingRequestStatus: (...args: unknown[]) => mockUpdatePortingRequestStatus(...args),
   updatePortingRequestAssignment: (...args: unknown[]) => mockUpdatePortingRequestAssignment(...args),
@@ -166,6 +170,11 @@ describe('porting request assignment routes', () => {
         },
       ],
     })
+    mockListAssignablePortingRequestUsers.mockResolvedValue({
+      users: [
+        { id: 'user-2', email: 'anna.nowak@np-manager.local', firstName: 'Anna', lastName: 'Nowak', role: 'BOK_CONSULTANT' },
+      ],
+    })
   })
 
   it('PATCH /api/porting-requests/:id/assignment requires auth', async () => {
@@ -270,6 +279,60 @@ describe('porting request assignment routes', () => {
 
       expect(response.statusCode).toBe(200)
       expect(mockGetPortingRequestAssignmentHistory).toHaveBeenCalledWith('request-1')
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('GET /api/porting-requests/assignment-users requires auth', async () => {
+    const app = await buildApp()
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/porting-requests/assignment-users',
+      })
+
+      expect(response.statusCode).toBe(401)
+      expect(mockListAssignablePortingRequestUsers).not.toHaveBeenCalled()
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('GET /api/porting-requests/assignment-users returns 403 for roles without assignment permissions', async () => {
+    const app = await buildApp()
+
+    try {
+      const token = app.jwt.sign({ id: 'backoffice-1', role: 'BACK_OFFICE' })
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/porting-requests/assignment-users',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(403)
+      expect(mockListAssignablePortingRequestUsers).not.toHaveBeenCalled()
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('GET /api/porting-requests/assignment-users is accessible for BOK_CONSULTANT', async () => {
+    const app = await buildApp()
+
+    try {
+      const token = app.jwt.sign({ id: 'bok-1', role: 'BOK_CONSULTANT' })
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/porting-requests/assignment-users',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(mockListAssignablePortingRequestUsers).toHaveBeenCalledOnce()
+      const body = response.json<{ success: true; data: { users: unknown[] } }>()
+      expect(body.data.users).toHaveLength(1)
     } finally {
       await app.close()
     }

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -19,6 +19,7 @@ import {
   getPortingRequestAssignmentHistory,
   getPortingRequestIntegrationEvents,
   getPortingRequest,
+  listAssignablePortingRequestUsers,
   listPortingRequests,
   syncPortingRequestFromPliCbd,
   updatePortingRequestAssignment,
@@ -73,6 +74,15 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
     const result = await listPortingRequests(query)
     return reply.status(200).send({ success: true, data: result })
   })
+
+  app.get(
+    '/assignment-users',
+    { preHandler: [authenticate, authorize(assignmentWriteRoles)] },
+    async (_request, reply) => {
+      const result = await listAssignablePortingRequestUsers()
+      return reply.status(200).send({ success: true, data: result })
+    },
+  )
 
   app.get<{ Params: { id: string } }>(
     '/:id/case-history',

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -9,6 +9,7 @@ import type {
   PortingRequestAssigneeSummaryDto,
   PortingRequestAssignmentHistoryItemDto,
   PortingRequestAssignmentHistoryResultDto,
+  PortingRequestAssignmentUsersResultDto,
   PortingCommunicationDto,
   PortingRequestDetailDto,
   PliCbdIntegrationEventsResultDto,
@@ -1006,6 +1007,30 @@ export async function getPortingRequestAssignmentHistory(
 
   return {
     items: rows.map(toAssignmentHistoryItem),
+  }
+}
+
+export async function listAssignablePortingRequestUsers(): Promise<PortingRequestAssignmentUsersResultDto> {
+  const rows = await prisma.user.findMany({
+    where: { isActive: true },
+    select: {
+      id: true,
+      email: true,
+      firstName: true,
+      lastName: true,
+      role: true,
+    },
+    orderBy: [{ lastName: 'asc' }, { firstName: 'asc' }, { email: 'asc' }],
+  })
+
+  return {
+    users: rows.map((row) => ({
+      id: row.id,
+      email: row.email,
+      firstName: row.firstName,
+      lastName: row.lastName,
+      role: row.role as UserRole,
+    })),
   }
 }
 

--- a/apps/frontend/src/lib/portingOwnership.test.ts
+++ b/apps/frontend/src/lib/portingOwnership.test.ts
@@ -118,6 +118,7 @@ describe('portingOwnership helpers', () => {
     expect(canManagePortingOwnership('BOK_CONSULTANT')).toBe(true)
     expect(canManagePortingOwnership('MANAGER')).toBe(false)
     expect(canSelectAnyAssignee('ADMIN')).toBe(true)
-    expect(canSelectAnyAssignee('BOK_CONSULTANT')).toBe(false)
+    expect(canSelectAnyAssignee('BOK_CONSULTANT')).toBe(true)
+    expect(canSelectAnyAssignee('MANAGER')).toBe(false)
   })
 })

--- a/apps/frontend/src/lib/portingOwnership.ts
+++ b/apps/frontend/src/lib/portingOwnership.ts
@@ -48,7 +48,7 @@ export function canManagePortingOwnership(role: UserRole | null | undefined): bo
 }
 
 export function canSelectAnyAssignee(role: UserRole | null | undefined): boolean {
-  return role === 'ADMIN'
+  return role === 'ADMIN' || role === 'BOK_CONSULTANT'
 }
 
 export function formatAssignmentHistoryHeadline(

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -20,6 +20,7 @@ import {
   getPortingRequestIntegrationEvents,
   getPortingRequestProcessSnapshot,
   getPortingRequestTechnicalPayload,
+  getPortingRequestAssignmentUsers,
   getPortingRequestXmlPreview,
   markPortingCommunicationAsSent,
   previewPortingCommunicationDraft,
@@ -31,9 +32,7 @@ import {
   updatePortingRequestAssignment,
   updatePortingRequestStatus,
 } from '@/services/portingRequests.api'
-import { getAdminUsers } from '@/services/adminUsers.api'
 import {
-  type AdminUserListItemDto,
   CONTACT_CHANNEL_LABELS,
   NUMBER_TYPE_LABELS,
   PLI_CBD_EXPORT_STATUS_LABELS,
@@ -54,6 +53,7 @@ import {
   type PortingCommunicationDto,
   type PortingCommunicationPreviewDto,
   type PortingCommunicationSummaryDto,
+  type PortingRequestAssignmentUserOptionDto,
   type PortingRequestCaseHistoryItemDto,
   type PortingRequestCommunicationActionType,
   type PortingRequestDetailDto,
@@ -327,7 +327,7 @@ export function RequestDetailPage() {
   const [assignmentFeedbackError, setAssignmentFeedbackError] = useState<string | null>(null)
   const [assignmentFeedbackSuccess, setAssignmentFeedbackSuccess] = useState<string | null>(null)
   const [assigneeDraft, setAssigneeDraft] = useState('')
-  const [assignableUsers, setAssignableUsers] = useState<AdminUserListItemDto[]>([])
+  const [assignableUsers, setAssignableUsers] = useState<PortingRequestAssignmentUserOptionDto[]>([])
   const [isAssignableUsersLoading, setIsAssignableUsersLoading] = useState(false)
   const [isAssigningToMe, setIsAssigningToMe] = useState(false)
   const [isUpdatingAssignment, setIsUpdatingAssignment] = useState(false)
@@ -565,8 +565,8 @@ export function RequestDetailPage() {
     setIsAssignableUsersLoading(true)
 
     try {
-      const result = await getAdminUsers({ isActive: true })
-      setAssignableUsers(result.users.filter((candidate) => candidate.isActive))
+      const result = await getPortingRequestAssignmentUsers()
+      setAssignableUsers(result.users)
     } catch {
       setAssignableUsers([])
     } finally {

--- a/apps/frontend/src/services/portingRequests.api.test.ts
+++ b/apps/frontend/src/services/portingRequests.api.test.ts
@@ -17,6 +17,7 @@ vi.mock('./api.client', () => ({
 import {
   assignPortingRequestToMe,
   getPortingRequestAssignmentHistory,
+  getPortingRequestAssignmentUsers,
   getPortingRequests,
   updatePortingRequestAssignment,
 } from './portingRequests.api'
@@ -67,5 +68,23 @@ describe('portingRequests.api assignment flow', () => {
     await getPortingRequestAssignmentHistory('request-1')
 
     expect(getMock).toHaveBeenCalledWith('/porting-requests/request-1/assignment-history')
+  })
+
+  it('calls assignment-users endpoint and returns user list', async () => {
+    getMock.mockResolvedValueOnce({
+      data: {
+        data: {
+          users: [
+            { id: 'user-1', email: 'user@np-manager.local', firstName: 'Jan', lastName: 'Kowalski', role: 'BOK_CONSULTANT' },
+          ],
+        },
+      },
+    })
+
+    const result = await getPortingRequestAssignmentUsers()
+
+    expect(getMock).toHaveBeenCalledWith('/porting-requests/assignment-users')
+    expect(result.users).toHaveLength(1)
+    expect(result.users[0]?.id).toBe('user-1')
   })
 })

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -17,6 +17,7 @@ import type {
   PliCbdManualExportResultDto,
   PliCbdProcessSnapshotDto,
   PortingRequestAssignmentHistoryResultDto,
+  PortingRequestAssignmentUsersResultDto,
   PortingRequestCaseHistoryResultDto,
   PortingRequestDetailDto,
   PortingRequestListQueryDto,
@@ -117,6 +118,15 @@ export async function getPortingRequestAssignmentHistory(
     success: true
     data: PortingRequestAssignmentHistoryResultDto
   }>(`/porting-requests/${id}/assignment-history`)
+
+  return response.data.data
+}
+
+export async function getPortingRequestAssignmentUsers(): Promise<PortingRequestAssignmentUsersResultDto> {
+  const response = await apiClient.get<{
+    success: true
+    data: PortingRequestAssignmentUsersResultDto
+  }>('/porting-requests/assignment-users')
 
   return response.data.data
 }

--- a/packages/shared/src/dto/porting-requests.dto.ts
+++ b/packages/shared/src/dto/porting-requests.dto.ts
@@ -223,3 +223,19 @@ export interface PortingRequestAssignmentHistoryItemDto {
 export interface PortingRequestAssignmentHistoryResultDto {
   items: PortingRequestAssignmentHistoryItemDto[]
 }
+
+// ============================================================
+// ASSIGNMENT USERS (lightweight list for reassignment UI)
+// ============================================================
+
+export interface PortingRequestAssignmentUserOptionDto {
+  id: string
+  email: string
+  firstName: string
+  lastName: string
+  role: UserRole
+}
+
+export interface PortingRequestAssignmentUsersResultDto {
+  users: PortingRequestAssignmentUserOptionDto[]
+}


### PR DESCRIPTION
## Cel

Domkniecie PR12C dla ownership / assignment, tak aby `BOK_CONSULTANT` mogl nie tylko przypisac sprawe do siebie, ale tez wybrac innego aktywnego uzytkownika z listy bez korzystania z adminowego API.

## Zakres

- dodanie lekkiego DTO `PortingRequestAssignmentUserOptionDto` oraz `PortingRequestAssignmentUsersResultDto`
- dodanie backendowej funkcji `listAssignablePortingRequestUsers()` zwracajacej aktywnych uzytkownikow, sortowanych po `lastName` / `firstName` / `email`
- dodanie endpointu `GET /api/porting-requests/assignment-users` z dostepem dla `ADMIN` i `BOK_CONSULTANT`
- przelaczenie `RequestDetailPage` z `getAdminUsers()` na nowe assignment API
- rozszerzenie `canSelectAnyAssignee()` o role `BOK_CONSULTANT`
- dodanie testow route / API / helperow RBAC

## Efekt

- frontend i backend assignmentu sa semantycznie spojne
- `BOK_CONSULTANT` moze wykonac reassignment end-to-end z detail page
- assignment flow nie zalezy juz od adminowego endpointu users
- role read-only pozostaja tylko w trybie podgladu

## Testy

- backend route tests dla `GET /api/porting-requests/assignment-users`:
  - 401 bez auth
  - 403 dla `BACK_OFFICE`
  - 200 dla `BOK_CONSULTANT`
- frontend:
  - `canSelectAnyAssignee('BOK_CONSULTANT') === true`
  - test klienta API dla `getPortingRequestAssignmentUsers()`

## Uwagi

Brak migracji DB. Zmiana korzysta z istniejacych danych users (`isActive`) i domyka niespojnosc: backend juz dopuszczal PATCH assignment dla BOK, ale frontend nie mial wlasciwego zrodla danych do wyboru innej osoby.