### PR TITLE
feat(pr12d): move ownership filter to backend — correct pagination an…

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockPortingRequestFindMany,
+  mockPortingRequestCount,
+  mockPrismaTransaction,
+} = vi.hoisted(() => ({
+  mockPortingRequestFindMany: vi.fn(),
+  mockPortingRequestCount: vi.fn(),
+  mockPrismaTransaction: vi.fn(),
+}))
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    portingRequest: {
+      findMany: (...args: unknown[]) => mockPortingRequestFindMany(...args),
+      count: (...args: unknown[]) => mockPortingRequestCount(...args),
+    },
+    $transaction: (fns: Array<() => unknown>) => mockPrismaTransaction(fns),
+  },
+}))
+
+import { listPortingRequests } from '../porting-requests.service'
+
+function makeListRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'request-1',
+    caseNumber: 'FNP-20260409-ABC123',
+    primaryNumber: '221234567',
+    rangeStart: null,
+    rangeEnd: null,
+    numberRangeKind: 'SINGLE',
+    portingMode: 'DAY',
+    statusInternal: 'SUBMITTED',
+    createdAt: new Date('2026-04-09T10:00:00.000Z'),
+    clientId: 'client-1',
+    client: {
+      id: 'client-1',
+      clientType: 'INDIVIDUAL',
+      firstName: 'Jan',
+      lastName: 'Kowalski',
+      companyName: null,
+      email: 'jan.kowalski@example.com',
+      addressStreet: 'Testowa 1',
+      addressCity: 'Warszawa',
+      addressZip: '00-001',
+    },
+    donorOperatorId: 'operator-1',
+    donorOperator: { id: 'operator-1', name: 'Orange Polska' },
+    assignedUser: null,
+    ...overrides,
+  }
+}
+
+const CURRENT_USER_ID = 'auth-user-1'
+
+describe('listPortingRequests — ownership filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // $transaction receives an array of Promises and resolves them
+    mockPrismaTransaction.mockImplementation(async (arg: unknown) => {
+      if (Array.isArray(arg)) return Promise.all(arg)
+      return undefined
+    })
+
+    mockPortingRequestCount.mockResolvedValue(0)
+    mockPortingRequestFindMany.mockResolvedValue([])
+  })
+
+  it('ALL — no assignedUserId constraint in where clause', async () => {
+    mockPortingRequestCount.mockResolvedValue(1)
+    mockPortingRequestFindMany.mockResolvedValue([makeListRow()])
+
+    await listPortingRequests(
+      { ownership: 'ALL', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    const countCall = mockPortingRequestCount.mock.calls[0]?.[0] as { where: Record<string, unknown> }
+    expect(countCall.where).not.toHaveProperty('assignedUserId')
+  })
+
+  it('MINE — filters by authenticated user id from server, not from client input', async () => {
+    const assignedRow = makeListRow({
+      assignedUser: {
+        id: CURRENT_USER_ID,
+        email: 'auth-user@np-manager.local',
+        firstName: 'Auth',
+        lastName: 'User',
+        role: 'BOK_CONSULTANT',
+        isActive: true,
+      },
+    })
+
+    mockPortingRequestCount.mockResolvedValue(1)
+    mockPortingRequestFindMany.mockResolvedValue([assignedRow])
+
+    const result = await listPortingRequests(
+      { ownership: 'MINE', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    // Verify Prisma was called with assignedUserId === authenticated user id
+    const countCall = mockPortingRequestCount.mock.calls[0]?.[0] as { where: Record<string, unknown> }
+    expect(countCall.where).toMatchObject({ assignedUserId: CURRENT_USER_ID })
+
+    const findManyCall = mockPortingRequestFindMany.mock.calls[0]?.[0] as { where: Record<string, unknown> }
+    expect(findManyCall.where).toMatchObject({ assignedUserId: CURRENT_USER_ID })
+
+    // Result contains the assigned item
+    expect(result.items).toHaveLength(1)
+    expect(result.pagination.total).toBe(1)
+  })
+
+  it('MINE — total and pagination reflect only assigned records', async () => {
+    mockPortingRequestCount.mockResolvedValue(3)
+    mockPortingRequestFindMany.mockResolvedValue([
+      makeListRow({ id: 'r-1' }),
+      makeListRow({ id: 'r-2' }),
+      makeListRow({ id: 'r-3' }),
+    ])
+
+    const result = await listPortingRequests(
+      { ownership: 'MINE', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    expect(result.pagination.total).toBe(3)
+    expect(result.pagination.totalPages).toBe(1)
+    expect(result.items).toHaveLength(3)
+  })
+
+  it('UNASSIGNED — filters to assignedUserId === null', async () => {
+    mockPortingRequestCount.mockResolvedValue(2)
+    mockPortingRequestFindMany.mockResolvedValue([
+      makeListRow({ id: 'r-1' }),
+      makeListRow({ id: 'r-2' }),
+    ])
+
+    await listPortingRequests(
+      { ownership: 'UNASSIGNED', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    const countCall = mockPortingRequestCount.mock.calls[0]?.[0] as { where: Record<string, unknown> }
+    expect(countCall.where).toMatchObject({ assignedUserId: null })
+
+    const findManyCall = mockPortingRequestFindMany.mock.calls[0]?.[0] as { where: Record<string, unknown> }
+    expect(findManyCall.where).toMatchObject({ assignedUserId: null })
+  })
+
+  it('UNASSIGNED — returns correct pagination total', async () => {
+    mockPortingRequestCount.mockResolvedValue(5)
+    mockPortingRequestFindMany.mockResolvedValue(Array.from({ length: 5 }, (_, i) =>
+      makeListRow({ id: `r-${i + 1}` }),
+    ))
+
+    const result = await listPortingRequests(
+      { ownership: 'UNASSIGNED', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    expect(result.pagination.total).toBe(5)
+    expect(result.items).toHaveLength(5)
+  })
+
+  it('ownership filter is applied before count() — count reflects filtered set, not all records', async () => {
+    // This test ensures ownership where clause is present in the count call,
+    // confirming that backend-side pagination is based on filtered data.
+    mockPortingRequestCount.mockResolvedValue(1)
+    mockPortingRequestFindMany.mockResolvedValue([makeListRow()])
+
+    await listPortingRequests(
+      { ownership: 'MINE', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    // Both count and findMany must receive the same where with assignedUserId
+    const countWhere = (mockPortingRequestCount.mock.calls[0]?.[0] as { where: Record<string, unknown> }).where
+    const findManyWhere = (mockPortingRequestFindMany.mock.calls[0]?.[0] as { where: Record<string, unknown> }).where
+
+    expect(countWhere).toMatchObject({ assignedUserId: CURRENT_USER_ID })
+    expect(findManyWhere).toMatchObject({ assignedUserId: CURRENT_USER_ID })
+  })
+})

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -71,7 +71,7 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
 
   app.get('/', { preHandler: [authenticate, authorize(readRoles)] }, async (request, reply) => {
     const query = portingRequestListQuerySchema.parse(request.query)
-    const result = await listPortingRequests(query)
+    const result = await listPortingRequests(query, request.user.id)
     return reply.status(200).send({ success: true, data: result })
   })
 

--- a/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
@@ -348,6 +348,7 @@ export const portingRequestListQuerySchema = z.object({
   status: statusEnum.optional(),
   portingMode: z.enum(['DAY', 'END', 'EOP']).optional(),
   donorOperatorId: z.string().uuid().optional(),
+  ownership: z.enum(['ALL', 'MINE', 'UNASSIGNED']).optional().default('ALL'),
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(100).default(20),
 })

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -834,6 +834,7 @@ export async function createPortingRequest(
 
 export async function listPortingRequests(
   query: PortingRequestListQuery,
+  currentUserId: string,
 ): Promise<PortingRequestListResultDto> {
   const where: Prisma.PortingRequestWhereInput = {}
 
@@ -847,6 +848,12 @@ export async function listPortingRequests(
 
   if (query.donorOperatorId) {
     where.donorOperatorId = query.donorOperatorId
+  }
+
+  if (query.ownership === 'MINE') {
+    where.assignedUserId = currentUserId
+  } else if (query.ownership === 'UNASSIGNED') {
+    where.assignedUserId = null
   }
 
   if (query.search?.trim()) {

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -5,12 +5,10 @@ import { useOperators } from '@/hooks/useOperators'
 import { getPortingRequests } from '@/services/portingRequests.api'
 import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
 import {
-  filterPortingRequestsByOwnership,
   formatAssigneeLabel,
   parseOwnershipFilter,
   type OwnershipFilter,
 } from '@/lib/portingOwnership'
-import { useAuthStore } from '@/stores/auth.store'
 import {
   PORTING_CASE_STATUSES,
   PORTING_MODE_LABELS,
@@ -108,7 +106,6 @@ function RequestRow({
 export function RequestsPage() {
   const navigate = useNavigate()
   const { operators } = useOperators()
-  const { user } = useAuthStore()
   const [searchParams, setSearchParams] = useSearchParams()
 
   // Derive filter state from URL
@@ -192,6 +189,7 @@ export function RequestsPage() {
         status: statusFilter ?? undefined,
         portingMode: portingModeFilter ?? undefined,
         donorOperatorId: donorOperatorId || undefined,
+        ownership: ownershipFilter !== 'ALL' ? ownershipFilter : undefined,
         page,
         pageSize: PAGE_SIZE,
       })
@@ -201,7 +199,7 @@ export function RequestsPage() {
     } finally {
       setIsLoading(false)
     }
-  }, [searchInput, statusFilter, portingModeFilter, donorOperatorId, page])
+  }, [searchInput, statusFilter, portingModeFilter, donorOperatorId, ownershipFilter, page])
 
   useEffect(() => {
     void loadData()
@@ -217,7 +215,6 @@ export function RequestsPage() {
     })
 
   const { items = [], pagination } = result ?? {}
-  const filteredItems = filterPortingRequestsByOwnership(items, ownershipFilter, user?.id)
 
   // ============================================================
   // Render
@@ -390,7 +387,7 @@ export function RequestsPage() {
               Spróbuj ponownie
             </button>
           </div>
-        ) : filteredItems.length === 0 ? (
+        ) : items.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-16 text-gray-400 gap-2">
             <span className="text-3xl">📋</span>
             <p className="text-sm font-medium text-gray-600">Brak spraw portowania</p>
@@ -431,7 +428,7 @@ export function RequestsPage() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
-                {filteredItems.map((request) => (
+                {items.map((request) => (
                   <RequestRow
                     key={request.id}
                     request={request}

--- a/apps/frontend/src/services/portingRequests.api.test.ts
+++ b/apps/frontend/src/services/portingRequests.api.test.ts
@@ -45,6 +45,36 @@ describe('portingRequests.api assignment flow', () => {
     )
   })
 
+  it('includes ownership=MINE in query string when filter is MINE', async () => {
+    await getPortingRequests({ ownership: 'MINE', page: 1, pageSize: 20 })
+
+    expect(getMock).toHaveBeenCalledWith(
+      expect.stringContaining('ownership=MINE'),
+    )
+  })
+
+  it('includes ownership=UNASSIGNED in query string when filter is UNASSIGNED', async () => {
+    await getPortingRequests({ ownership: 'UNASSIGNED', page: 1, pageSize: 20 })
+
+    expect(getMock).toHaveBeenCalledWith(
+      expect.stringContaining('ownership=UNASSIGNED'),
+    )
+  })
+
+  it('omits ownership param when filter is ALL', async () => {
+    await getPortingRequests({ ownership: 'ALL', page: 1, pageSize: 20 })
+
+    const calledUrl = getMock.mock.calls[0]?.[0] as string
+    expect(calledUrl).not.toContain('ownership=')
+  })
+
+  it('omits ownership param when ownership is not provided', async () => {
+    await getPortingRequests({ page: 1, pageSize: 20 })
+
+    const calledUrl = getMock.mock.calls[0]?.[0] as string
+    expect(calledUrl).not.toContain('ownership=')
+  })
+
   it('calls PATCH assignment endpoint with selected user id or null', async () => {
     await updatePortingRequestAssignment('request-1', { assignedUserId: 'user-1' })
     await updatePortingRequestAssignment('request-1', { assignedUserId: null })

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -47,6 +47,7 @@ export async function getPortingRequests(
   if (params.status) query.set('status', params.status)
   if (params.portingMode) query.set('portingMode', params.portingMode)
   if (params.donorOperatorId) query.set('donorOperatorId', params.donorOperatorId)
+  if (params.ownership && params.ownership !== 'ALL') query.set('ownership', params.ownership)
   if (params.page) query.set('page', String(params.page))
   if (params.pageSize) query.set('pageSize', String(params.pageSize))
 

--- a/packages/shared/src/dto/porting-requests.dto.ts
+++ b/packages/shared/src/dto/porting-requests.dto.ts
@@ -23,11 +23,14 @@ import type {
 // QUERY / LISTA
 // ============================================================
 
+export type OwnershipFilter = 'ALL' | 'MINE' | 'UNASSIGNED'
+
 export interface PortingRequestListQueryDto {
   search?: string
   status?: PortingCaseStatus
   portingMode?: PortingMode
   donorOperatorId?: string
+  ownership?: OwnershipFilter
   page?: number
   pageSize?: number
 }


### PR DESCRIPTION
…d total for MINE/UNASSIGNED

- shared DTO: add OwnershipFilter type and ownership? field to PortingRequestListQueryDto
- backend schema: extend portingRequestListQuerySchema with ownership enum (ALL/MINE/UNASSIGNED, default ALL)
- backend router: pass request.user.id to listPortingRequests — MINE always uses authenticated user, never client input
- backend service: apply ownership where clause before count() and findMany() so total and pagination reflect filtered set
- frontend API client: include ownership in query string (omit when ALL)
- RequestsPage: pass ownershipFilter to getPortingRequests, add to loadData deps, remove client-side filterPortingRequestsByOwnership and useAuthStore
- tests (backend): 6 new service tests covering ALL/MINE/UNASSIGNED, where-clause presence in count+findMany, auth-user-id source
- tests (frontend): 4 new API client tests covering ownership query string inclusion/omission