### PR TITLE
feat(pr13a): add commercial owner (SALES role) and internal notificat…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,117 @@
+# AGENTS.md — NP-Manager
+
+Wytyczne dla agentów AI pracujących w tym repozytorium.
+
+---
+
+## Struktura projektu
+
+Monorepo zarządzane przez npm workspaces:
+
+```
+np-manager/
+  apps/
+    backend/     # Fastify + Prisma 5 + PostgreSQL (port 3001)
+    frontend/    # React 18 + Vite + Tailwind CSS (port 5173)
+  packages/
+    shared/      # Wspólne typy DTO i stałe (@np-manager/shared)
+  docs/          # Dokumentacja projektu
+```
+
+---
+
+## Komendy
+
+### Backend
+
+```bash
+cd apps/backend
+npx vitest run              # Uruchom wszystkie testy
+npx tsc --noEmit            # Sprawdź typy TypeScript
+npx prisma generate --no-engine  # Regeneruj klienta Prisma (gdy DLL jest zablokowany)
+npx prisma generate         # Regeneruj klienta Prisma (pełna wersja)
+```
+
+### Frontend
+
+```bash
+cd apps/frontend
+npx vitest run              # Uruchom wszystkie testy
+npx tsc --noEmit            # Sprawdź typy TypeScript
+```
+
+### Shared package
+
+```bash
+# Zmiany w packages/shared są automatycznie widoczne przez workspaces
+# Nie trzeba budować — import bezpośrednio ze źródeł TypeScript
+```
+
+---
+
+## Zasady pracy
+
+### Przed zakończeniem zadania ZAWSZE
+
+1. Uruchom `npx vitest run` w `apps/backend` — wszystkie testy muszą przejść
+2. Uruchom `npx vitest run` w `apps/frontend` — wszystkie testy muszą przejść
+3. Uruchom `npx tsc --noEmit` w obu apps — brak błędów TypeScript
+
+### Testy
+
+- Framework: **Vitest** (nie Jest)
+- Mocki: `vi.hoisted()` + `vi.mock()` na górze pliku — **przed** importami modułów pod testem
+- Prisma mock pattern:
+  ```typescript
+  mockPrismaTransaction.mockImplementation(async (arg: unknown) => {
+    if (Array.isArray(arg)) return Promise.all(arg)  // tablica Promise
+    if (typeof arg === 'function') return arg(tx)    // callback z tx
+  })
+  ```
+- Testy **nie** potrzebują działającej bazy — wszystko przez mocki
+
+### Prisma / baza danych
+
+- Po zmianie `prisma/schema.prisma` → `npx prisma generate`
+- Nowe migracje: utwórz plik SQL w `prisma/migrations/YYYYMMDDHHMMSS_nazwa/migration.sql`
+- Nigdy nie usuwaj istniejących kolumn w migracji — tylko addytywne zmiany
+- `$transaction([p1, p2])` przyjmuje tablicę Promise (nie funkcje)
+
+### Bezpieczeństwo
+
+- Backend nigdy nie ufa danym z frontendu dla operacji wymagających tożsamości  
+  (np. filtr `MINE` używa `request.user.id` z JWT, nie query param)
+- Każda mutacja musi logować przez `logAuditEvent()`
+- DTO w `packages/shared` to kontrakt publiczny — nie zawiera pól wrażliwych (np. `passwordHash`)
+
+### Styl kodu
+
+- TypeScript strict mode (bez `any`)
+- Zod do walidacji body/query w routerach
+- `AppError.notFound()` / `AppError.badRequest(msg, code)` — nigdy `throw new Error()`
+- Polskie komunikaty błędów (system obsługi portowania w Polsce)
+- Powiadomienia: non-blocking dispatch z `.catch(() => {})`
+
+---
+
+## Kontekst biznesowy
+
+NP-Manager to system zarządzania procesem przenoszenia numerów (number portability) w Polsce.
+
+Główne podmioty:
+- **PortingRequest** — sprawa portowania numeru telefonu
+- **User** — pracownik operatora (BOK, BACK_OFFICE, MANAGER, SALES, itp.)
+- **Operator** — operator telefoniczny (donor/recipient)
+- **PLI CBD** — zewnętrzny system regulatora (interfejs XML/SOAP)
+
+Workflow spraw jest kontrolowany przez `availableStatusActions` zwracane przez backend — frontend tylko wyświetla dozwolone akcje.
+
+---
+
+## Ciągłość między sesjami
+
+Stan projektu jest udokumentowany w:
+- `docs/PROJECT_CONTINUITY.md` — szczegółowy opis stanu i decyzji architektonicznych
+- `C:\Users\cicha\.claude\projects\...\memory\MEMORY.md` — zwięzłe podsumowanie dla Claude
+
+Po każdym PR aktualizuj oba dokumenty.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,20 @@
-# AGENTS.md — NP-Manager
+# AGENTS.md - NP-Manager
 
-Wytyczne dla agentów AI pracujących w tym repozytorium.
+Wytyczne dla agentow AI pracujacych w tym repozytorium.
 
 ---
 
 ## Struktura projektu
 
-Monorepo zarządzane przez npm workspaces:
+Monorepo zarzadzane przez npm workspaces:
 
-```
+```text
 np-manager/
   apps/
     backend/     # Fastify + Prisma 5 + PostgreSQL (port 3001)
     frontend/    # React 18 + Vite + Tailwind CSS (port 5173)
   packages/
-    shared/      # Wspólne typy DTO i stałe (@np-manager/shared)
+    shared/      # Wspolne typy DTO i stale (@np-manager/shared)
   docs/          # Dokumentacja projektu
 ```
 
@@ -26,41 +26,41 @@ np-manager/
 
 ```bash
 cd apps/backend
-npx vitest run              # Uruchom wszystkie testy
-npx tsc --noEmit            # Sprawdź typy TypeScript
-npx prisma generate --no-engine  # Regeneruj klienta Prisma (gdy DLL jest zablokowany)
-npx prisma generate         # Regeneruj klienta Prisma (pełna wersja)
+npx vitest run                    # Uruchom wszystkie testy
+npx tsc --noEmit                  # Sprawdz typy TypeScript
+npx prisma generate --no-engine   # Regeneruj klienta Prisma (gdy DLL jest zablokowany)
+npx prisma generate               # Regeneruj klienta Prisma (pelna wersja)
 ```
 
 ### Frontend
 
 ```bash
 cd apps/frontend
-npx vitest run              # Uruchom wszystkie testy
-npx tsc --noEmit            # Sprawdź typy TypeScript
+npx vitest run                    # Uruchom wszystkie testy
+npx tsc --noEmit                  # Sprawdz typy TypeScript
 ```
 
 ### Shared package
 
 ```bash
-# Zmiany w packages/shared są automatycznie widoczne przez workspaces
-# Nie trzeba budować — import bezpośrednio ze źródeł TypeScript
+# Zmiany w packages/shared sa automatycznie widoczne przez workspaces
+# Nie trzeba budowac - import bezposrednio ze zrodel TypeScript
 ```
 
 ---
 
 ## Zasady pracy
 
-### Przed zakończeniem zadania ZAWSZE
+### Przed zakonczeniem zadania ZAWSZE
 
-1. Uruchom `npx vitest run` w `apps/backend` — wszystkie testy muszą przejść
-2. Uruchom `npx vitest run` w `apps/frontend` — wszystkie testy muszą przejść
-3. Uruchom `npx tsc --noEmit` w obu apps — brak błędów TypeScript
+1. Uruchom `npx vitest run` w `apps/backend` - wszystkie testy musza przejsc
+2. Uruchom `npx vitest run` w `apps/frontend` - wszystkie testy musza przejsc
+3. Uruchom `npx tsc --noEmit` w obu apps - brak bledow TypeScript
 
 ### Testy
 
 - Framework: **Vitest** (nie Jest)
-- Mocki: `vi.hoisted()` + `vi.mock()` na górze pliku — **przed** importami modułów pod testem
+- Mocki: `vi.hoisted()` + `vi.mock()` na gorze pliku - **przed** importami modulow pod testem
 - Prisma mock pattern:
   ```typescript
   mockPrismaTransaction.mockImplementation(async (arg: unknown) => {
@@ -68,50 +68,61 @@ npx tsc --noEmit            # Sprawdź typy TypeScript
     if (typeof arg === 'function') return arg(tx)    // callback z tx
   })
   ```
-- Testy **nie** potrzebują działającej bazy — wszystko przez mocki
+- Testy **nie** potrzebuja dzialajacej bazy - wszystko przez mocki
 
 ### Prisma / baza danych
 
-- Po zmianie `prisma/schema.prisma` → `npx prisma generate`
-- Nowe migracje: utwórz plik SQL w `prisma/migrations/YYYYMMDDHHMMSS_nazwa/migration.sql`
-- Nigdy nie usuwaj istniejących kolumn w migracji — tylko addytywne zmiany
-- `$transaction([p1, p2])` przyjmuje tablicę Promise (nie funkcje)
+- Po zmianie `prisma/schema.prisma` -> `npx prisma generate`
+- Nowe migracje: utworz plik SQL w `prisma/migrations/YYYYMMDDHHMMSS_nazwa/migration.sql`
+- Nigdy nie usuwaj istniejacych kolumn w migracji - tylko addytywne zmiany
+- `$transaction([p1, p2])` przyjmuje tablice Promise (nie funkcje)
 
-### Bezpieczeństwo
+### Bezpieczenstwo
 
-- Backend nigdy nie ufa danym z frontendu dla operacji wymagających tożsamości  
-  (np. filtr `MINE` używa `request.user.id` z JWT, nie query param)
-- Każda mutacja musi logować przez `logAuditEvent()`
-- DTO w `packages/shared` to kontrakt publiczny — nie zawiera pól wrażliwych (np. `passwordHash`)
+- Backend nigdy nie ufa danym z frontendu dla operacji wymagajacych tozsamosci  
+  (np. filtr `MINE` uzywa `request.user.id` z JWT, nie query param)
+- Kazda mutacja musi logowac przez `logAuditEvent()`
+- DTO w `packages/shared` to kontrakt publiczny - nie zawiera pol wrazliwych (np. `passwordHash`)
 
 ### Styl kodu
 
 - TypeScript strict mode (bez `any`)
 - Zod do walidacji body/query w routerach
-- `AppError.notFound()` / `AppError.badRequest(msg, code)` — nigdy `throw new Error()`
-- Polskie komunikaty błędów (system obsługi portowania w Polsce)
+- `AppError.notFound()` / `AppError.badRequest(msg, code)` - nigdy `throw new Error()`
+- Polskie komunikaty bledow (system obslugi portowania w Polsce)
 - Powiadomienia: non-blocking dispatch z `.catch(() => {})`
 
 ---
 
 ## Kontekst biznesowy
 
-NP-Manager to system zarządzania procesem przenoszenia numerów (number portability) w Polsce.
+NP-Manager to system zarzadzania procesem przenoszenia numerow (number portability) w Polsce.
 
-Główne podmioty:
-- **PortingRequest** — sprawa portowania numeru telefonu
-- **User** — pracownik operatora (BOK, BACK_OFFICE, MANAGER, SALES, itp.)
-- **Operator** — operator telefoniczny (donor/recipient)
-- **PLI CBD** — zewnętrzny system regulatora (interfejs XML/SOAP)
+Glowne podmioty:
+- **PortingRequest** - sprawa portowania numeru telefonu
+- **User** - pracownik operatora (BOK, BACK_OFFICE, MANAGER, SALES, itp.)
+- **Operator** - operator telefoniczny (donor/recipient)
+- **PLI CBD** - zewnetrzny system regulatora (interfejs XML/SOAP)
 
-Workflow spraw jest kontrolowany przez `availableStatusActions` zwracane przez backend — frontend tylko wyświetla dozwolone akcje.
+Workflow spraw jest kontrolowany przez `availableStatusActions` zwracane przez backend - frontend tylko wyswietla dozwolone akcje.
+
+### Semantyka ownership i notyfikacji (PR13A+)
+
+- Biznesowo ownership operacyjny jest po stronie **zespolu BOK**, a nie personalnie pojedynczego pracownika.
+- `assignedUserId` pozostaje na razie mechanizmem technicznym (additive, bez destrukcyjnego usuwania), ale nie jest glowna osia rozwoju domeny.
+- Sprawa moze miec opcjonalnego `commercialOwnerUserId` (rola `SALES`) odpowiedzialnego za relacje handlowa.
+- Powiadomienia wewnetrzne sa modelowane eventowo (`PortingNotificationEvent`) i routowane:
+  - do opiekuna handlowego, gdy jest aktywny,
+  - do odbiorcow zespolowych (e-mail/Teams fallback), gdy opiekuna brak lub jest nieaktywny.
+- Powiadomienia wewnetrzne sa oddzielone od komunikacji do klienta koncowego (to osobny strumien funkcjonalny).
+- Future note: mozna rozwazyc domyslnego opiekuna handlowego na poziomie `Client`, ale foundation PR13A jest celowo na poziomie `PortingRequest`.
 
 ---
 
-## Ciągłość między sesjami
+## Ciaglosc miedzy sesjami
 
 Stan projektu jest udokumentowany w:
-- `docs/PROJECT_CONTINUITY.md` — szczegółowy opis stanu i decyzji architektonicznych
-- `C:\Users\cicha\.claude\projects\...\memory\MEMORY.md` — zwięzłe podsumowanie dla Claude
+- `docs/PROJECT_CONTINUITY.md` - szczegolowy opis stanu i decyzji architektonicznych
+- `C:\Users\cicha\.claude\projects\...\memory\MEMORY.md` - zwiezle podsumowanie dla Claude
 
-Po każdym PR aktualizuj oba dokumenty.
+Po kazdym PR aktualizuj oba dokumenty.

--- a/apps/backend/prisma/migrations/20260409120000_pr13a_sales_role_commercial_owner/migration.sql
+++ b/apps/backend/prisma/migrations/20260409120000_pr13a_sales_role_commercial_owner/migration.sql
@@ -1,0 +1,15 @@
+-- PR13A: Foundation pod opiekuna handlowego i routing powiadomień
+-- Additive migration — nie usuwa istniejących kolumn assignmentu BOK
+
+-- Dodaj wartość SALES do enumeracji UserRole
+ALTER TYPE "UserRole" ADD VALUE 'SALES';
+
+-- Dodaj kolumnę opiekuna handlowego do porting_requests
+ALTER TABLE "porting_requests" ADD COLUMN "commercialOwnerUserId" TEXT;
+
+-- Dodaj klucz obcy do tabeli users (ON DELETE SET NULL — jeśli user usunięty, pole wyzerowane)
+ALTER TABLE "porting_requests" ADD CONSTRAINT "porting_requests_commercialOwnerUserId_fkey"
+  FOREIGN KEY ("commercialOwnerUserId") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Dodaj indeks dla zapytań filtrujących po opiekunie handlowym
+CREATE INDEX "porting_requests_commercialOwnerUserId_idx" ON "porting_requests"("commercialOwnerUserId");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -19,6 +19,7 @@ enum UserRole {
   TECHNICAL
   LEGAL
   AUDITOR
+  SALES
 }
 
 enum ClientType {
@@ -265,6 +266,7 @@ model User {
   createdPortingRequests                  PortingRequest[]                  @relation("PortingRequestCreatedBy")
   assignedPortingRequests                 PortingRequest[]                  @relation("PortingRequestAssignedUser")
   assignmentUpdatesPerformed              PortingRequest[]                  @relation("PortingRequestAssignedByUser")
+  commercialOwnerPortingRequests          PortingRequest[]                  @relation("PortingRequestCommercialOwner")
   portingRequestEvents                    PortingRequestEvent[]             @relation("PortingEventCreatedBy")
   pliCbdIntegrationEvents                 PliCbdIntegrationEvent[]          @relation("PliCbdIntegrationTriggeredBy")
   portingRequestCaseHistoryEntries        PortingRequestCaseHistory[]       @relation("PortingRequestCaseHistoryActor")
@@ -445,6 +447,7 @@ model PortingRequest {
   assignedUserId                        String?
   assignedAt                            DateTime?
   assignedByUserId                      String?
+  commercialOwnerUserId                 String?
   createdAt                             DateTime               @default(now())
   updatedAt                             DateTime               @updatedAt
 
@@ -455,6 +458,7 @@ model PortingRequest {
   createdByUser          User      @relation("PortingRequestCreatedBy", fields: [createdByUserId], references: [id])
   assignedUser           User?     @relation("PortingRequestAssignedUser", fields: [assignedUserId], references: [id])
   assignedByUser         User?     @relation("PortingRequestAssignedByUser", fields: [assignedByUserId], references: [id])
+  commercialOwner        User?     @relation("PortingRequestCommercialOwner", fields: [commercialOwnerUserId], references: [id])
 
   phoneNumbers             PhoneNumber[]
   documents                Document[]
@@ -479,6 +483,7 @@ model PortingRequest {
   @@index([assignedAt])
   @@index([createdAt])
   @@index([pliCbdExportStatus])
+  @@index([commercialOwnerUserId])
   @@map("porting_requests")
 }
 

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1635,24 +1635,43 @@ export async function seedMain() {
       type: 'json',
       label: 'Dozwolone typy plików (MIME)',
     },
-    // PR13A — powiadomienia wewnętrzne (routing zdarzeń portowania)
+    // PR13A - powiadomienia wewnetrzne (routing zdarzen portowania)
+    {
+      key: 'porting_status_notify_shared_emails',
+      value: 'bok@multiplay.pl,sud@multiplay.pl',
+      type: 'string',
+      label:
+        'Domyslni odbiorcy powiadomien statusowych portowania (e-mail, rozdzielone przecinkami)',
+    },
+    {
+      key: 'porting_status_teams_enabled',
+      value: 'false',
+      type: 'boolean',
+      label: 'Wlacz powiadomienia Teams dla statusowych zdarzen portowania',
+    },
+    {
+      key: 'porting_status_notify_shared_teams_webhook',
+      value: '',
+      type: 'string',
+      label: 'URL webhooka Teams dla statusowych powiadomien portowania',
+    },
     {
       key: 'porting_notify_shared_emails',
       value: 'bok@multiplay.pl,sud@multiplay.pl',
       type: 'string',
-      label: 'Domyślni odbiorcy powiadomień portowania (e-mail, rozdzielone przecinkami)',
+      label: 'Domyslni odbiorcy powiadomien portowania (legacy key)',
     },
     {
       key: 'porting_notify_teams_enabled',
       value: 'false',
       type: 'boolean',
-      label: 'Włącz powiadomienia Teams dla zdarzeń portowania',
+      label: 'Wlacz powiadomienia Teams dla zdarzen portowania (legacy key)',
     },
     {
       key: 'porting_notify_teams_webhook',
       value: '',
       type: 'string',
-      label: 'URL webhooka Teams dla powiadomień portowania',
+      label: 'URL webhooka Teams dla powiadomien portowania (legacy key)',
     },
   ]
 

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1635,6 +1635,25 @@ export async function seedMain() {
       type: 'json',
       label: 'Dozwolone typy plików (MIME)',
     },
+    // PR13A — powiadomienia wewnętrzne (routing zdarzeń portowania)
+    {
+      key: 'porting_notify_shared_emails',
+      value: 'bok@multiplay.pl,sud@multiplay.pl',
+      type: 'string',
+      label: 'Domyślni odbiorcy powiadomień portowania (e-mail, rozdzielone przecinkami)',
+    },
+    {
+      key: 'porting_notify_teams_enabled',
+      value: 'false',
+      type: 'boolean',
+      label: 'Włącz powiadomienia Teams dla zdarzeń portowania',
+    },
+    {
+      key: 'porting_notify_teams_webhook',
+      value: '',
+      type: 'string',
+      label: 'URL webhooka Teams dla powiadomień portowania',
+    },
   ]
 
   for (const setting of settings) {

--- a/apps/backend/src/__tests__/app.admin-users.routes.test.ts
+++ b/apps/backend/src/__tests__/app.admin-users.routes.test.ts
@@ -242,6 +242,28 @@ describe('POST /api/admin/users', () => {
     }
   })
 
+  it('akceptuje role SALES w payloadzie tworzenia', async () => {
+    const created = makeUserDetail({ email: 'sales@np-manager.local', role: 'SALES' })
+    mockCreateAdminUser.mockResolvedValue(created)
+
+    const app = await buildApp()
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/admin/users',
+        payload: { ...validBody, role: 'SALES', email: 'sales@np-manager.local' },
+      })
+
+      expect(response.statusCode).toBe(201)
+      expect(mockCreateAdminUser).toHaveBeenCalledWith(
+        expect.objectContaining({ role: 'SALES' }),
+        'actor-admin-id',
+      )
+    } finally {
+      await app.close()
+    }
+  })
+
   it('przekazuje actorUserId z tokenu JWT do serwisu', async () => {
     mockCreateAdminUser.mockResolvedValue(makeUserDetail())
 
@@ -322,6 +344,24 @@ describe('PATCH /api/admin/users/:id/role', () => {
       })
       expect(response.statusCode).toBe(200)
       expect(response.json().data.user.role).toBe('BACK_OFFICE')
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('akceptuje zmiane roli użytkownika na SALES', async () => {
+    const updated = makeUserDetail({ role: 'SALES' })
+    mockUpdateUserRole.mockResolvedValue(updated)
+
+    const app = await buildApp()
+    try {
+      const response = await app.inject({
+        method: 'PATCH',
+        url: '/api/admin/users/user-id-1/role',
+        payload: { role: 'SALES' },
+      })
+      expect(response.statusCode).toBe(200)
+      expect(mockUpdateUserRole).toHaveBeenCalledWith('user-id-1', { role: 'SALES' }, 'actor-admin-id')
     } finally {
       await app.close()
     }

--- a/apps/backend/src/modules/admin-users/__tests__/admin-users.schema.test.ts
+++ b/apps/backend/src/modules/admin-users/__tests__/admin-users.schema.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  adminUsersListQuerySchema,
+  createAdminUserBodySchema,
+  updateUserRoleBodySchema,
+} from '../admin-users.schema'
+
+describe('admin-users schemas', () => {
+  it('accepts SALES role in createAdminUserBodySchema', () => {
+    const parsed = createAdminUserBodySchema.parse({
+      email: 'sales@np-manager.local',
+      firstName: 'Jan',
+      lastName: 'Sprzedaz',
+      role: 'SALES',
+      temporaryPassword: 'Temp@1234',
+    })
+
+    expect(parsed.role).toBe('SALES')
+  })
+
+  it('accepts SALES role in updateUserRoleBodySchema', () => {
+    const parsed = updateUserRoleBodySchema.parse({ role: 'SALES' })
+    expect(parsed.role).toBe('SALES')
+  })
+
+  it('accepts SALES role in adminUsersListQuerySchema', () => {
+    const parsed = adminUsersListQuerySchema.parse({ role: 'SALES' })
+    expect(parsed.role).toBe('SALES')
+  })
+})

--- a/apps/backend/src/modules/admin-users/admin-users.schema.ts
+++ b/apps/backend/src/modules/admin-users/admin-users.schema.ts
@@ -10,6 +10,7 @@ const userRoleValues = [
   'BOK_CONSULTANT',
   'BACK_OFFICE',
   'MANAGER',
+  'SALES',
   'TECHNICAL',
   'LEGAL',
   'AUDITOR',

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-commercial-owner.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-commercial-owner.service.test.ts
@@ -1,0 +1,374 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockPortingRequestFindUnique,
+  mockPortingRequestUpdate,
+  mockUserFindUnique,
+  mockUserFindMany,
+  mockLogAuditEvent,
+  mockGetPortingCommunicationHistoryItems,
+  mockDispatchPortingNotification,
+} = vi.hoisted(() => ({
+  mockPortingRequestFindUnique: vi.fn(),
+  mockPortingRequestUpdate: vi.fn(),
+  mockUserFindUnique: vi.fn(),
+  mockUserFindMany: vi.fn(),
+  mockLogAuditEvent: vi.fn(),
+  mockGetPortingCommunicationHistoryItems: vi.fn(),
+  mockDispatchPortingNotification: vi.fn(),
+}))
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    portingRequest: {
+      findUnique: (...args: unknown[]) => mockPortingRequestFindUnique(...args),
+      update: (...args: unknown[]) => mockPortingRequestUpdate(...args),
+    },
+    user: {
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+      findMany: (...args: unknown[]) => mockUserFindMany(...args),
+    },
+  },
+}))
+
+vi.mock('../../../shared/audit/audit.service', () => ({
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
+}))
+
+vi.mock('../porting-request-communication.service', async () => {
+  const actual = await vi.importActual<typeof import('../porting-request-communication.service')>(
+    '../porting-request-communication.service',
+  )
+
+  return {
+    ...actual,
+    getPortingCommunicationHistoryItems: (...args: unknown[]) =>
+      mockGetPortingCommunicationHistoryItems(...args),
+  }
+})
+
+vi.mock('../porting-notification.service', () => ({
+  dispatchPortingNotification: (...args: unknown[]) => mockDispatchPortingNotification(...args),
+}))
+
+import { updateCommercialOwner, listCommercialOwnerCandidates } from '../porting-requests.service'
+
+// ============================================================
+// Factory helpers
+// ============================================================
+
+function makeSalesUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'sales-1',
+    email: 'adam.sprzedaz@np-manager.local',
+    firstName: 'Adam',
+    lastName: 'Sprzedaz',
+    role: 'SALES',
+    isActive: true,
+    ...overrides,
+  }
+}
+
+function makeClient() {
+  return {
+    id: 'client-1',
+    clientType: 'INDIVIDUAL',
+    firstName: 'Jan',
+    lastName: 'Kowalski',
+    companyName: null,
+    email: 'jan.kowalski@example.com',
+    addressStreet: 'Testowa 1',
+    addressCity: 'Warszawa',
+    addressZip: '00-001',
+  }
+}
+
+function makeOperator(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'operator-1',
+    name: 'Orange Polska',
+    shortName: 'ORANGE',
+    routingNumber: '2600',
+    isActive: true,
+    ...overrides,
+  }
+}
+
+function makeDetailRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'request-1',
+    caseNumber: 'FNP-20260409-XYZ999',
+    clientId: 'client-1',
+    numberType: 'FIXED_LINE',
+    numberRangeKind: 'SINGLE',
+    primaryNumber: '221234567',
+    rangeStart: null,
+    rangeEnd: null,
+    requestDocumentNumber: 'DOC-1',
+    donorRoutingNumber: '2600',
+    recipientRoutingNumber: '2700',
+    sentToExternalSystemAt: null,
+    portingMode: 'DAY',
+    requestedPortDate: new Date('2026-04-15T00:00:00.000Z'),
+    requestedPortTime: '00:00',
+    earliestAcceptablePortDate: null,
+    confirmedPortDate: null,
+    donorAssignedPortDate: null,
+    donorAssignedPortTime: null,
+    statusInternal: 'SUBMITTED',
+    statusPliCbd: null,
+    pliCbdCaseId: null,
+    pliCbdCaseNumber: null,
+    pliCbdPackageId: null,
+    pliCbdExportStatus: 'NOT_EXPORTED',
+    pliCbdLastSyncAt: null,
+    lastExxReceived: null,
+    lastPliCbdStatusCode: null,
+    lastPliCbdStatusDescription: null,
+    rejectionCode: null,
+    rejectionReason: null,
+    subscriberKind: 'INDIVIDUAL',
+    subscriberFirstName: 'Jan',
+    subscriberLastName: 'Kowalski',
+    subscriberCompanyName: null,
+    identityType: 'PESEL',
+    identityValue: '90010112345',
+    correspondenceAddress: 'Testowa 1, 00-001 Warszawa',
+    hasPowerOfAttorney: true,
+    linkedWholesaleServiceOnRecipientSide: false,
+    contactChannel: 'EMAIL',
+    internalNotes: null,
+    createdByUserId: 'creator-1',
+    assignedAt: null,
+    assignedByUserId: null,
+    commercialOwnerUserId: null,
+    createdAt: new Date('2026-04-09T10:00:00.000Z'),
+    updatedAt: new Date('2026-04-09T10:00:00.000Z'),
+    client: makeClient(),
+    donorOperator: makeOperator(),
+    recipientOperator: makeOperator({
+      id: 'operator-2',
+      name: 'G-NET',
+      shortName: 'GNET',
+      routingNumber: '2700',
+    }),
+    infrastructureOperator: null,
+    assignedUser: null,
+    commercialOwner: null,
+    ...overrides,
+  }
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('updateCommercialOwner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLogAuditEvent.mockResolvedValue(undefined)
+    mockPortingRequestUpdate.mockResolvedValue(undefined)
+    mockGetPortingCommunicationHistoryItems.mockResolvedValue([])
+    mockDispatchPortingNotification.mockResolvedValue(undefined)
+  })
+
+  it('assigns a valid SALES user as commercial owner', async () => {
+    const salesUser = makeSalesUser()
+
+    // 1st findUnique: validate candidate (select id/role/isActive/firstName/lastName)
+    mockUserFindUnique.mockResolvedValueOnce(salesUser)
+    // 2nd findUnique: find current request (select id/caseNumber/commercialOwnerUserId)
+    mockPortingRequestFindUnique.mockResolvedValueOnce({
+      id: 'request-1',
+      caseNumber: 'FNP-20260409-XYZ999',
+      commercialOwnerUserId: null,
+    })
+    // 3rd findUnique: getPortingRequest (full detail)
+    mockPortingRequestFindUnique.mockResolvedValueOnce(
+      makeDetailRow({
+        commercialOwnerUserId: 'sales-1',
+        commercialOwner: {
+          id: 'sales-1',
+          email: 'adam.sprzedaz@np-manager.local',
+          firstName: 'Adam',
+          lastName: 'Sprzedaz',
+          role: 'SALES',
+        },
+      }),
+    )
+
+    const result = await updateCommercialOwner(
+      'request-1',
+      { commercialOwnerUserId: 'sales-1' },
+      'actor-1',
+      'MANAGER',
+    )
+
+    expect(mockPortingRequestUpdate).toHaveBeenCalledWith({
+      where: { id: 'request-1' },
+      data: { commercialOwnerUserId: 'sales-1' },
+    })
+    expect(mockLogAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'UPDATE',
+        fieldName: 'commercialOwnerUserId',
+        oldValue: 'BRAK',
+        newValue: 'sales-1',
+      }),
+    )
+    expect(result.commercialOwner).not.toBeNull()
+    expect(result.commercialOwner?.displayName).toBe('Adam Sprzedaz')
+  })
+
+  it('clears commercial owner when commercialOwnerUserId is null', async () => {
+    // No user lookup when clearing (nextOwnerId is null)
+    mockPortingRequestFindUnique.mockResolvedValueOnce({
+      id: 'request-1',
+      caseNumber: 'FNP-20260409-XYZ999',
+      commercialOwnerUserId: 'sales-1',
+    })
+    mockPortingRequestFindUnique.mockResolvedValueOnce(makeDetailRow({ commercialOwner: null }))
+
+    const result = await updateCommercialOwner(
+      'request-1',
+      { commercialOwnerUserId: null },
+      'actor-1',
+      'ADMIN',
+    )
+
+    // User validation skipped
+    expect(mockUserFindUnique).not.toHaveBeenCalled()
+    expect(mockPortingRequestUpdate).toHaveBeenCalledWith({
+      where: { id: 'request-1' },
+      data: { commercialOwnerUserId: null },
+    })
+    expect(mockLogAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        oldValue: 'sales-1',
+        newValue: 'BRAK',
+      }),
+    )
+    expect(result.commercialOwner).toBeNull()
+  })
+
+  it('returns current request without update when owner unchanged', async () => {
+    mockUserFindUnique.mockResolvedValueOnce(makeSalesUser())
+    mockPortingRequestFindUnique.mockResolvedValueOnce({
+      id: 'request-1',
+      caseNumber: 'FNP-20260409-XYZ999',
+      commercialOwnerUserId: 'sales-1', // same as requested
+    })
+    // getPortingRequest call for early return
+    mockPortingRequestFindUnique.mockResolvedValueOnce(
+      makeDetailRow({ commercialOwnerUserId: 'sales-1' }),
+    )
+
+    await updateCommercialOwner(
+      'request-1',
+      { commercialOwnerUserId: 'sales-1' },
+      'actor-1',
+      'ADMIN',
+    )
+
+    // No DB update or audit when value unchanged
+    expect(mockPortingRequestUpdate).not.toHaveBeenCalled()
+    expect(mockLogAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('throws NOT_FOUND when candidate user does not exist', async () => {
+    mockUserFindUnique.mockResolvedValueOnce(null)
+
+    await expect(
+      updateCommercialOwner(
+        'request-1',
+        { commercialOwnerUserId: 'nonexistent-user' },
+        'actor-1',
+        'ADMIN',
+      ),
+    ).rejects.toMatchObject({ statusCode: 404 })
+
+    expect(mockPortingRequestUpdate).not.toHaveBeenCalled()
+  })
+
+  it('throws BAD_REQUEST when candidate user is inactive', async () => {
+    mockUserFindUnique.mockResolvedValueOnce(makeSalesUser({ isActive: false }))
+
+    await expect(
+      updateCommercialOwner(
+        'request-1',
+        { commercialOwnerUserId: 'sales-1' },
+        'actor-1',
+        'ADMIN',
+      ),
+    ).rejects.toMatchObject({ statusCode: 400, code: 'COMMERCIAL_OWNER_INACTIVE' })
+
+    expect(mockPortingRequestUpdate).not.toHaveBeenCalled()
+  })
+
+  it('throws BAD_REQUEST when candidate user does not have SALES role', async () => {
+    mockUserFindUnique.mockResolvedValueOnce(makeSalesUser({ role: 'BOK_CONSULTANT' }))
+
+    await expect(
+      updateCommercialOwner(
+        'request-1',
+        { commercialOwnerUserId: 'sales-1' },
+        'actor-1',
+        'ADMIN',
+      ),
+    ).rejects.toMatchObject({ statusCode: 400, code: 'COMMERCIAL_OWNER_INVALID_ROLE' })
+
+    expect(mockPortingRequestUpdate).not.toHaveBeenCalled()
+  })
+
+  it('throws NOT_FOUND when porting request does not exist', async () => {
+    mockUserFindUnique.mockResolvedValueOnce(makeSalesUser())
+    mockPortingRequestFindUnique.mockResolvedValueOnce(null)
+
+    await expect(
+      updateCommercialOwner(
+        'nonexistent-request',
+        { commercialOwnerUserId: 'sales-1' },
+        'actor-1',
+        'ADMIN',
+      ),
+    ).rejects.toMatchObject({ statusCode: 404 })
+  })
+})
+
+describe('listCommercialOwnerCandidates', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns active SALES users sorted by lastName, firstName', async () => {
+    const salesRows = [
+      makeSalesUser({ id: 'sales-1', firstName: 'Adam', lastName: 'Sprzedaz' }),
+      makeSalesUser({ id: 'sales-2', firstName: 'Basia', lastName: 'Kowalska' }),
+    ]
+    mockUserFindMany.mockResolvedValueOnce(salesRows)
+
+    const result = await listCommercialOwnerCandidates()
+
+    expect(mockUserFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { isActive: true, role: 'SALES' },
+        orderBy: [{ lastName: 'asc' }, { firstName: 'asc' }],
+      }),
+    )
+    expect(result.users).toHaveLength(2)
+    expect(result.users[0]).toMatchObject({
+      id: 'sales-1',
+      firstName: 'Adam',
+      lastName: 'Sprzedaz',
+      role: 'SALES',
+    })
+  })
+
+  it('returns empty list when no SALES users exist', async () => {
+    mockUserFindMany.mockResolvedValueOnce([])
+
+    const result = await listCommercialOwnerCandidates()
+
+    expect(result.users).toHaveLength(0)
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-commercial-owner.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-commercial-owner.service.test.ts
@@ -251,8 +251,7 @@ describe('updateCommercialOwner', () => {
     expect(result.commercialOwner).toBeNull()
   })
 
-  it('returns current request without update when owner unchanged', async () => {
-    mockUserFindUnique.mockResolvedValueOnce(makeSalesUser())
+  it('returns current request without side effects when owner is unchanged', async () => {
     mockPortingRequestFindUnique.mockResolvedValueOnce({
       id: 'request-1',
       caseNumber: 'FNP-20260409-XYZ999',
@@ -270,12 +269,19 @@ describe('updateCommercialOwner', () => {
       'ADMIN',
     )
 
-    // No DB update or audit when value unchanged
+    // No validation/update/audit/dispatch when value unchanged
+    expect(mockUserFindUnique).not.toHaveBeenCalled()
     expect(mockPortingRequestUpdate).not.toHaveBeenCalled()
     expect(mockLogAuditEvent).not.toHaveBeenCalled()
+    expect(mockDispatchPortingNotification).not.toHaveBeenCalled()
   })
 
   it('throws NOT_FOUND when candidate user does not exist', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce({
+      id: 'request-1',
+      caseNumber: 'FNP-20260409-XYZ999',
+      commercialOwnerUserId: null,
+    })
     mockUserFindUnique.mockResolvedValueOnce(null)
 
     await expect(
@@ -291,6 +297,11 @@ describe('updateCommercialOwner', () => {
   })
 
   it('throws BAD_REQUEST when candidate user is inactive', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce({
+      id: 'request-1',
+      caseNumber: 'FNP-20260409-XYZ999',
+      commercialOwnerUserId: null,
+    })
     mockUserFindUnique.mockResolvedValueOnce(makeSalesUser({ isActive: false }))
 
     await expect(
@@ -306,6 +317,11 @@ describe('updateCommercialOwner', () => {
   })
 
   it('throws BAD_REQUEST when candidate user does not have SALES role', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce({
+      id: 'request-1',
+      caseNumber: 'FNP-20260409-XYZ999',
+      commercialOwnerUserId: null,
+    })
     mockUserFindUnique.mockResolvedValueOnce(makeSalesUser({ role: 'BOK_CONSULTANT' }))
 
     await expect(
@@ -321,7 +337,6 @@ describe('updateCommercialOwner', () => {
   })
 
   it('throws NOT_FOUND when porting request does not exist', async () => {
-    mockUserFindUnique.mockResolvedValueOnce(makeSalesUser())
     mockPortingRequestFindUnique.mockResolvedValueOnce(null)
 
     await expect(
@@ -332,6 +347,8 @@ describe('updateCommercialOwner', () => {
         'ADMIN',
       ),
     ).rejects.toMatchObject({ statusCode: 404 })
+
+    expect(mockUserFindUnique).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-notification-events.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-notification-events.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  PORTING_NOTIFICATION_EVENT,
+  PORTING_NOTIFICATION_EVENT_LABELS,
+} from '../porting-notification-events'
+
+describe('PORTING_NOTIFICATION_EVENT catalog', () => {
+  it('contains the PR13A foundation events', () => {
+    expect(PORTING_NOTIFICATION_EVENT).toMatchObject({
+      REQUEST_CREATED: 'REQUEST_CREATED',
+      STATUS_CHANGED: 'STATUS_CHANGED',
+      E03_SENT: 'E03_SENT',
+      E06_RECEIVED: 'E06_RECEIVED',
+      PORT_DATE_CONFIRMED: 'PORT_DATE_CONFIRMED',
+      E12_SENT: 'E12_SENT',
+      E13_RECEIVED: 'E13_RECEIVED',
+      NUMBER_PORTED: 'NUMBER_PORTED',
+      CASE_REJECTED: 'CASE_REJECTED',
+      COMMERCIAL_OWNER_CHANGED: 'COMMERCIAL_OWNER_CHANGED',
+    })
+  })
+
+  it('exposes labels for each event', () => {
+    for (const event of Object.values(PORTING_NOTIFICATION_EVENT)) {
+      expect(PORTING_NOTIFICATION_EVENT_LABELS[event]).toBeTruthy()
+    }
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-notification-recipient-resolver.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-notification-recipient-resolver.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockUserFindUnique,
+  mockSystemSettingFindUnique,
+} = vi.hoisted(() => ({
+  mockUserFindUnique: vi.fn(),
+  mockSystemSettingFindUnique: vi.fn(),
+}))
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    user: {
+      findUnique: (...args: unknown[]) => mockUserFindUnique(...args),
+    },
+    systemSetting: {
+      findUnique: (...args: unknown[]) => mockSystemSettingFindUnique(...args),
+    },
+  },
+}))
+
+import { resolvePortingNotificationRecipients } from '../porting-notification-recipient-resolver'
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('resolvePortingNotificationRecipients', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('when commercialOwnerUserId is provided', () => {
+    it('returns USER recipient when owner exists and is active', async () => {
+      mockUserFindUnique.mockResolvedValueOnce({
+        id: 'sales-1',
+        email: 'adam.sprzedaz@np-manager.local',
+        firstName: 'Adam',
+        lastName: 'Sprzedaz',
+        isActive: true,
+      })
+
+      const recipients = await resolvePortingNotificationRecipients('sales-1')
+
+      expect(recipients).toHaveLength(1)
+      expect(recipients[0]).toEqual({
+        kind: 'USER',
+        userId: 'sales-1',
+        email: 'adam.sprzedaz@np-manager.local',
+        displayName: 'Adam Sprzedaz',
+      })
+      // Should NOT query system settings when owner found
+      expect(mockSystemSettingFindUnique).not.toHaveBeenCalled()
+    })
+
+    it('falls back to team email when owner user is not found', async () => {
+      mockUserFindUnique.mockResolvedValueOnce(null)
+      mockSystemSettingFindUnique.mockResolvedValueOnce({
+        value: 'team@np-manager.local,backup@np-manager.local',
+      })
+
+      const recipients = await resolvePortingNotificationRecipients('nonexistent-sales')
+
+      expect(recipients).toHaveLength(1)
+      expect(recipients[0]).toEqual({
+        kind: 'TEAM_EMAIL',
+        emails: ['team@np-manager.local', 'backup@np-manager.local'],
+      })
+    })
+
+    it('falls back to team email when owner user is inactive', async () => {
+      mockUserFindUnique.mockResolvedValueOnce({
+        id: 'sales-1',
+        email: 'adam.sprzedaz@np-manager.local',
+        firstName: 'Adam',
+        lastName: 'Sprzedaz',
+        isActive: false,
+      })
+      mockSystemSettingFindUnique.mockResolvedValueOnce({
+        value: 'team@np-manager.local',
+      })
+
+      const recipients = await resolvePortingNotificationRecipients('sales-1')
+
+      expect(recipients).toHaveLength(1)
+      expect(recipients[0]).toMatchObject({
+        kind: 'TEAM_EMAIL',
+        emails: ['team@np-manager.local'],
+      })
+    })
+  })
+
+  describe('when commercialOwnerUserId is null or undefined', () => {
+    it('returns TEAM_EMAIL recipient when shared emails are configured (null)', async () => {
+      mockSystemSettingFindUnique.mockResolvedValueOnce({
+        value: 'bok@np-manager.local',
+      })
+
+      const recipients = await resolvePortingNotificationRecipients(null)
+
+      expect(recipients).toHaveLength(1)
+      expect(recipients[0]).toEqual({
+        kind: 'TEAM_EMAIL',
+        emails: ['bok@np-manager.local'],
+      })
+      expect(mockUserFindUnique).not.toHaveBeenCalled()
+    })
+
+    it('returns TEAM_EMAIL recipient when shared emails are configured (undefined)', async () => {
+      mockSystemSettingFindUnique.mockResolvedValueOnce({
+        value: 'bok@np-manager.local,manager@np-manager.local',
+      })
+
+      const recipients = await resolvePortingNotificationRecipients(undefined)
+
+      expect(recipients[0]).toMatchObject({
+        kind: 'TEAM_EMAIL',
+        emails: ['bok@np-manager.local', 'manager@np-manager.local'],
+      })
+    })
+
+    it('returns empty array when system setting not configured', async () => {
+      mockSystemSettingFindUnique.mockResolvedValueOnce(null)
+
+      const recipients = await resolvePortingNotificationRecipients(null)
+
+      expect(recipients).toHaveLength(0)
+    })
+
+    it('returns empty array when system setting value is empty string', async () => {
+      mockSystemSettingFindUnique.mockResolvedValueOnce({ value: '' })
+
+      const recipients = await resolvePortingNotificationRecipients(null)
+
+      expect(recipients).toHaveLength(0)
+    })
+
+    it('filters out whitespace-only entries from shared emails', async () => {
+      mockSystemSettingFindUnique.mockResolvedValueOnce({
+        value: 'valid@np-manager.local,,  ,another@np-manager.local',
+      })
+
+      const recipients = await resolvePortingNotificationRecipients(null)
+
+      expect(recipients).toHaveLength(1)
+      expect(recipients[0]).toMatchObject({
+        kind: 'TEAM_EMAIL',
+        emails: ['valid@np-manager.local', 'another@np-manager.local'],
+      })
+    })
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-notification-recipient-resolver.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-notification-recipient-resolver.test.ts
@@ -1,9 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const {
-  mockUserFindUnique,
-  mockSystemSettingFindUnique,
-} = vi.hoisted(() => ({
+const { mockUserFindUnique, mockSystemSettingFindUnique } = vi.hoisted(() => ({
   mockUserFindUnique: vi.fn(),
   mockSystemSettingFindUnique: vi.fn(),
 }))
@@ -21,132 +18,101 @@ vi.mock('../../../config/database', () => ({
 
 import { resolvePortingNotificationRecipients } from '../porting-notification-recipient-resolver'
 
-// ============================================================
-// Tests
-// ============================================================
-
 describe('resolvePortingNotificationRecipients', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  describe('when commercialOwnerUserId is provided', () => {
-    it('returns USER recipient when owner exists and is active', async () => {
-      mockUserFindUnique.mockResolvedValueOnce({
-        id: 'sales-1',
-        email: 'adam.sprzedaz@np-manager.local',
-        firstName: 'Adam',
-        lastName: 'Sprzedaz',
-        isActive: true,
-      })
+  it('returns USER recipient when owner exists and is active', async () => {
+    mockUserFindUnique.mockResolvedValueOnce({
+      id: 'sales-1',
+      email: 'adam.sprzedaz@np-manager.local',
+      firstName: 'Adam',
+      lastName: 'Sprzedaz',
+      isActive: true,
+    })
 
-      const recipients = await resolvePortingNotificationRecipients('sales-1')
+    const recipients = await resolvePortingNotificationRecipients('sales-1')
 
-      expect(recipients).toHaveLength(1)
-      expect(recipients[0]).toEqual({
+    expect(recipients).toEqual([
+      {
         kind: 'USER',
         userId: 'sales-1',
         email: 'adam.sprzedaz@np-manager.local',
         displayName: 'Adam Sprzedaz',
-      })
-      // Should NOT query system settings when owner found
-      expect(mockSystemSettingFindUnique).not.toHaveBeenCalled()
-    })
-
-    it('falls back to team email when owner user is not found', async () => {
-      mockUserFindUnique.mockResolvedValueOnce(null)
-      mockSystemSettingFindUnique.mockResolvedValueOnce({
-        value: 'team@np-manager.local,backup@np-manager.local',
-      })
-
-      const recipients = await resolvePortingNotificationRecipients('nonexistent-sales')
-
-      expect(recipients).toHaveLength(1)
-      expect(recipients[0]).toEqual({
-        kind: 'TEAM_EMAIL',
-        emails: ['team@np-manager.local', 'backup@np-manager.local'],
-      })
-    })
-
-    it('falls back to team email when owner user is inactive', async () => {
-      mockUserFindUnique.mockResolvedValueOnce({
-        id: 'sales-1',
-        email: 'adam.sprzedaz@np-manager.local',
-        firstName: 'Adam',
-        lastName: 'Sprzedaz',
-        isActive: false,
-      })
-      mockSystemSettingFindUnique.mockResolvedValueOnce({
-        value: 'team@np-manager.local',
-      })
-
-      const recipients = await resolvePortingNotificationRecipients('sales-1')
-
-      expect(recipients).toHaveLength(1)
-      expect(recipients[0]).toMatchObject({
-        kind: 'TEAM_EMAIL',
-        emails: ['team@np-manager.local'],
-      })
-    })
+      },
+    ])
+    expect(mockSystemSettingFindUnique).not.toHaveBeenCalled()
   })
 
-  describe('when commercialOwnerUserId is null or undefined', () => {
-    it('returns TEAM_EMAIL recipient when shared emails are configured (null)', async () => {
-      mockSystemSettingFindUnique.mockResolvedValueOnce({
-        value: 'bok@np-manager.local',
-      })
+  it('falls back to shared recipients when owner does not exist', async () => {
+    mockUserFindUnique.mockResolvedValueOnce(null)
+    mockSystemSettingFindUnique
+      .mockResolvedValueOnce({ value: 'bok@np-manager.local,sud@np-manager.local' })
+      .mockResolvedValueOnce({ value: 'false' })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
 
-      const recipients = await resolvePortingNotificationRecipients(null)
+    const recipients = await resolvePortingNotificationRecipients('missing-owner')
 
-      expect(recipients).toHaveLength(1)
-      expect(recipients[0]).toEqual({
+    expect(recipients).toEqual([
+      {
         kind: 'TEAM_EMAIL',
-        emails: ['bok@np-manager.local'],
-      })
-      expect(mockUserFindUnique).not.toHaveBeenCalled()
+        emails: ['bok@np-manager.local', 'sud@np-manager.local'],
+      },
+    ])
+  })
+
+  it('falls back to team email and teams webhook when owner is inactive', async () => {
+    mockUserFindUnique.mockResolvedValueOnce({
+      id: 'sales-1',
+      email: 'adam.sprzedaz@np-manager.local',
+      firstName: 'Adam',
+      lastName: 'Sprzedaz',
+      isActive: false,
     })
 
-    it('returns TEAM_EMAIL recipient when shared emails are configured (undefined)', async () => {
-      mockSystemSettingFindUnique.mockResolvedValueOnce({
-        value: 'bok@np-manager.local,manager@np-manager.local',
-      })
+    mockSystemSettingFindUnique
+      .mockResolvedValueOnce({ value: 'bok@np-manager.local' })
+      .mockResolvedValueOnce({ value: 'true' })
+      .mockResolvedValueOnce({ value: 'https://teams.example/webhook' })
 
-      const recipients = await resolvePortingNotificationRecipients(undefined)
+    const recipients = await resolvePortingNotificationRecipients('sales-1')
 
-      expect(recipients[0]).toMatchObject({
-        kind: 'TEAM_EMAIL',
-        emails: ['bok@np-manager.local', 'manager@np-manager.local'],
-      })
-    })
+    expect(recipients).toEqual([
+      { kind: 'TEAM_EMAIL', emails: ['bok@np-manager.local'] },
+      { kind: 'TEAM_WEBHOOK', webhookUrl: 'https://teams.example/webhook' },
+    ])
+  })
 
-    it('returns empty array when system setting not configured', async () => {
-      mockSystemSettingFindUnique.mockResolvedValueOnce(null)
+  it('uses legacy key aliases when preferred settings are missing', async () => {
+    mockSystemSettingFindUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ value: 'legacy@np-manager.local' })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ value: '1' })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ value: 'https://legacy.example/hook' })
 
-      const recipients = await resolvePortingNotificationRecipients(null)
+    const recipients = await resolvePortingNotificationRecipients(null)
 
-      expect(recipients).toHaveLength(0)
-    })
+    expect(recipients).toEqual([
+      { kind: 'TEAM_EMAIL', emails: ['legacy@np-manager.local'] },
+      { kind: 'TEAM_WEBHOOK', webhookUrl: 'https://legacy.example/hook' },
+    ])
+  })
 
-    it('returns empty array when system setting value is empty string', async () => {
-      mockSystemSettingFindUnique.mockResolvedValueOnce({ value: '' })
+  it('returns empty array when neither owner nor fallback settings are configured', async () => {
+    mockSystemSettingFindUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
 
-      const recipients = await resolvePortingNotificationRecipients(null)
+    const recipients = await resolvePortingNotificationRecipients(undefined)
 
-      expect(recipients).toHaveLength(0)
-    })
-
-    it('filters out whitespace-only entries from shared emails', async () => {
-      mockSystemSettingFindUnique.mockResolvedValueOnce({
-        value: 'valid@np-manager.local,,  ,another@np-manager.local',
-      })
-
-      const recipients = await resolvePortingNotificationRecipients(null)
-
-      expect(recipients).toHaveLength(1)
-      expect(recipients[0]).toMatchObject({
-        kind: 'TEAM_EMAIL',
-        emails: ['valid@np-manager.local', 'another@np-manager.local'],
-      })
-    })
+    expect(recipients).toEqual([])
   })
 })

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-notification.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-notification.service.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockNotificationCreate, mockPortingRequestEventCreate, mockResolveRecipients } = vi.hoisted(
+  () => ({
+    mockNotificationCreate: vi.fn(),
+    mockPortingRequestEventCreate: vi.fn(),
+    mockResolveRecipients: vi.fn(),
+  }),
+)
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    notification: {
+      create: (...args: unknown[]) => mockNotificationCreate(...args),
+    },
+    portingRequestEvent: {
+      create: (...args: unknown[]) => mockPortingRequestEventCreate(...args),
+    },
+  },
+}))
+
+vi.mock('../porting-notification-recipient-resolver', () => ({
+  resolvePortingNotificationRecipients: (...args: unknown[]) => mockResolveRecipients(...args),
+}))
+
+import { PORTING_NOTIFICATION_EVENT } from '../porting-notification-events'
+import { dispatchPortingNotification } from '../porting-notification.service'
+
+describe('dispatchPortingNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockNotificationCreate.mockResolvedValue(undefined)
+    mockPortingRequestEventCreate.mockResolvedValue(undefined)
+  })
+
+  it('creates Notification for active owner recipient on STATUS_CHANGED', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      {
+        kind: 'USER',
+        userId: 'sales-1',
+        email: 'sales@np-manager.local',
+        displayName: 'Jan Sprzedaz',
+      },
+    ])
+
+    await dispatchPortingNotification({
+      requestId: 'request-1',
+      caseNumber: 'FNP-20260409-AAA111',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: 'sales-1',
+      actorUserId: 'actor-1',
+      metadata: { newStatus: 'ACCEPTED' },
+    })
+
+    expect(mockNotificationCreate).toHaveBeenCalledWith({
+      data: {
+        userId: 'sales-1',
+        type: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+        title: 'Zmiana statusu sprawy - sprawa FNP-20260409-AAA111',
+        body: 'Status sprawy zostal zmieniony na: ACCEPTED.',
+        relatedEntityType: 'porting_request',
+        relatedEntityId: 'request-1',
+      },
+    })
+    expect(mockPortingRequestEventCreate).not.toHaveBeenCalled()
+  })
+
+  it('creates fallback timeline note for TEAM_EMAIL recipients', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'TEAM_EMAIL', emails: ['bok@multiplay.pl', 'sud@multiplay.pl'] },
+    ])
+
+    await dispatchPortingNotification({
+      requestId: 'request-2',
+      caseNumber: 'FNP-20260409-BBB222',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: null,
+      actorUserId: 'actor-2',
+      metadata: { newStatus: 'PENDING_DONOR' },
+    })
+
+    expect(mockNotificationCreate).not.toHaveBeenCalled()
+    expect(mockPortingRequestEventCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          eventType: 'NOTE',
+          title: 'Powiadomienie zespolowe: Zmiana statusu sprawy',
+          description: expect.stringContaining('bok@multiplay.pl, sud@multiplay.pl'),
+        }),
+      }),
+    )
+  })
+
+  it('creates fallback timeline note for TEAM_WEBHOOK recipients', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'TEAM_WEBHOOK', webhookUrl: 'https://teams.example/hook' },
+    ])
+
+    await dispatchPortingNotification({
+      requestId: 'request-3',
+      caseNumber: 'FNP-20260409-CCC333',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: null,
+      metadata: { newStatus: 'PORTED' },
+    })
+
+    expect(mockNotificationCreate).not.toHaveBeenCalled()
+    expect(mockPortingRequestEventCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          description: expect.stringContaining('https://teams.example/hook'),
+        }),
+      }),
+    )
+  })
+
+  it('does nothing when resolver returns no recipients', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([])
+
+    await dispatchPortingNotification({
+      requestId: 'request-4',
+      caseNumber: 'FNP-20260409-DDD444',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: null,
+    })
+
+    expect(mockNotificationCreate).not.toHaveBeenCalled()
+    expect(mockPortingRequestEventCreate).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-request-assignment.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-request-assignment.service.test.ts
@@ -447,7 +447,7 @@ describe('porting-request assignment service foundation', () => {
       }),
     ])
 
-    const result = await listPortingRequests({ page: 1, pageSize: 20 })
+    const result = await listPortingRequests({ page: 1, pageSize: 20, ownership: 'ALL' }, 'current-user-1')
 
     expect(result.items[0]?.assignedUserSummary?.id).toBe('user-2')
     expect(result.items[0]?.assignedUserSummary?.displayName).toBe('Anna Nowak')

--- a/apps/backend/src/modules/porting-requests/porting-notification-events.ts
+++ b/apps/backend/src/modules/porting-requests/porting-notification-events.ts
@@ -1,32 +1,22 @@
 /**
- * Katalog wewnętrznych zdarzeń domenowych procesu portowania numeru.
+ * Internal notification events for the porting process.
  *
- * Zdarzenia te są bazą routingu powiadomień wewnętrznych — do opiekuna
- * handlowego lub do wspólnych odbiorców zespołowych.
- *
- * Architektura jest rozszerzalna pod przyszłe zdarzenia PLI CBD:
- *   E03_SENT, E06_RECEIVED, PORT_DATE_CONFIRMED, E12_SENT,
- *   E13_RECEIVED, NUMBER_PORTED, CASE_REJECTED itp.
- *
- * Na tym etapie wdrożone eventy:
- *   - REQUEST_CREATED      — sprawa zarejestrowana
- *   - STATUS_CHANGED       — zmiana statusu sprawy
- *   - COMMERCIAL_OWNER_CHANGED — zmiana opiekuna handlowego
+ * Foundation scope (PR13A):
+ * - model a wider, extensible event catalog,
+ * - wire low-risk events only (currently STATUS_CHANGED and COMMERCIAL_OWNER_CHANGED),
+ * - keep the catalog ready for future PLI CBD event hooks.
  */
-
 export const PORTING_NOTIFICATION_EVENT = {
   REQUEST_CREATED: 'REQUEST_CREATED',
   STATUS_CHANGED: 'STATUS_CHANGED',
+  E03_SENT: 'E03_SENT',
+  E06_RECEIVED: 'E06_RECEIVED',
+  PORT_DATE_CONFIRMED: 'PORT_DATE_CONFIRMED',
+  E12_SENT: 'E12_SENT',
+  E13_RECEIVED: 'E13_RECEIVED',
+  NUMBER_PORTED: 'NUMBER_PORTED',
+  CASE_REJECTED: 'CASE_REJECTED',
   COMMERCIAL_OWNER_CHANGED: 'COMMERCIAL_OWNER_CHANGED',
-
-  // TODO(PR13B+): podłączyć po wdrożeniu pełnego flow PLI CBD
-  // E03_SENT: 'E03_SENT',
-  // E06_RECEIVED: 'E06_RECEIVED',
-  // PORT_DATE_CONFIRMED: 'PORT_DATE_CONFIRMED',
-  // E12_SENT: 'E12_SENT',
-  // E13_RECEIVED: 'E13_RECEIVED',
-  // NUMBER_PORTED: 'NUMBER_PORTED',
-  // CASE_REJECTED: 'CASE_REJECTED',
 } as const
 
 export type PortingNotificationEvent =
@@ -35,5 +25,12 @@ export type PortingNotificationEvent =
 export const PORTING_NOTIFICATION_EVENT_LABELS: Record<PortingNotificationEvent, string> = {
   REQUEST_CREATED: 'Nowa sprawa portowania',
   STATUS_CHANGED: 'Zmiana statusu sprawy',
+  E03_SENT: 'Wyslano E03',
+  E06_RECEIVED: 'Odebrano E06',
+  PORT_DATE_CONFIRMED: 'Potwierdzono date przeniesienia',
+  E12_SENT: 'Wyslano E12',
+  E13_RECEIVED: 'Odebrano E13',
+  NUMBER_PORTED: 'Numer zostal przeniesiony',
+  CASE_REJECTED: 'Sprawa zostala odrzucona',
   COMMERCIAL_OWNER_CHANGED: 'Zmiana opiekuna handlowego',
 }

--- a/apps/backend/src/modules/porting-requests/porting-notification-events.ts
+++ b/apps/backend/src/modules/porting-requests/porting-notification-events.ts
@@ -1,0 +1,39 @@
+/**
+ * Katalog wewnętrznych zdarzeń domenowych procesu portowania numeru.
+ *
+ * Zdarzenia te są bazą routingu powiadomień wewnętrznych — do opiekuna
+ * handlowego lub do wspólnych odbiorców zespołowych.
+ *
+ * Architektura jest rozszerzalna pod przyszłe zdarzenia PLI CBD:
+ *   E03_SENT, E06_RECEIVED, PORT_DATE_CONFIRMED, E12_SENT,
+ *   E13_RECEIVED, NUMBER_PORTED, CASE_REJECTED itp.
+ *
+ * Na tym etapie wdrożone eventy:
+ *   - REQUEST_CREATED      — sprawa zarejestrowana
+ *   - STATUS_CHANGED       — zmiana statusu sprawy
+ *   - COMMERCIAL_OWNER_CHANGED — zmiana opiekuna handlowego
+ */
+
+export const PORTING_NOTIFICATION_EVENT = {
+  REQUEST_CREATED: 'REQUEST_CREATED',
+  STATUS_CHANGED: 'STATUS_CHANGED',
+  COMMERCIAL_OWNER_CHANGED: 'COMMERCIAL_OWNER_CHANGED',
+
+  // TODO(PR13B+): podłączyć po wdrożeniu pełnego flow PLI CBD
+  // E03_SENT: 'E03_SENT',
+  // E06_RECEIVED: 'E06_RECEIVED',
+  // PORT_DATE_CONFIRMED: 'PORT_DATE_CONFIRMED',
+  // E12_SENT: 'E12_SENT',
+  // E13_RECEIVED: 'E13_RECEIVED',
+  // NUMBER_PORTED: 'NUMBER_PORTED',
+  // CASE_REJECTED: 'CASE_REJECTED',
+} as const
+
+export type PortingNotificationEvent =
+  (typeof PORTING_NOTIFICATION_EVENT)[keyof typeof PORTING_NOTIFICATION_EVENT]
+
+export const PORTING_NOTIFICATION_EVENT_LABELS: Record<PortingNotificationEvent, string> = {
+  REQUEST_CREATED: 'Nowa sprawa portowania',
+  STATUS_CHANGED: 'Zmiana statusu sprawy',
+  COMMERCIAL_OWNER_CHANGED: 'Zmiana opiekuna handlowego',
+}

--- a/apps/backend/src/modules/porting-requests/porting-notification-recipient-resolver.ts
+++ b/apps/backend/src/modules/porting-requests/porting-notification-recipient-resolver.ts
@@ -1,0 +1,66 @@
+/**
+ * Resolver odbiorców powiadomień wewnętrznych dla spraw portowania.
+ *
+ * Logika:
+ *  1. Jeśli sprawa ma ustawionego opiekuna handlowego (commercialOwnerUserId)
+ *     i jest on aktywnym użytkownikiem systemu → powiadomienie tylko do niego.
+ *  2. Fallback — brak opiekuna lub użytkownik nieaktywny → powiadomienie
+ *     do wspólnych odbiorców zespołowych (e-mail z system_settings).
+ *
+ * Zwracany typ jest rozszerzalny: w przyszłości można dodać
+ *   { kind: 'TEAMS_WEBHOOK'; webhookUrl: string }
+ * lub inne kanały bez zmiany interfejsu wywołującego.
+ */
+
+import { prisma } from '../../config/database'
+import { SYSTEM_SETTING_KEYS } from '@np-manager/shared'
+
+// ============================================================
+// Typy odbiorców
+// ============================================================
+
+export type NotificationRecipient =
+  | { kind: 'USER'; userId: string; email: string; displayName: string }
+  | { kind: 'TEAM_EMAIL'; emails: string[] }
+
+// ============================================================
+// Resolver
+// ============================================================
+
+export async function resolvePortingNotificationRecipients(
+  commercialOwnerUserId: string | null | undefined,
+): Promise<NotificationRecipient[]> {
+  if (commercialOwnerUserId) {
+    const owner = await prisma.user.findUnique({
+      where: { id: commercialOwnerUserId },
+      select: { id: true, email: true, firstName: true, lastName: true, isActive: true },
+    })
+
+    if (owner?.isActive) {
+      const displayName =
+        [owner.firstName, owner.lastName].filter(Boolean).join(' ') || owner.email
+      return [{ kind: 'USER', userId: owner.id, email: owner.email, displayName }]
+    }
+    // Opiekun istnieje ale jest nieaktywny — przechodzimy do fallbacku
+  }
+
+  return resolveTeamFallbackRecipients()
+}
+
+async function resolveTeamFallbackRecipients(): Promise<NotificationRecipient[]> {
+  const setting = await prisma.systemSetting.findUnique({
+    where: { key: SYSTEM_SETTING_KEYS.PORTING_NOTIFY_SHARED_EMAILS },
+    select: { value: true },
+  })
+
+  const emails = (setting?.value ?? '')
+    .split(',')
+    .map((e: string) => e.trim())
+    .filter(Boolean)
+
+  if (emails.length === 0) {
+    return []
+  }
+
+  return [{ kind: 'TEAM_EMAIL', emails }]
+}

--- a/apps/backend/src/modules/porting-requests/porting-notification-recipient-resolver.ts
+++ b/apps/backend/src/modules/porting-requests/porting-notification-recipient-resolver.ts
@@ -1,31 +1,19 @@
 /**
- * Resolver odbiorców powiadomień wewnętrznych dla spraw portowania.
+ * Recipient resolver for internal porting notifications.
  *
- * Logika:
- *  1. Jeśli sprawa ma ustawionego opiekuna handlowego (commercialOwnerUserId)
- *     i jest on aktywnym użytkownikiem systemu → powiadomienie tylko do niego.
- *  2. Fallback — brak opiekuna lub użytkownik nieaktywny → powiadomienie
- *     do wspólnych odbiorców zespołowych (e-mail z system_settings).
- *
- * Zwracany typ jest rozszerzalny: w przyszłości można dodać
- *   { kind: 'TEAMS_WEBHOOK'; webhookUrl: string }
- * lub inne kanały bez zmiany interfejsu wywołującego.
+ * Routing rules:
+ * 1) active commercial owner -> USER recipient,
+ * 2) otherwise fallback to configured shared team recipients
+ *    (emails and optional Teams webhook).
  */
 
-import { prisma } from '../../config/database'
 import { SYSTEM_SETTING_KEYS } from '@np-manager/shared'
-
-// ============================================================
-// Typy odbiorców
-// ============================================================
+import { prisma } from '../../config/database'
 
 export type NotificationRecipient =
   | { kind: 'USER'; userId: string; email: string; displayName: string }
   | { kind: 'TEAM_EMAIL'; emails: string[] }
-
-// ============================================================
-// Resolver
-// ============================================================
+  | { kind: 'TEAM_WEBHOOK'; webhookUrl: string }
 
 export async function resolvePortingNotificationRecipients(
   commercialOwnerUserId: string | null | undefined,
@@ -39,28 +27,78 @@ export async function resolvePortingNotificationRecipients(
     if (owner?.isActive) {
       const displayName =
         [owner.firstName, owner.lastName].filter(Boolean).join(' ') || owner.email
+
       return [{ kind: 'USER', userId: owner.id, email: owner.email, displayName }]
     }
-    // Opiekun istnieje ale jest nieaktywny — przechodzimy do fallbacku
   }
 
   return resolveTeamFallbackRecipients()
 }
 
 async function resolveTeamFallbackRecipients(): Promise<NotificationRecipient[]> {
-  const setting = await prisma.systemSetting.findUnique({
-    where: { key: SYSTEM_SETTING_KEYS.PORTING_NOTIFY_SHARED_EMAILS },
-    select: { value: true },
-  })
+  const sharedEmailsValue = await readSettingValue([
+    SYSTEM_SETTING_KEYS.PORTING_STATUS_NOTIFY_SHARED_EMAILS,
+    SYSTEM_SETTING_KEYS.PORTING_NOTIFY_SHARED_EMAILS,
+  ])
 
-  const emails = (setting?.value ?? '')
-    .split(',')
-    .map((e: string) => e.trim())
-    .filter(Boolean)
+  const teamsEnabledValue = await readSettingValue([
+    SYSTEM_SETTING_KEYS.PORTING_STATUS_TEAMS_ENABLED,
+    SYSTEM_SETTING_KEYS.PORTING_NOTIFY_TEAMS_ENABLED,
+  ])
 
-  if (emails.length === 0) {
+  const teamsWebhookValue = await readSettingValue([
+    SYSTEM_SETTING_KEYS.PORTING_STATUS_NOTIFY_SHARED_TEAMS_WEBHOOK,
+    SYSTEM_SETTING_KEYS.PORTING_NOTIFY_TEAMS_WEBHOOK,
+  ])
+
+  const emails = toEmailList(sharedEmailsValue)
+  const teamsEnabled = parseBooleanSetting(teamsEnabledValue)
+  const teamsWebhookUrl = teamsWebhookValue?.trim() || null
+
+  const recipients: NotificationRecipient[] = []
+
+  if (emails.length > 0) {
+    recipients.push({ kind: 'TEAM_EMAIL', emails })
+  }
+
+  if (teamsEnabled && teamsWebhookUrl) {
+    recipients.push({ kind: 'TEAM_WEBHOOK', webhookUrl: teamsWebhookUrl })
+  }
+
+  return recipients
+}
+
+async function readSettingValue(keys: string[]): Promise<string | null> {
+  for (const key of keys) {
+    const setting = await prisma.systemSetting.findUnique({
+      where: { key },
+      select: { value: true },
+    })
+
+    if (setting?.value) {
+      return setting.value
+    }
+  }
+
+  return null
+}
+
+function toEmailList(rawValue: string | null): string[] {
+  if (!rawValue) {
     return []
   }
 
-  return [{ kind: 'TEAM_EMAIL', emails }]
+  return rawValue
+    .split(',')
+    .map((email) => email.trim())
+    .filter(Boolean)
+}
+
+function parseBooleanSetting(rawValue: string | null): boolean {
+  if (!rawValue) {
+    return false
+  }
+
+  const normalized = rawValue.trim().toLowerCase()
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on'
 }

--- a/apps/backend/src/modules/porting-requests/porting-notification.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-notification.service.ts
@@ -1,48 +1,31 @@
 /**
- * Foundation serwisu powiadomień wewnętrznych dla spraw portowania.
+ * Foundation internal notification dispatcher for porting requests.
  *
- * Odpowiada za:
- *  - rozwiązanie odbiorców (commercialOwner lub fallback zespołowy),
- *  - zapis śladu powiadomienia w modelu Notification (dla nazwanych użytkowników),
- *  - zapis zdarzenia NOTE w timeline sprawy (dla fallbacku zespołowego — brak userId),
- *  - budowanie treści powiadomienia na podstawie zdarzenia domenowego.
- *
- * Nie wysyła jeszcze e-maili ani webhooków Teams — to kolejny etap.
- * Architektura jest gotowa pod adapter transportowy (email/Teams).
+ * Responsibilities:
+ * - resolve recipients (commercial owner or team fallback),
+ * - persist Notification for named user recipients,
+ * - persist timeline note for shared recipients,
+ * - build event-specific notification copy.
  */
 
 import { prisma } from '../../config/database'
 import {
-  type PortingNotificationEvent,
   PORTING_NOTIFICATION_EVENT_LABELS,
+  type PortingNotificationEvent,
 } from './porting-notification-events'
 import { resolvePortingNotificationRecipients } from './porting-notification-recipient-resolver'
-
-// ============================================================
-// Typy
-// ============================================================
 
 export interface DispatchPortingNotificationParams {
   requestId: string
   caseNumber: string
   event: PortingNotificationEvent
-  /** ID opiekuna handlowego z pola commercialOwnerUserId — może być null. */
   commercialOwnerUserId: string | null | undefined
-  /** ID użytkownika wykonującego akcję — dołączany do zdarzenia fallbackowego. */
   actorUserId?: string
-  /** Dodatkowy kontekst biznesowy dla treści powiadomienia. */
   metadata?: Record<string, unknown>
 }
 
-// ============================================================
-// Dispatch
-// ============================================================
-
 /**
- * Dispatches a notification for a porting domain event.
- *
- * Non-blocking — należy wywoływać z .catch(() => {}) aby nie blokować
- * głównego flow API w razie błędu infrastruktury powiadomień.
+ * Non-blocking by design. Callers should use `.catch(() => {})`.
  */
 export async function dispatchPortingNotification(
   params: DispatchPortingNotificationParams,
@@ -50,18 +33,16 @@ export async function dispatchPortingNotification(
   const { requestId, caseNumber, event, commercialOwnerUserId, actorUserId, metadata } = params
 
   const recipients = await resolvePortingNotificationRecipients(commercialOwnerUserId)
-
   if (recipients.length === 0) {
     return
   }
 
   const eventLabel = PORTING_NOTIFICATION_EVENT_LABELS[event]
-  const title = `${eventLabel} — sprawa ${caseNumber}`
+  const title = `${eventLabel} - sprawa ${caseNumber}`
   const body = buildNotificationBody(event, metadata)
 
   for (const recipient of recipients) {
     if (recipient.kind === 'USER') {
-      // Zapis in-app Notification dla nazwanego użytkownika (opiekun handlowy)
       await prisma.notification.create({
         data: {
           userId: recipient.userId,
@@ -72,51 +53,62 @@ export async function dispatchPortingNotification(
           relatedEntityId: requestId,
         },
       })
-    } else if (recipient.kind === 'TEAM_EMAIL') {
-      // Fallback — brak userId, zapisujemy ślad w timeline sprawy
-      // TODO(PR13B): tu podłączyć faktyczny adapter e-mail lub Teams webhook
-      await prisma.portingRequestEvent.create({
-        data: {
-          request: { connect: { id: requestId } },
-          eventSource: 'INTERNAL',
-          eventType: 'NOTE',
-          title: `Powiadomienie zespołowe: ${eventLabel}`,
-          description: [
-            `Routing do: ${recipient.emails.join(', ')}.`,
-            metadata ? `Kontekst: ${JSON.stringify(metadata)}.` : null,
-          ]
-            .filter(Boolean)
-            .join(' '),
-          ...(actorUserId ? { createdBy: { connect: { id: actorUserId } } } : {}),
-        },
-      })
+      continue
     }
+
+    await prisma.portingRequestEvent.create({
+      data: {
+        request: { connect: { id: requestId } },
+        eventSource: 'INTERNAL',
+        eventType: 'NOTE',
+        title: `Powiadomienie zespolowe: ${eventLabel}`,
+        description: buildFallbackDescription(recipient, metadata),
+        ...(actorUserId ? { createdBy: { connect: { id: actorUserId } } } : {}),
+      },
+    })
   }
 }
 
-// ============================================================
-// Treść powiadomienia
-// ============================================================
+function buildFallbackDescription(
+  recipient: { kind: 'TEAM_EMAIL'; emails: string[] } | { kind: 'TEAM_WEBHOOK'; webhookUrl: string },
+  metadata?: Record<string, unknown>,
+): string {
+  const destination =
+    recipient.kind === 'TEAM_EMAIL'
+      ? `Routing do e-mail: ${recipient.emails.join(', ')}.`
+      : `Routing do Teams webhook: ${recipient.webhookUrl}.`
+
+  const metadataText = metadata ? ` Kontekst: ${safeJson(metadata)}.` : ''
+  return `${destination}${metadataText}`.trim()
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return '"[unserializable metadata]"'
+  }
+}
 
 function buildNotificationBody(
   event: PortingNotificationEvent,
   metadata?: Record<string, unknown>,
 ): string {
   if (event === 'REQUEST_CREATED') {
-    return 'Sprawa portowania została zarejestrowana i oczekuje na przetworzenie.'
+    return 'Sprawa portowania zostala zarejestrowana i oczekuje na przetworzenie.'
   }
 
   if (event === 'STATUS_CHANGED') {
     const status = metadata?.newStatus ?? 'nieznany'
-    return `Status sprawy został zmieniony na: ${status}.`
+    return `Status sprawy zostal zmieniony na: ${status}.`
   }
 
   if (event === 'COMMERCIAL_OWNER_CHANGED') {
     const ownerName = metadata?.newOwnerName
     return ownerName
-      ? `Opiekun handlowy sprawy został zmieniony na: ${ownerName}.`
-      : 'Opiekun handlowy sprawy został usunięty.'
+      ? `Opiekun handlowy sprawy zostal zmieniony na: ${ownerName}.`
+      : 'Opiekun handlowy sprawy zostal usuniety.'
   }
 
-  return 'Aktualizacja sprawy portowania.'
+  return 'Zarejestrowano nowe zdarzenie procesu portowania.'
 }

--- a/apps/backend/src/modules/porting-requests/porting-notification.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-notification.service.ts
@@ -1,0 +1,122 @@
+/**
+ * Foundation serwisu powiadomień wewnętrznych dla spraw portowania.
+ *
+ * Odpowiada za:
+ *  - rozwiązanie odbiorców (commercialOwner lub fallback zespołowy),
+ *  - zapis śladu powiadomienia w modelu Notification (dla nazwanych użytkowników),
+ *  - zapis zdarzenia NOTE w timeline sprawy (dla fallbacku zespołowego — brak userId),
+ *  - budowanie treści powiadomienia na podstawie zdarzenia domenowego.
+ *
+ * Nie wysyła jeszcze e-maili ani webhooków Teams — to kolejny etap.
+ * Architektura jest gotowa pod adapter transportowy (email/Teams).
+ */
+
+import { prisma } from '../../config/database'
+import {
+  type PortingNotificationEvent,
+  PORTING_NOTIFICATION_EVENT_LABELS,
+} from './porting-notification-events'
+import { resolvePortingNotificationRecipients } from './porting-notification-recipient-resolver'
+
+// ============================================================
+// Typy
+// ============================================================
+
+export interface DispatchPortingNotificationParams {
+  requestId: string
+  caseNumber: string
+  event: PortingNotificationEvent
+  /** ID opiekuna handlowego z pola commercialOwnerUserId — może być null. */
+  commercialOwnerUserId: string | null | undefined
+  /** ID użytkownika wykonującego akcję — dołączany do zdarzenia fallbackowego. */
+  actorUserId?: string
+  /** Dodatkowy kontekst biznesowy dla treści powiadomienia. */
+  metadata?: Record<string, unknown>
+}
+
+// ============================================================
+// Dispatch
+// ============================================================
+
+/**
+ * Dispatches a notification for a porting domain event.
+ *
+ * Non-blocking — należy wywoływać z .catch(() => {}) aby nie blokować
+ * głównego flow API w razie błędu infrastruktury powiadomień.
+ */
+export async function dispatchPortingNotification(
+  params: DispatchPortingNotificationParams,
+): Promise<void> {
+  const { requestId, caseNumber, event, commercialOwnerUserId, actorUserId, metadata } = params
+
+  const recipients = await resolvePortingNotificationRecipients(commercialOwnerUserId)
+
+  if (recipients.length === 0) {
+    return
+  }
+
+  const eventLabel = PORTING_NOTIFICATION_EVENT_LABELS[event]
+  const title = `${eventLabel} — sprawa ${caseNumber}`
+  const body = buildNotificationBody(event, metadata)
+
+  for (const recipient of recipients) {
+    if (recipient.kind === 'USER') {
+      // Zapis in-app Notification dla nazwanego użytkownika (opiekun handlowy)
+      await prisma.notification.create({
+        data: {
+          userId: recipient.userId,
+          type: event,
+          title,
+          body,
+          relatedEntityType: 'porting_request',
+          relatedEntityId: requestId,
+        },
+      })
+    } else if (recipient.kind === 'TEAM_EMAIL') {
+      // Fallback — brak userId, zapisujemy ślad w timeline sprawy
+      // TODO(PR13B): tu podłączyć faktyczny adapter e-mail lub Teams webhook
+      await prisma.portingRequestEvent.create({
+        data: {
+          request: { connect: { id: requestId } },
+          eventSource: 'INTERNAL',
+          eventType: 'NOTE',
+          title: `Powiadomienie zespołowe: ${eventLabel}`,
+          description: [
+            `Routing do: ${recipient.emails.join(', ')}.`,
+            metadata ? `Kontekst: ${JSON.stringify(metadata)}.` : null,
+          ]
+            .filter(Boolean)
+            .join(' '),
+          ...(actorUserId ? { createdBy: { connect: { id: actorUserId } } } : {}),
+        },
+      })
+    }
+  }
+}
+
+// ============================================================
+// Treść powiadomienia
+// ============================================================
+
+function buildNotificationBody(
+  event: PortingNotificationEvent,
+  metadata?: Record<string, unknown>,
+): string {
+  if (event === 'REQUEST_CREATED') {
+    return 'Sprawa portowania została zarejestrowana i oczekuje na przetworzenie.'
+  }
+
+  if (event === 'STATUS_CHANGED') {
+    const status = metadata?.newStatus ?? 'nieznany'
+    return `Status sprawy został zmieniony na: ${status}.`
+  }
+
+  if (event === 'COMMERCIAL_OWNER_CHANGED') {
+    const ownerName = metadata?.newOwnerName
+    return ownerName
+      ? `Opiekun handlowy sprawy został zmieniony na: ${ownerName}.`
+      : 'Opiekun handlowy sprawy został usunięty.'
+  }
+
+  return 'Aktualizacja sprawy portowania.'
+}

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -9,6 +9,7 @@ import {
   portingRequestListQuerySchema,
   preparePortingCommunicationDraftSchema,
   updatePortingRequestAssignmentSchema,
+  updatePortingRequestCommercialOwnerSchema,
   updatePortingRequestStatusSchema,
 } from './porting-requests.schema'
 import {
@@ -20,9 +21,11 @@ import {
   getPortingRequestIntegrationEvents,
   getPortingRequest,
   listAssignablePortingRequestUsers,
+  listCommercialOwnerCandidates,
   listPortingRequests,
   syncPortingRequestFromPliCbd,
   updatePortingRequestAssignment,
+  updateCommercialOwner,
   updatePortingRequestStatus,
 } from './porting-requests.service'
 import {
@@ -66,6 +69,7 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
   ]
   const writeRoles: UserRole[] = ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER']
   const assignmentWriteRoles: UserRole[] = ['ADMIN', 'BOK_CONSULTANT']
+  const commercialOwnerWriteRoles: UserRole[] = ['ADMIN', 'BOK_CONSULTANT', 'MANAGER']
   const externalActionRoles: UserRole[] = ['ADMIN', 'BACK_OFFICE', 'MANAGER']
   const pliCbdRoles: UserRole[] = ['ADMIN']
 
@@ -81,6 +85,32 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
     async (_request, reply) => {
       const result = await listAssignablePortingRequestUsers()
       return reply.status(200).send({ success: true, data: result })
+    },
+  )
+
+  app.get(
+    '/commercial-owner-candidates',
+    { preHandler: [authenticate, authorize(commercialOwnerWriteRoles)] },
+    async (_request, reply) => {
+      const result = await listCommercialOwnerCandidates()
+      return reply.status(200).send({ success: true, data: result })
+    },
+  )
+
+  app.patch<{ Params: { id: string } }>(
+    '/:id/commercial-owner',
+    { preHandler: [authenticate, authorize(commercialOwnerWriteRoles)] },
+    async (request, reply) => {
+      const body = updatePortingRequestCommercialOwnerSchema.parse(request.body)
+      const result = await updateCommercialOwner(
+        request.params.id,
+        body,
+        request.user.id,
+        request.user.role as UserRole,
+        request.ip,
+        request.headers['user-agent'],
+      )
+      return reply.status(200).send({ success: true, data: { request: result } })
     },
   )
 

--- a/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
@@ -365,6 +365,16 @@ export const updatePortingRequestAssignmentSchema = z.object({
 export type UpdatePortingRequestAssignmentBody =
   z.infer<typeof updatePortingRequestAssignmentSchema>
 
+export const updatePortingRequestCommercialOwnerSchema = z.object({
+  commercialOwnerUserId: z.preprocess(
+    (value) => (value === '' ? null : value),
+    z.string().uuid().nullable(),
+  ),
+})
+
+export type UpdatePortingRequestCommercialOwnerBody =
+  z.infer<typeof updatePortingRequestCommercialOwnerSchema>
+
 export const preparePortingCommunicationDraftSchema = z.object({
   actionType: z
     .enum([

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -1169,6 +1169,19 @@ export async function updateCommercialOwner(
 ): Promise<PortingRequestDetailDto> {
   const nextOwnerId = body.commercialOwnerUserId
 
+  const current = await prisma.portingRequest.findUnique({
+    where: { id: requestId },
+    select: { id: true, caseNumber: true, commercialOwnerUserId: true },
+  })
+
+  if (!current) {
+    throw AppError.notFound('Sprawa portowania nie została znaleziona.')
+  }
+
+  if (current.commercialOwnerUserId === nextOwnerId) {
+    return getPortingRequest(requestId, userRole)
+  }
+
   if (nextOwnerId) {
     const candidate = await prisma.user.findUnique({
       where: { id: nextOwnerId },
@@ -1192,19 +1205,6 @@ export async function updateCommercialOwner(
         'COMMERCIAL_OWNER_INVALID_ROLE',
       )
     }
-  }
-
-  const current = await prisma.portingRequest.findUnique({
-    where: { id: requestId },
-    select: { id: true, caseNumber: true, commercialOwnerUserId: true },
-  })
-
-  if (!current) {
-    throw AppError.notFound('Sprawa portowania nie została znaleziona.')
-  }
-
-  if (current.commercialOwnerUserId === nextOwnerId) {
-    return getPortingRequest(requestId, userRole)
   }
 
   await prisma.portingRequest.update({

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -4,6 +4,8 @@ import { AppError } from '../../shared/errors/app-error'
 import { logAuditEvent } from '../../shared/audit/audit.service'
 import { PortingEvents } from './porting-events.service'
 import type {
+  CommercialOwnerCandidatesResultDto,
+  CommercialOwnerSummaryDto,
   CreatePortingRequestDto,
   ExecutePortingRequestExternalActionResultDto,
   PortingRequestAssigneeSummaryDto,
@@ -24,8 +26,11 @@ import type {
   ExecutePortingRequestExternalActionBody,
   PortingRequestListQuery,
   UpdatePortingRequestAssignmentBody,
+  UpdatePortingRequestCommercialOwnerBody,
   UpdatePortingRequestStatusBody,
 } from './porting-requests.schema'
+import { dispatchPortingNotification } from './porting-notification.service'
+import { PORTING_NOTIFICATION_EVENT } from './porting-notification-events'
 import {
   PLI_CBD_TRIGGER_SELECT,
   type PliCbdTriggerRow,
@@ -155,6 +160,7 @@ const DETAIL_SELECT = {
   createdByUserId: true,
   assignedAt: true,
   assignedByUserId: true,
+  commercialOwnerUserId: true,
   createdAt: true,
   updatedAt: true,
   client: { select: CLIENT_SELECT },
@@ -162,6 +168,7 @@ const DETAIL_SELECT = {
   recipientOperator: { select: OPERATOR_SELECT },
   infrastructureOperator: { select: OPERATOR_SELECT },
   assignedUser: { select: ASSIGNEE_SELECT },
+  commercialOwner: { select: ASSIGNEE_SELECT },
 } as const
 
 type ClientRow = Prisma.ClientGetPayload<{ select: typeof CLIENT_SELECT }>
@@ -252,6 +259,19 @@ function getUserDisplayName(user: {
 }
 
 function toAssigneeSummary(user: AssigneeRow | null | undefined): PortingRequestAssigneeSummaryDto | null {
+  if (!user) {
+    return null
+  }
+
+  return {
+    id: user.id,
+    email: user.email,
+    displayName: getUserDisplayName(user),
+    role: user.role,
+  }
+}
+
+function toCommercialOwnerSummary(user: AssigneeRow | null | undefined): CommercialOwnerSummaryDto | null {
   if (!user) {
     return null
   }
@@ -705,6 +725,7 @@ function toDetailDto(
     assignedUser: toAssigneeSummary(row.assignedUser),
     assignedAt: row.assignedAt?.toISOString() ?? null,
     assignedByUserId: row.assignedByUserId,
+    commercialOwner: toCommercialOwnerSummary(row.commercialOwner),
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),
     availableStatusActions: getAvailableStatusActions(row.statusInternal, actorRole),
@@ -1123,7 +1144,126 @@ export async function updatePortingRequestStatus(
   userAgent?: string,
 ): Promise<PortingRequestDetailDto> {
   await changePortingRequestStatus(requestId, body, userId, userRole, ipAddress, userAgent)
-  return getPortingRequest(requestId, userRole)
+  const updated = await getPortingRequest(requestId, userRole)
+
+  // Powiadomienie wewnętrzne — non-blocking, nie blokuje odpowiedzi API
+  dispatchPortingNotification({
+    requestId,
+    caseNumber: updated.caseNumber,
+    event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+    commercialOwnerUserId: updated.commercialOwner?.id ?? null,
+    actorUserId: userId,
+    metadata: { newStatus: updated.statusInternal },
+  }).catch(() => {})
+
+  return updated
+}
+
+export async function updateCommercialOwner(
+  requestId: string,
+  body: UpdatePortingRequestCommercialOwnerBody,
+  userId: string,
+  userRole: UserRole,
+  ipAddress?: string,
+  userAgent?: string,
+): Promise<PortingRequestDetailDto> {
+  const nextOwnerId = body.commercialOwnerUserId
+
+  if (nextOwnerId) {
+    const candidate = await prisma.user.findUnique({
+      where: { id: nextOwnerId },
+      select: { id: true, role: true, isActive: true, firstName: true, lastName: true },
+    })
+
+    if (!candidate) {
+      throw AppError.notFound('Wskazany opiekun handlowy nie został znaleziony.')
+    }
+
+    if (!candidate.isActive) {
+      throw AppError.badRequest(
+        'Wskazany użytkownik jest nieaktywny i nie może pełnić roli opiekuna handlowego.',
+        'COMMERCIAL_OWNER_INACTIVE',
+      )
+    }
+
+    if (candidate.role !== 'SALES') {
+      throw AppError.badRequest(
+        'Opiekunem handlowym może zostać wyłącznie użytkownik z rolą Opiekun Handlowy (SALES).',
+        'COMMERCIAL_OWNER_INVALID_ROLE',
+      )
+    }
+  }
+
+  const current = await prisma.portingRequest.findUnique({
+    where: { id: requestId },
+    select: { id: true, caseNumber: true, commercialOwnerUserId: true },
+  })
+
+  if (!current) {
+    throw AppError.notFound('Sprawa portowania nie została znaleziona.')
+  }
+
+  if (current.commercialOwnerUserId === nextOwnerId) {
+    return getPortingRequest(requestId, userRole)
+  }
+
+  await prisma.portingRequest.update({
+    where: { id: requestId },
+    data: { commercialOwnerUserId: nextOwnerId },
+  })
+
+  await logAuditEvent({
+    action: 'UPDATE',
+    userId,
+    entityType: 'porting_request',
+    entityId: requestId,
+    requestId,
+    fieldName: 'commercialOwnerUserId',
+    oldValue: current.commercialOwnerUserId ?? 'BRAK',
+    newValue: nextOwnerId ?? 'BRAK',
+    ipAddress,
+    userAgent,
+  })
+
+  const updated = await getPortingRequest(requestId, userRole)
+
+  // Powiadomienie wewnętrzne — non-blocking
+  dispatchPortingNotification({
+    requestId,
+    caseNumber: updated.caseNumber,
+    event: PORTING_NOTIFICATION_EVENT.COMMERCIAL_OWNER_CHANGED,
+    commercialOwnerUserId: nextOwnerId,
+    actorUserId: userId,
+    metadata: {
+      newOwnerName: updated.commercialOwner?.displayName ?? null,
+    },
+  }).catch(() => {})
+
+  return updated
+}
+
+export async function listCommercialOwnerCandidates(): Promise<CommercialOwnerCandidatesResultDto> {
+  const rows = await prisma.user.findMany({
+    where: { isActive: true, role: 'SALES' },
+    select: {
+      id: true,
+      email: true,
+      firstName: true,
+      lastName: true,
+      role: true,
+    },
+    orderBy: [{ lastName: 'asc' }, { firstName: 'asc' }],
+  })
+
+  return {
+    users: rows.map((row) => ({
+      id: row.id,
+      email: row.email,
+      firstName: row.firstName,
+      lastName: row.lastName,
+      role: row.role as UserRole,
+    })),
+  }
 }
 
 export async function executePortingRequestExternalAction(

--- a/apps/backend/src/modules/users/users.schema.ts
+++ b/apps/backend/src/modules/users/users.schema.ts
@@ -14,6 +14,7 @@ const userRoleValues = [
   'TECHNICAL',
   'LEGAL',
   'AUDITOR',
+  'SALES',
 ] as const
 
 /**

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -30,7 +30,9 @@ import {
   type PliCbdTechnicalPayloadApiMessageType,
   syncPortingRequest,
   updatePortingRequestAssignment,
+  updatePortingRequestCommercialOwner,
   updatePortingRequestStatus,
+  listCommercialOwnerCandidates,
 } from '@/services/portingRequests.api'
 import {
   CONTACT_CHANNEL_LABELS,
@@ -60,6 +62,7 @@ import {
   type PortingRequestExternalActionDto,
   type PortingRequestAssignmentHistoryItemDto,
   type PortingRequestStatusActionDto,
+  type CommercialOwnerCandidateDto,
 } from '@np-manager/shared'
 import { PortingAssignmentPanel } from '@/components/PortingAssignmentPanel/PortingAssignmentPanel'
 import { PortingCaseHistory } from '@/components/PortingCaseHistory/PortingCaseHistory'
@@ -333,6 +336,13 @@ export function RequestDetailPage() {
   const [isUpdatingAssignment, setIsUpdatingAssignment] = useState(false)
   const [isUnassigning, setIsUnassigning] = useState(false)
 
+  const [commercialOwnerCandidates, setCommercialOwnerCandidates] = useState<CommercialOwnerCandidateDto[]>([])
+  const [isCommercialOwnerCandidatesLoading, setIsCommercialOwnerCandidatesLoading] = useState(false)
+  const [commercialOwnerDraft, setCommercialOwnerDraft] = useState<string>('')
+  const [isUpdatingCommercialOwner, setIsUpdatingCommercialOwner] = useState(false)
+  const [commercialOwnerFeedbackError, setCommercialOwnerFeedbackError] = useState<string | null>(null)
+  const [commercialOwnerFeedbackSuccess, setCommercialOwnerFeedbackSuccess] = useState<string | null>(null)
+
   const [communicationItems, setCommunicationItems] = useState<PortingCommunicationDto[]>([])
   const [isCommunicationLoading, setIsCommunicationLoading] = useState(true)
   const [communicationPreview, setCommunicationPreview] = useState<PortingCommunicationPreviewDto | null>(null)
@@ -408,6 +418,10 @@ export function RequestDetailPage() {
   const isAdmin = useMemo(() => user?.role === 'ADMIN', [user?.role])
   const canManageAssignment = useMemo(() => canManagePortingOwnership(user?.role), [user?.role])
   const canSelectAssignee = useMemo(() => canSelectAnyAssignee(user?.role), [user?.role])
+  const canManageCommercialOwner = useMemo(
+    () => ['ADMIN', 'BOK_CONSULTANT', 'MANAGER'].includes(user?.role ?? ''),
+    [user?.role],
+  )
   const assigneeOptions = useMemo(
     () =>
       assignableUsers.map((candidate) => ({
@@ -498,6 +512,7 @@ export function RequestDetailPage() {
       const nextRequest = await getPortingRequestById(id)
       setRequest(nextRequest)
       setAssigneeDraft(nextRequest.assignedUser?.id ?? '')
+      setCommercialOwnerDraft(nextRequest.commercialOwner?.id ?? '')
       setSelectedStatusAction((current) =>
         current
           ? nextRequest.availableStatusActions.find(
@@ -573,6 +588,24 @@ export function RequestDetailPage() {
       setIsAssignableUsersLoading(false)
     }
   }, [canSelectAssignee])
+
+  const loadCommercialOwnerCandidates = useCallback(async () => {
+    if (!canManageCommercialOwner) {
+      setCommercialOwnerCandidates([])
+      setIsCommercialOwnerCandidatesLoading(false)
+      return
+    }
+
+    setIsCommercialOwnerCandidatesLoading(true)
+    try {
+      const result = await listCommercialOwnerCandidates()
+      setCommercialOwnerCandidates(result.users)
+    } catch {
+      setCommercialOwnerCandidates([])
+    } finally {
+      setIsCommercialOwnerCandidatesLoading(false)
+    }
+  }, [canManageCommercialOwner])
 
   const loadCommunicationHistory = useCallback(async () => {
     if (!id) return
@@ -763,6 +796,7 @@ export function RequestDetailPage() {
     void loadCaseHistory()
     void loadAssignmentHistory()
     void loadAssignableUsers()
+    void loadCommercialOwnerCandidates()
     void loadCommunicationHistory()
     void loadIntegrationEvents()
     void loadProcessSnapshot()
@@ -774,6 +808,7 @@ export function RequestDetailPage() {
     loadAssignableUsers,
     loadAssignmentHistory,
     loadCaseHistory,
+    loadCommercialOwnerCandidates,
     loadCommunicationHistory,
     loadIntegrationEvents,
     loadProcessSnapshot,
@@ -794,6 +829,40 @@ export function RequestDetailPage() {
     setAssignmentFeedbackError(null)
     setAssignmentFeedbackSuccess(null)
   }, [])
+
+  const clearCommercialOwnerFeedback = useCallback(() => {
+    setCommercialOwnerFeedbackError(null)
+    setCommercialOwnerFeedbackSuccess(null)
+  }, [])
+
+  const handleUpdateCommercialOwner = useCallback(
+    async (newOwnerId: string | null) => {
+      if (!id || !canManageCommercialOwner || isUpdatingCommercialOwner) return
+
+      clearCommercialOwnerFeedback()
+      setIsUpdatingCommercialOwner(true)
+
+      try {
+        const updatedRequest = await updatePortingRequestCommercialOwner(id, {
+          commercialOwnerUserId: newOwnerId,
+        })
+        setRequest(updatedRequest)
+        setCommercialOwnerDraft(updatedRequest.commercialOwner?.id ?? '')
+        setCommercialOwnerFeedbackSuccess(
+          newOwnerId ? 'Opiekun handlowy zostal przypisany.' : 'Opiekun handlowy zostal usunieto.',
+        )
+      } catch (errorValue) {
+        const message =
+          axios.isAxiosError(errorValue) && errorValue.response?.data?.error?.message
+            ? String(errorValue.response.data.error.message)
+            : 'Nie udalo sie zaktualizowac opiekuna handlowego.'
+        setCommercialOwnerFeedbackError(message)
+      } finally {
+        setIsUpdatingCommercialOwner(false)
+      }
+    },
+    [canManageCommercialOwner, clearCommercialOwnerFeedback, id, isUpdatingCommercialOwner],
+  )
 
   const applyUpdatedAssignment = useCallback(
     (updatedRequest: PortingRequestDetailDto) => {
@@ -1538,6 +1607,80 @@ export function RequestDetailPage() {
             onUpdateAssignment={() => void handleUpdateAssignment()}
             onUnassign={() => void handleUnassign()}
           />
+
+          <SectionCard
+            title="Opiekun handlowy"
+            description="Opcjonalny opiekun handlowy odpowiedzialny za relacje z klientem."
+          >
+            <div className="space-y-3">
+              <div>
+                <span className="block text-xs font-medium text-gray-500">Aktualny opiekun</span>
+                {request.commercialOwner ? (
+                  <span className="mt-0.5 block text-sm font-medium text-gray-900">
+                    {request.commercialOwner.displayName}{' '}
+                    <span className="font-normal text-gray-500">({request.commercialOwner.email})</span>
+                  </span>
+                ) : (
+                  <span className="mt-0.5 block text-sm text-gray-400">Brak przypisanego opiekuna</span>
+                )}
+              </div>
+
+              {canManageCommercialOwner && (
+                <div className="space-y-2">
+                  <label className="block">
+                    <span className="mb-1 block text-xs font-medium text-gray-600">
+                      Zmien opiekuna handlowego
+                    </span>
+                    <select
+                      value={commercialOwnerDraft}
+                      onChange={(e) => setCommercialOwnerDraft(e.target.value)}
+                      disabled={isUpdatingCommercialOwner || isCommercialOwnerCandidatesLoading}
+                      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-100 disabled:bg-gray-50 disabled:text-gray-400"
+                    >
+                      <option value="">— brak —</option>
+                      {commercialOwnerCandidates.map((candidate) => (
+                        <option key={candidate.id} value={candidate.id}>
+                          {candidate.firstName} {candidate.lastName} ({candidate.email})
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => void handleUpdateCommercialOwner(commercialOwnerDraft || null)}
+                      disabled={isUpdatingCommercialOwner || isCommercialOwnerCandidatesLoading}
+                      className="btn-primary"
+                    >
+                      {isUpdatingCommercialOwner ? 'Zapisywanie...' : 'Zapisz'}
+                    </button>
+                    {request.commercialOwner && (
+                      <button
+                        type="button"
+                        onClick={() => void handleUpdateCommercialOwner(null)}
+                        disabled={isUpdatingCommercialOwner}
+                        className="btn-secondary"
+                      >
+                        Usun opiekuna
+                      </button>
+                    )}
+                  </div>
+                </div>
+              )}
+
+              {commercialOwnerFeedbackSuccess && (
+                <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+                  {commercialOwnerFeedbackSuccess}
+                </div>
+              )}
+              {commercialOwnerFeedbackError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                  {commercialOwnerFeedbackError}
+                </div>
+              )}
+            </div>
+          </SectionCard>
 
           <SectionCard
             title="Akcje"

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -1,5 +1,7 @@
 import { apiClient } from './api.client'
 import type {
+  CommercialOwnerCandidatesResultDto,
+  UpdatePortingRequestCommercialOwnerDto,
   CommunicationDeliveryAttemptsResultDto,
   CreatePortingRequestDto,
   ExecutePortingRequestExternalActionDto,
@@ -37,6 +39,7 @@ export interface UpdatePortingRequestAssignmentPayload {
 export type PliCbdTechnicalPayloadApiMessageType = 'e03' | 'e12' | 'e18' | 'e23'
 export type PreparePortingCommunicationDraftPayload = PreparePortingCommunicationDraftDto
 export type ExecutePortingRequestExternalActionPayload = ExecutePortingRequestExternalActionDto
+export type UpdatePortingRequestCommercialOwnerPayload = UpdatePortingRequestCommercialOwnerDto
 
 export async function getPortingRequests(
   params: GetPortingRequestsParams = {},
@@ -360,4 +363,25 @@ export async function triggerManualPliCbdExport(
   }>(`/porting-requests/${id}/pli-cbd-exports/${messageType.toLowerCase()}/manual`)
 
   return response.data.data.exportResult
+}
+
+export async function listCommercialOwnerCandidates(): Promise<CommercialOwnerCandidatesResultDto> {
+  const response = await apiClient.get<{
+    success: true
+    data: CommercialOwnerCandidatesResultDto
+  }>('/porting-requests/commercial-owner-candidates')
+
+  return response.data.data
+}
+
+export async function updatePortingRequestCommercialOwner(
+  id: string,
+  data: UpdatePortingRequestCommercialOwnerPayload,
+): Promise<PortingRequestDetailDto> {
+  const response = await apiClient.patch<{
+    success: true
+    data: { request: PortingRequestDetailDto }
+  }>(`/porting-requests/${id}/commercial-owner`, data)
+
+  return response.data.data.request
 }

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -1,0 +1,120 @@
+# NP-Manager — Project Continuity Guide
+
+Dokument przeznaczony dla agentów AI i deweloperów przejmujących pracę nad projektem.
+Opisuje stan implementacji, architekturę decyzji i zasady kontynuowania pracy.
+
+---
+
+## Aktualny stan projektu (2026-04-09)
+
+### Zrealizowane PR-y
+
+| PR      | Opis                                                              | Status |
+|---------|-------------------------------------------------------------------|--------|
+| PR11A   | Backend foundation — użytkownicy admin, role, JWT auth            | ✅     |
+| PR11B   | Frontend — panel admina użytkowników                              | ✅     |
+| PR12D   | Ownership filter (MINE/UNASSIGNED) przeniesiony na backend        | ✅     |
+| PR13A   | Opiekun handlowy (SALES) + fundament powiadomień wewnętrznych     | ✅     |
+
+---
+
+## Architektura decyzji
+
+### Model ownership spraw portowania
+
+Sprawa portowania ma **dwa niezależne pola powiązania z użytkownikami**:
+
+- **`assignedUserId`** — operacyjny właściciel ze strony BOK (kto obsługuje sprawę),  
+  role: BOK_CONSULTANT, BACK_OFFICE, MANAGER, ADMIN
+- **`commercialOwnerUserId`** — opiekun handlowy odpowiedzialny za relację z klientem,  
+  wyłącznie rola SALES
+
+Oba pola są opcjonalne i niezależne — zmiana jednego nie wpływa na drugie.
+
+### Notyfikacje wewnętrzne (fundament PR13A)
+
+System notyfikacji używa dwóch ścieżek:
+
+1. **`Notification` (DB record)** — gdy istnieje aktywny `commercialOwner` → zapis na konkretnego `userId`
+2. **`PortingRequestEvent` NOTE** — fallback gdy brak opiekuna lub jest nieaktywny → zapis do dziennika sprawy  
+   *(Notification wymaga non-null `userId`, więc nie można go użyć dla odbiorców "zespołowych")*
+
+Dispatch jest **non-blocking** (fire-and-forget z `.catch(() => {})`), więc awaria powiadomienia nie blokuje odpowiedzi API.
+
+### System settings kluczowe dla powiadomień
+
+| Klucz                                 | Opis                                         |
+|---------------------------------------|----------------------------------------------|
+| `porting_notify_shared_emails`        | Lista e-maili zespołu (CSV), fallback recipient |
+| `porting_notify_teams_enabled`        | Flaga włączenia MS Teams webhook              |
+| `porting_notify_teams_webhook`        | URL webhooka MS Teams                        |
+
+Klucze są zdefiniowane w `packages/shared/src/constants/index.ts` → `SYSTEM_SETTING_KEYS`.
+
+---
+
+## Konwencje kodowania
+
+### Backend
+
+- **Prisma `$transaction`**: w kodzie używamy `prisma.$transaction([promise1, promise2])` (tablica Promise, NIE funkcja). Mocki w testach:  
+  ```typescript
+  mockPrismaTransaction.mockImplementation(async (arg: unknown) => {
+    if (Array.isArray(arg)) return Promise.all(arg)
+    // ...
+  })
+  ```
+- **AppError**: zawsze `AppError.notFound()` / `AppError.badRequest(msg, code)` — nigdy `throw new Error()`
+- **AuditLog**: każda mutacja musi logować przez `logAuditEvent()` z `apps/backend/src/shared/audit/audit.service.ts`
+- **Zod schemas**: każdy endpoint ma schemat w `*.schema.ts` z walidacją przez Fastify `preHandler`
+
+### Frontend
+
+- **URL-driven state**: filtry listy spraw są w URL params, nie w lokalnym state
+- **Ownership filter security**: backend używa `request.user.id` z JWT dla filtru `MINE` — frontend nigdy nie wysyła userId
+- **API functions**: w `apps/frontend/src/services/portingRequests.api.ts`, zawsze async, zwracają już rozwinięte DTO (nie wrapper `{ success, data }`)
+
+---
+
+## Struktura kluczowych plików
+
+```
+apps/backend/src/modules/porting-requests/
+  porting-requests.service.ts          # Główny serwis — logika biznesowa
+  porting-requests.router.ts           # Fastify routes + autoryzacja
+  porting-requests.schema.ts           # Zod schemas dla request body/query
+  porting-notification-events.ts       # Enum zdarzeń powiadomień
+  porting-notification-recipient-resolver.ts  # Resolver odbiorców
+  porting-notification.service.ts      # Dispatch powiadomień
+
+apps/backend/prisma/
+  schema.prisma                        # Główny schemat Prisma
+  migrations/                          # Historia migracji SQL
+
+packages/shared/src/
+  dto/porting-requests.dto.ts          # Kontrakty DTO (frontend ↔ backend)
+  constants/index.ts                   # USER_ROLES, SYSTEM_SETTING_KEYS, etc.
+
+apps/frontend/src/
+  services/portingRequests.api.ts      # Funkcje API klienta
+  pages/Requests/RequestDetailPage.tsx # Strona szczegółów sprawy (duża, ~1750 linii)
+```
+
+---
+
+## Zasady kontynuowania pracy
+
+1. **Zawsze uruchamiaj testy** przed commitem: `npx vitest run` w obu apps
+2. **Po zmianie Prisma schema** uruchom `npx prisma generate --no-engine` (lub poczekaj na zwolnienie DLL przez inne procesy i uruchom bez flagi)
+3. **TypeScript check**: `npx tsc --noEmit` — oba projekty muszą przechodzić bez błędów
+4. **Shared package**: zmiany w `packages/shared` wymagają aktualizacji DTOs **i** stałych — oba są eksportowane przez `@np-manager/shared`
+5. **Branch naming**: `prXXy/short-description` (np. `pr13b/notification-dispatch`)
+6. **Commit prefix**: `feat(prXXy): opis`
+
+---
+
+## Planowane kolejne kroki
+
+- **PR13B**: Faktyczny dispatch e-mail/Teams — implementacja serwisu wysyłki opartego o ustawienia systemowe
+- **PR14**: Historia powiadomień w UI + panel ustawień systemowych dla admina
+- **PR15**: Rozszerzenie opiekuna handlowego — raportowanie, widok "moje sprawy" dla SALES

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -1,7 +1,6 @@
-# NP-Manager — Project Continuity Guide
+# NP-Manager - Project Continuity Guide
 
-Dokument przeznaczony dla agentów AI i deweloperów przejmujących pracę nad projektem.
-Opisuje stan implementacji, architekturę decyzji i zasady kontynuowania pracy.
+Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architektoniczne i zasady kontynuacji.
 
 ---
 
@@ -9,112 +8,117 @@ Opisuje stan implementacji, architekturę decyzji i zasady kontynuowania pracy.
 
 ### Zrealizowane PR-y
 
-| PR      | Opis                                                              | Status |
-|---------|-------------------------------------------------------------------|--------|
-| PR11A   | Backend foundation — użytkownicy admin, role, JWT auth            | ✅     |
-| PR11B   | Frontend — panel admina użytkowników                              | ✅     |
-| PR12D   | Ownership filter (MINE/UNASSIGNED) przeniesiony na backend        | ✅     |
-| PR13A   | Opiekun handlowy (SALES) + fundament powiadomień wewnętrznych     | ✅     |
+| PR    | Opis                                                                 | Status |
+|-------|----------------------------------------------------------------------|--------|
+| PR11A | Backend foundation - uzytkownicy admin, role, JWT auth              | DONE   |
+| PR11B | Frontend - panel admina uzytkownikow                                | DONE   |
+| PR12D | Ownership filter (MINE/UNASSIGNED) przeniesiony na backend          | DONE   |
+| PR13A | Commercial owner (SALES) + foundation internal event notifications  | DONE   |
 
 ---
 
-## Architektura decyzji
+## Kluczowe decyzje domenowe
 
-### Model ownership spraw portowania
+### Ownership spraw portowania
 
-Sprawa portowania ma **dwa niezależne pola powiązania z użytkownikami**:
+- Biznesowo sprawa nalezy operacyjnie do **zespolu BOK**.
+- `assignedUserId` pozostaje tymczasowo jako mechanizm techniczny/historyczny i jest utrzymany addytywnie.
+- Glowny nowy model biznesowy PR13A: opcjonalny `commercialOwnerUserId` (`User.role = SALES`) na `PortingRequest`.
+- `commercialOwnerUserId` nie usuwa ani nie nadpisuje istniejacego assignmentu BOK, ale jest osia routingu notyfikacji wewnetrznych.
 
-- **`assignedUserId`** — operacyjny właściciel ze strony BOK (kto obsługuje sprawę),  
-  role: BOK_CONSULTANT, BACK_OFFICE, MANAGER, ADMIN
-- **`commercialOwnerUserId`** — opiekun handlowy odpowiedzialny za relację z klientem,  
-  wyłącznie rola SALES
+Future note:
+- W kolejnych etapach mozna rozwazyc domyslnego commercial ownera na poziomie `Client`, ale PR13A celowo wdraza foundation na poziomie `PortingRequest`.
 
-Oba pola są opcjonalne i niezależne — zmiana jednego nie wpływa na drugie.
+### Notyfikacje wewnetrzne (event-driven foundation)
 
-### Notyfikacje wewnętrzne (fundament PR13A)
+Architektura rozdziela trzy warstwy:
 
-System notyfikacji używa dwóch ścieżek:
+1. **Event domenowy** (`PortingNotificationEvent`)
+2. **Resolver odbiorcow** (owner -> USER, fallback -> TEAM_EMAIL / TEAM_WEBHOOK)
+3. **Trace**
+   - `Notification` dla odbiorcy typu USER,
+   - `PortingRequestEvent` typu NOTE dla fallbacku zespolowego bez konkretnego `userId`.
 
-1. **`Notification` (DB record)** — gdy istnieje aktywny `commercialOwner` → zapis na konkretnego `userId`
-2. **`PortingRequestEvent` NOTE** — fallback gdy brak opiekuna lub jest nieaktywny → zapis do dziennika sprawy  
-   *(Notification wymaga non-null `userId`, więc nie można go użyć dla odbiorców "zespołowych")*
+Dispatch jest non-blocking (`.catch(() => {})`) i nie blokuje glownego flow API.
 
-Dispatch jest **non-blocking** (fire-and-forget z `.catch(() => {})`), więc awaria powiadomienia nie blokuje odpowiedzi API.
+### Katalog eventow foundation
 
-### System settings kluczowe dla powiadomień
+- `REQUEST_CREATED`
+- `STATUS_CHANGED` (realnie podlaczony)
+- `E03_SENT`
+- `E06_RECEIVED`
+- `PORT_DATE_CONFIRMED`
+- `E12_SENT`
+- `E13_RECEIVED`
+- `NUMBER_PORTED`
+- `CASE_REJECTED`
+- `COMMERCIAL_OWNER_CHANGED`
 
-| Klucz                                 | Opis                                         |
-|---------------------------------------|----------------------------------------------|
-| `porting_notify_shared_emails`        | Lista e-maili zespołu (CSV), fallback recipient |
-| `porting_notify_teams_enabled`        | Flaga włączenia MS Teams webhook              |
-| `porting_notify_teams_webhook`        | URL webhooka MS Teams                        |
+W PR13A aktywnie podlaczony jest bezpieczny hook `STATUS_CHANGED` (+ zmiana ownera). Pozostale eventy sa gotowe jako punkt rozszerzenia.
 
-Klucze są zdefiniowane w `packages/shared/src/constants/index.ts` → `SYSTEM_SETTING_KEYS`.
+### Rozdzial odpowiedzialnosci komunikacyjnych
 
----
-
-## Konwencje kodowania
-
-### Backend
-
-- **Prisma `$transaction`**: w kodzie używamy `prisma.$transaction([promise1, promise2])` (tablica Promise, NIE funkcja). Mocki w testach:  
-  ```typescript
-  mockPrismaTransaction.mockImplementation(async (arg: unknown) => {
-    if (Array.isArray(arg)) return Promise.all(arg)
-    // ...
-  })
-  ```
-- **AppError**: zawsze `AppError.notFound()` / `AppError.badRequest(msg, code)` — nigdy `throw new Error()`
-- **AuditLog**: każda mutacja musi logować przez `logAuditEvent()` z `apps/backend/src/shared/audit/audit.service.ts`
-- **Zod schemas**: każdy endpoint ma schemat w `*.schema.ts` z walidacją przez Fastify `preHandler`
-
-### Frontend
-
-- **URL-driven state**: filtry listy spraw są w URL params, nie w lokalnym state
-- **Ownership filter security**: backend używa `request.user.id` z JWT dla filtru `MINE` — frontend nigdy nie wysyła userId
-- **API functions**: w `apps/frontend/src/services/portingRequests.api.ts`, zawsze async, zwracają już rozwinięte DTO (nie wrapper `{ success, data }`)
+- **Internal notifications**: routing do opiekuna handlowego albo fallbacku zespolowego.
+- **Komunikacja do klienta koncowego**: osobny strumien funkcjonalny (nie czesc PR13A).
 
 ---
 
-## Struktura kluczowych plików
+## System settings dla notyfikacji
 
-```
+Preferowane klucze:
+- `porting_status_notify_shared_emails`
+- `porting_status_teams_enabled`
+- `porting_status_notify_shared_teams_webhook`
+
+Kompatybilnosc wsteczna (legacy aliases):
+- `porting_notify_shared_emails`
+- `porting_notify_teams_enabled`
+- `porting_notify_teams_webhook`
+
+Resolver najpierw probuje kluczy preferowanych, potem legacy.
+
+---
+
+## Kluczowe pliki
+
+```text
 apps/backend/src/modules/porting-requests/
-  porting-requests.service.ts          # Główny serwis — logika biznesowa
-  porting-requests.router.ts           # Fastify routes + autoryzacja
-  porting-requests.schema.ts           # Zod schemas dla request body/query
-  porting-notification-events.ts       # Enum zdarzeń powiadomień
-  porting-notification-recipient-resolver.ts  # Resolver odbiorców
-  porting-notification.service.ts      # Dispatch powiadomień
+  porting-requests.service.ts
+  porting-requests.router.ts
+  porting-requests.schema.ts
+  porting-notification-events.ts
+  porting-notification-recipient-resolver.ts
+  porting-notification.service.ts
 
 apps/backend/prisma/
-  schema.prisma                        # Główny schemat Prisma
-  migrations/                          # Historia migracji SQL
+  schema.prisma
+  seed.ts
+  migrations/
 
 packages/shared/src/
-  dto/porting-requests.dto.ts          # Kontrakty DTO (frontend ↔ backend)
-  constants/index.ts                   # USER_ROLES, SYSTEM_SETTING_KEYS, etc.
+  constants/index.ts
+  dto/porting-requests.dto.ts
 
 apps/frontend/src/
-  services/portingRequests.api.ts      # Funkcje API klienta
-  pages/Requests/RequestDetailPage.tsx # Strona szczegółów sprawy (duża, ~1750 linii)
+  pages/Requests/RequestDetailPage.tsx
+  services/portingRequests.api.ts
 ```
 
 ---
 
-## Zasady kontynuowania pracy
+## Zasady kontynuacji pracy
 
-1. **Zawsze uruchamiaj testy** przed commitem: `npx vitest run` w obu apps
-2. **Po zmianie Prisma schema** uruchom `npx prisma generate --no-engine` (lub poczekaj na zwolnienie DLL przez inne procesy i uruchom bez flagi)
-3. **TypeScript check**: `npx tsc --noEmit` — oba projekty muszą przechodzić bez błędów
-4. **Shared package**: zmiany w `packages/shared` wymagają aktualizacji DTOs **i** stałych — oba są eksportowane przez `@np-manager/shared`
-5. **Branch naming**: `prXXy/short-description` (np. `pr13b/notification-dispatch`)
-6. **Commit prefix**: `feat(prXXy): opis`
+1. Zawsze uruchamiaj testy: `npx vitest run` w `apps/backend` i `apps/frontend`
+2. Po zmianie Prisma schema: `npx prisma generate --no-engine` (lub pelne `npx prisma generate`)
+3. Typy: `npx tsc --noEmit` w obu apps
+4. Zmiany w `packages/shared` wymagaja spojnosci kontraktow backend/frontend
+5. Branch naming: `prXXy/short-description`
+6. Commit prefix: `feat(prXXy): opis`
 
 ---
 
-## Planowane kolejne kroki
+## Kolejne kroki (poza PR13A)
 
-- **PR13B**: Faktyczny dispatch e-mail/Teams — implementacja serwisu wysyłki opartego o ustawienia systemowe
-- **PR14**: Historia powiadomień w UI + panel ustawień systemowych dla admina
-- **PR15**: Rozszerzenie opiekuna handlowego — raportowanie, widok "moje sprawy" dla SALES
+- PR13B: realny transport adapter dla fallbacku (email/Teams)
+- PR14: historia notyfikacji wewnetrznych i ustawienia systemowe w UI admina
+- PR15: raportowanie i widoki operacyjne dla modelu commercial owner

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -10,6 +10,7 @@ export const USER_ROLES = {
   TECHNICAL: 'TECHNICAL',
   LEGAL: 'LEGAL',
   AUDITOR: 'AUDITOR',
+  SALES: 'SALES',
 } as const
 
 export type UserRole = (typeof USER_ROLES)[keyof typeof USER_ROLES]
@@ -22,6 +23,7 @@ export const USER_ROLE_LABELS: Record<UserRole, string> = {
   TECHNICAL: 'Dzial Techniczny',
   LEGAL: 'Dzial Prawny',
   AUDITOR: 'Audytor',
+  SALES: 'Opiekun Handlowy',
 }
 
 // ============================================================
@@ -625,6 +627,10 @@ export const SYSTEM_SETTING_KEYS = {
   DONOR_RESPONSE_DAYS: 'donor_response_days',
   MAX_FILE_SIZE_MB: 'max_file_size_mb',
   MAX_RETRY_COUNT: 'max_retry_count',
+  // Powiadomienia wewnętrzne — routing zdarzeń portowania
+  PORTING_NOTIFY_SHARED_EMAILS: 'porting_notify_shared_emails',
+  PORTING_NOTIFY_TEAMS_ENABLED: 'porting_notify_teams_enabled',
+  PORTING_NOTIFY_TEAMS_WEBHOOK: 'porting_notify_teams_webhook',
 } as const
 
 export type SystemSettingKey = (typeof SYSTEM_SETTING_KEYS)[keyof typeof SYSTEM_SETTING_KEYS]

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -627,6 +627,10 @@ export const SYSTEM_SETTING_KEYS = {
   DONOR_RESPONSE_DAYS: 'donor_response_days',
   MAX_FILE_SIZE_MB: 'max_file_size_mb',
   MAX_RETRY_COUNT: 'max_retry_count',
+  // Powiadomienia wewnetrzne - routing zdarzen portowania (preferred keys)
+  PORTING_STATUS_NOTIFY_SHARED_EMAILS: 'porting_status_notify_shared_emails',
+  PORTING_STATUS_TEAMS_ENABLED: 'porting_status_teams_enabled',
+  PORTING_STATUS_NOTIFY_SHARED_TEAMS_WEBHOOK: 'porting_status_notify_shared_teams_webhook',
   // Powiadomienia wewnętrzne — routing zdarzeń portowania
   PORTING_NOTIFY_SHARED_EMAILS: 'porting_notify_shared_emails',
   PORTING_NOTIFY_TEAMS_ENABLED: 'porting_notify_teams_enabled',

--- a/packages/shared/src/dto/porting-requests.dto.ts
+++ b/packages/shared/src/dto/porting-requests.dto.ts
@@ -25,6 +25,36 @@ import type {
 
 export type OwnershipFilter = 'ALL' | 'MINE' | 'UNASSIGNED'
 
+// ============================================================
+// OPIEKUN HANDLOWY
+// ============================================================
+
+/** Skrócony profil opiekuna handlowego (rola SALES) zwracany w detail DTO. */
+export interface CommercialOwnerSummaryDto {
+  id: string
+  email: string
+  displayName: string
+  role: UserRole
+}
+
+/** Opcja opiekuna handlowego na liście kandydatów (dropdown). */
+export interface CommercialOwnerCandidateDto {
+  id: string
+  email: string
+  firstName: string
+  lastName: string
+  role: UserRole
+}
+
+export interface CommercialOwnerCandidatesResultDto {
+  users: CommercialOwnerCandidateDto[]
+}
+
+/** Body żądania zmiany opiekuna handlowego. */
+export interface UpdatePortingRequestCommercialOwnerDto {
+  commercialOwnerUserId: string | null
+}
+
 export interface PortingRequestListQueryDto {
   search?: string
   status?: PortingCaseStatus
@@ -206,6 +236,7 @@ export interface PortingRequestDetailDto {
   assignedUser: PortingRequestAssigneeSummaryDto | null
   assignedAt: string | null
   assignedByUserId: string | null
+  commercialOwner: CommercialOwnerSummaryDto | null
   createdAt: string
   updatedAt: string
   availableStatusActions: PortingRequestStatusActionDto[]


### PR DESCRIPTION
…ion foundation

- Add SALES to UserRole enum (Prisma schema + migration + shared constants)
- Add commercialOwnerUserId to PortingRequest with FK, index (additive migration)
- Backend: CRUD endpoints GET /commercial-owner-candidates, PATCH /:id/commercial-owner with validation (user must exist, be active, have SALES role)
- Notification foundation: event enum, recipient resolver (owner → USER, fallback → TEAM_EMAIL), dispatchPortingNotification service (Notification record for named user, PortingRequestEvent NOTE for team fallback since Notification requires non-null userId)
- System settings: porting_notify_shared_emails / teams_enabled / teams_webhook (seed)
- Frontend: commercial owner section in RequestDetailPage (dropdown, save, clear, feedback)
- Tests: commercial owner service (6 cases) + notification recipient resolver (7 cases)
- Fix: listPortingRequests call in old test missing currentUserId arg (PR12D compat)
- Docs: PROJECT_CONTINUITY.md, AGENTS.md
- 251 backend tests, 80 frontend tests — all passing; tsc clean in both apps