### PR TITLE
feat(pr13b): realny transport wewnętrznych powiadomień email/Teams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Glowne podmioty:
 
 Workflow spraw jest kontrolowany przez `availableStatusActions` zwracane przez backend - frontend tylko wyswietla dozwolone akcje.
 
-### Semantyka ownership i notyfikacji (PR13A+)
+### Semantyka ownership i notyfikacji (PR13A+, PR13B)
 
 - Biznesowo ownership operacyjny jest po stronie **zespolu BOK**, a nie personalnie pojedynczego pracownika.
 - `assignedUserId` pozostaje na razie mechanizmem technicznym (additive, bez destrukcyjnego usuwania), ale nie jest glowna osia rozwoju domeny.
@@ -135,6 +135,15 @@ Workflow spraw jest kontrolowany przez `availableStatusActions` zwracane przez b
   - do odbiorcow zespolowych (e-mail/Teams fallback), gdy opiekuna brak lub jest nieaktywny.
 - Powiadomienia wewnetrzne sa oddzielone od komunikacji do klienta koncowego (to osobny strumien funkcjonalny).
 - Future note: mozna rozwazyc domyslnego opiekuna handlowego na poziomie `Client`, ale foundation PR13A jest celowo na poziomie `PortingRequest`.
+
+#### Transport wewnetrznych powiadomien (PR13B)
+
+- `internal-notification.adapter.ts` — email (nodemailer) + Teams webhook; osobny od `communication-delivery.adapter.ts`
+- `internal-notification-formatter.ts` — formatter tresci wiadomosci (plain-text, j. polski)
+- Tryb email: `INTERNAL_NOTIFICATION_EMAIL_ADAPTER=STUB|REAL|DISABLED` (domyslnie: STUB)
+- Teams: zawsze real gdy webhook URL jest skonfigurowany w SystemSettings
+- Brak crasha glownego API przy bledzie transportu — dispatch jest non-blocking
+- Kazdy dispatch zostawia `PortingRequestEvent NOTE` z trescia: kanal, odbiorca, outcome, tryb, ewentualny blad
 
 ---
 

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -48,7 +48,17 @@ PLI_CBD_REAL_SOAP_ACTION_E18="urn:pli-cbd:fnp:E18"
 PLI_CBD_REAL_SOAP_ACTION_E23="urn:pli-cbd:fnp:E23"
 
 # ============================================================
-# EMAIL (Faza 2 - na razie pozostaw puste)
+# POWIADOMIENIA WEWNETRZNE — transport email (PR13B)
+# ============================================================
+# Tryb adaptera email dla notyfikacji wewnetrznych:
+#   STUB     — brak realnej wysylki, loguje stub (domyslnie)
+#   REAL     — wysylka przez SMTP (wymaga konfiguracji ponizej)
+#   DISABLED — transport cakowicie wylaczony
+INTERNAL_NOTIFICATION_EMAIL_ADAPTER="STUB"
+
+# ============================================================
+# SMTP — konfiguracja serwera poczty wychodzącej
+# Wymagane gdy INTERNAL_NOTIFICATION_EMAIL_ADAPTER=REAL
 # ============================================================
 SMTP_HOST=""
 SMTP_PORT=587

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -29,11 +29,13 @@
     "bcrypt": "^5.1.1",
     "dotenv": "^16.4.5",
     "fastify": "^4.28.1",
+    "nodemailer": "^6.9.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
     "@types/node": "^22.0.0",
+    "@types/nodemailer": "^6.4.0",
     "pino-pretty": "^11.2.2",
     "prisma": "^5.17.0",
     "rimraf": "^3.0.2",

--- a/apps/backend/src/modules/porting-requests/__tests__/internal-notification-formatter.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/internal-notification-formatter.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatInternalNotification } from '../internal-notification-formatter'
+import { PORTING_NOTIFICATION_EVENT } from '../porting-notification-events'
+
+describe('formatInternalNotification', () => {
+  // ============================================================
+  // STATUS_CHANGED
+  // ============================================================
+
+  it('formats STATUS_CHANGED subject correctly', () => {
+    const { subject } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      'FNP-2026-AAA111',
+      { newStatus: 'CONFIRMED' },
+    )
+
+    expect(subject).toContain('[NP-Manager]')
+    expect(subject).toContain('Zmiana statusu sprawy')
+    expect(subject).toContain('FNP-2026-AAA111')
+  })
+
+  it('formats STATUS_CHANGED text with new and old status', () => {
+    const { text } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      'FNP-2026-AAA111',
+      { newStatus: 'CONFIRMED', oldStatus: 'PENDING_DONOR' },
+    )
+
+    expect(text).toContain('Nowy status sprawy: CONFIRMED')
+    expect(text).toContain('Poprzedni status: PENDING_DONOR')
+    expect(text).toContain('FNP-2026-AAA111')
+  })
+
+  it('formats STATUS_CHANGED without oldStatus (omits previous status line)', () => {
+    const { text } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      'FNP-2026-AAA111',
+      { newStatus: 'PORTED' },
+    )
+
+    expect(text).toContain('Nowy status sprawy: PORTED')
+    expect(text).not.toContain('Poprzedni status')
+  })
+
+  it('formats STATUS_CHANGED with dash when metadata missing', () => {
+    const { text } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      'FNP-2026-AAA111',
+    )
+
+    expect(text).toContain('Nowy status sprawy: —')
+  })
+
+  // ============================================================
+  // COMMERCIAL_OWNER_CHANGED
+  // ============================================================
+
+  it('formats COMMERCIAL_OWNER_CHANGED subject correctly', () => {
+    const { subject } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.COMMERCIAL_OWNER_CHANGED,
+      'FNP-2026-BBB222',
+      { newOwnerName: 'Jan Kowalski' },
+    )
+
+    expect(subject).toContain('[NP-Manager]')
+    expect(subject).toContain('Zmiana opiekuna handlowego')
+    expect(subject).toContain('FNP-2026-BBB222')
+  })
+
+  it('formats COMMERCIAL_OWNER_CHANGED text with new owner name', () => {
+    const { text } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.COMMERCIAL_OWNER_CHANGED,
+      'FNP-2026-BBB222',
+      { newOwnerName: 'Jan Kowalski' },
+    )
+
+    expect(text).toContain('Nowy opiekun handlowy: Jan Kowalski')
+  })
+
+  it('formats COMMERCIAL_OWNER_CHANGED when owner is removed (no ownerName in metadata)', () => {
+    const { text } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.COMMERCIAL_OWNER_CHANGED,
+      'FNP-2026-BBB222',
+      {},
+    )
+
+    expect(text).toContain('usuniety')
+  })
+
+  it('formats COMMERCIAL_OWNER_CHANGED when metadata is undefined', () => {
+    const { text } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.COMMERCIAL_OWNER_CHANGED,
+      'FNP-2026-BBB222',
+    )
+
+    expect(text).toContain('usuniety')
+  })
+
+  // ============================================================
+  // REQUEST_CREATED
+  // ============================================================
+
+  it('formats REQUEST_CREATED subject correctly', () => {
+    const { subject } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.REQUEST_CREATED,
+      'FNP-2026-CCC333',
+    )
+
+    expect(subject).toContain('[NP-Manager]')
+    expect(subject).toContain('Nowa sprawa portowania')
+    expect(subject).toContain('FNP-2026-CCC333')
+  })
+
+  it('formats REQUEST_CREATED text body', () => {
+    const { text } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.REQUEST_CREATED,
+      'FNP-2026-CCC333',
+    )
+
+    expect(text).toContain('Zarejestrowano nowa sprawe portowania')
+    expect(text).toContain('FNP-2026-CCC333')
+  })
+
+  // ============================================================
+  // INNE EVENTY (generic fallback)
+  // ============================================================
+
+  it('formats E03_SENT using generic fallback text', () => {
+    const { text } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.E03_SENT,
+      'FNP-2026-DDD444',
+    )
+
+    expect(text).toContain('Wyslano E03')
+  })
+
+  it('formats CASE_REJECTED using generic fallback text', () => {
+    const { subject, text } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.CASE_REJECTED,
+      'FNP-2026-EEE555',
+    )
+
+    expect(subject).toContain('Sprawa zostala odrzucona')
+    expect(text).toContain('Sprawa zostala odrzucona')
+  })
+
+  // ============================================================
+  // WSPOLNE WYMAGANIA
+  // ============================================================
+
+  it('includes case number in both subject and text for all events', () => {
+    const caseNumber = 'FNP-2026-XTEST'
+
+    for (const event of Object.values(PORTING_NOTIFICATION_EVENT)) {
+      const { subject, text } = formatInternalNotification(event, caseNumber)
+      expect(subject).toContain(caseNumber)
+      expect(text).toContain(caseNumber)
+    }
+  })
+
+  it('always includes NP-Manager system footer', () => {
+    const { text } = formatInternalNotification(
+      PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      'FNP-2026-FOOTER',
+    )
+
+    expect(text).toContain('NP-Manager')
+    expect(text).toContain('automatycznie')
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/internal-notification.adapter.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/internal-notification.adapter.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock global fetch (Teams transport)
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Mock nodemailer (used only in REAL email mode)
+const { mockCreateTransport, mockSendMail } = vi.hoisted(() => ({
+  mockCreateTransport: vi.fn(),
+  mockSendMail: vi.fn(),
+}))
+
+vi.mock('nodemailer', () => ({
+  default: { createTransport: mockCreateTransport },
+  createTransport: mockCreateTransport,
+}))
+
+import {
+  resolveEmailAdapterMode,
+  resolveSmtpConfig,
+  sendInternalEmail,
+  sendInternalTeamsWebhook,
+} from '../internal-notification.adapter'
+
+// ============================================================
+// sendInternalEmail
+// ============================================================
+
+describe('sendInternalEmail', () => {
+  const envelope = {
+    to: ['test@np-manager.local'],
+    subject: '[NP-Manager] Test — sprawa FNP-2026-TEST',
+    text: 'Tresc testowa.',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFetch.mockResolvedValue({ ok: true, status: 200, statusText: 'OK' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns STUBBED outcome in default STUB mode', async () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', 'STUB')
+
+    const result = await sendInternalEmail(envelope)
+
+    expect(result.outcome).toBe('STUBBED')
+    expect(result.mode).toBe('STUB')
+    expect(result.channel).toBe('EMAIL')
+    expect(result.errorMessage).toBeNull()
+    expect(result.messageId).toMatch(/^stub-email-\d+$/)
+    expect(mockCreateTransport).not.toHaveBeenCalled()
+  })
+
+  it('returns STUBBED when env var is not set (defaults to STUB)', async () => {
+    // No stub — rely on default
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', '')
+
+    const result = await sendInternalEmail(envelope)
+
+    expect(result.outcome).toBe('STUBBED')
+    expect(result.mode).toBe('STUB')
+  })
+
+  it('returns DISABLED outcome when DISABLED mode', async () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', 'DISABLED')
+
+    const result = await sendInternalEmail(envelope)
+
+    expect(result.outcome).toBe('DISABLED')
+    expect(result.mode).toBe('DISABLED')
+    expect(result.messageId).toBeNull()
+    expect(result.errorMessage).toBeNull()
+    expect(mockCreateTransport).not.toHaveBeenCalled()
+  })
+
+  it('returns MISCONFIGURED when REAL mode but SMTP_HOST not configured', async () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', 'REAL')
+    vi.stubEnv('SMTP_HOST', '')
+
+    const result = await sendInternalEmail(envelope)
+
+    expect(result.outcome).toBe('MISCONFIGURED')
+    expect(result.mode).toBe('REAL')
+    expect(result.errorMessage).toBeTruthy()
+    expect(mockCreateTransport).not.toHaveBeenCalled()
+  })
+
+  it('sends via nodemailer in REAL mode when SMTP is configured', async () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', 'REAL')
+    vi.stubEnv('SMTP_HOST', 'smtp.example.com')
+    vi.stubEnv('SMTP_PORT', '587')
+    vi.stubEnv('SMTP_USER', 'user@example.com')
+    vi.stubEnv('SMTP_PASS', 'secret')
+    vi.stubEnv('SMTP_FROM', 'noreply@example.com')
+
+    mockSendMail.mockResolvedValueOnce({ messageId: '<msg-real-001@smtp.example.com>' })
+    mockCreateTransport.mockReturnValue({ sendMail: mockSendMail })
+
+    const result = await sendInternalEmail(envelope)
+
+    expect(result.outcome).toBe('SENT')
+    expect(result.mode).toBe('REAL')
+    expect(result.messageId).toBe('<msg-real-001@smtp.example.com>')
+    expect(result.errorMessage).toBeNull()
+    expect(mockSendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: 'test@np-manager.local',
+        subject: envelope.subject,
+        from: 'noreply@example.com',
+      }),
+    )
+  })
+
+  it('returns FAILED when nodemailer throws in REAL mode', async () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', 'REAL')
+    vi.stubEnv('SMTP_HOST', 'smtp.example.com')
+
+    mockSendMail.mockRejectedValueOnce(new Error('SMTP connection refused'))
+    mockCreateTransport.mockReturnValue({ sendMail: mockSendMail })
+
+    const result = await sendInternalEmail(envelope)
+
+    expect(result.outcome).toBe('FAILED')
+    expect(result.mode).toBe('REAL')
+    expect(result.errorMessage).toBe('SMTP connection refused')
+    expect(result.messageId).toBeNull()
+  })
+
+  it('joins multiple recipients into a single recipient field string', async () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', 'STUB')
+
+    const result = await sendInternalEmail({
+      to: ['bok@np.pl', 'sud@np.pl'],
+      subject: 'Multi',
+      text: 'Test',
+    })
+
+    expect(result.recipient).toBe('bok@np.pl, sud@np.pl')
+  })
+})
+
+// ============================================================
+// sendInternalTeamsWebhook
+// ============================================================
+
+describe('sendInternalTeamsWebhook', () => {
+  const envelope = {
+    webhookUrl: 'https://teams.example.com/webhook/abc123',
+    title: 'Zmiana statusu sprawy — FNP-2026-AAA111',
+    text: 'Nowy status: CONFIRMED.',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('sends POST and returns SENT outcome on HTTP 200', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' })
+
+    const result = await sendInternalTeamsWebhook(envelope)
+
+    expect(result.outcome).toBe('SENT')
+    expect(result.channel).toBe('TEAMS')
+    expect(result.mode).toBe('REAL')
+    expect(result.errorMessage).toBeNull()
+    expect(result.recipient).toBe(envelope.webhookUrl)
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://teams.example.com/webhook/abc123',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+  })
+
+  it('posts MessageCard payload with correct structure', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK' })
+
+    await sendInternalTeamsWebhook(envelope)
+
+    const fetchInit = mockFetch.mock.calls[0]![1] as { body: string }
+    const body = JSON.parse(fetchInit.body)
+    expect(body['@type']).toBe('MessageCard')
+    expect(body['@context']).toBe('http://schema.org/extensions')
+    expect(body.title).toBe(envelope.title)
+    expect(body.text).toBe(envelope.text)
+    expect(body.summary).toBe(envelope.title)
+  })
+
+  it('returns FAILED when response status is not ok', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 429, statusText: 'Too Many Requests' })
+
+    const result = await sendInternalTeamsWebhook(envelope)
+
+    expect(result.outcome).toBe('FAILED')
+    expect(result.errorMessage).toContain('429')
+    expect(result.errorMessage).toContain('Too Many Requests')
+  })
+
+  it('returns FAILED when fetch throws (network error)', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error — connection refused'))
+
+    const result = await sendInternalTeamsWebhook(envelope)
+
+    expect(result.outcome).toBe('FAILED')
+    expect(result.mode).toBe('REAL')
+    expect(result.errorMessage).toBe('Network error — connection refused')
+  })
+})
+
+// ============================================================
+// resolveEmailAdapterMode
+// ============================================================
+
+describe('resolveEmailAdapterMode', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('defaults to STUB when env var is empty', () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', '')
+    expect(resolveEmailAdapterMode()).toBe('STUB')
+  })
+
+  it('returns REAL when env var is REAL', () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', 'REAL')
+    expect(resolveEmailAdapterMode()).toBe('REAL')
+  })
+
+  it('returns DISABLED when env var is DISABLED', () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', 'DISABLED')
+    expect(resolveEmailAdapterMode()).toBe('DISABLED')
+  })
+
+  it('is case-insensitive', () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', 'real')
+    expect(resolveEmailAdapterMode()).toBe('REAL')
+  })
+
+  it('falls back to STUB for unrecognised values', () => {
+    vi.stubEnv('INTERNAL_NOTIFICATION_EMAIL_ADAPTER', 'UNKNOWN_VALUE')
+    expect(resolveEmailAdapterMode()).toBe('STUB')
+  })
+})
+
+// ============================================================
+// resolveSmtpConfig
+// ============================================================
+
+describe('resolveSmtpConfig', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns null when SMTP_HOST is not set', () => {
+    vi.stubEnv('SMTP_HOST', '')
+    expect(resolveSmtpConfig()).toBeNull()
+  })
+
+  it('returns config object when SMTP_HOST is set', () => {
+    vi.stubEnv('SMTP_HOST', 'smtp.example.com')
+    vi.stubEnv('SMTP_PORT', '465')
+    vi.stubEnv('SMTP_USER', 'user@example.com')
+    vi.stubEnv('SMTP_PASS', 'secret')
+    vi.stubEnv('SMTP_FROM', 'noreply@example.com')
+
+    const config = resolveSmtpConfig()
+
+    expect(config).toEqual({
+      host: 'smtp.example.com',
+      port: 465,
+      user: 'user@example.com',
+      pass: 'secret',
+      from: 'noreply@example.com',
+    })
+  })
+
+  it('uses defaults for missing optional fields', () => {
+    vi.stubEnv('SMTP_HOST', 'smtp.example.com')
+    vi.stubEnv('SMTP_PORT', '')
+    vi.stubEnv('SMTP_USER', '')
+    vi.stubEnv('SMTP_PASS', '')
+    vi.stubEnv('SMTP_FROM', '')
+
+    const config = resolveSmtpConfig()
+
+    expect(config?.port).toBe(587)
+    expect(config?.user).toBeNull()
+    expect(config?.pass).toBeNull()
+    expect(config?.from).toBe('noreply@np-manager.local')
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-notification.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-notification.service.test.ts
@@ -1,12 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { mockNotificationCreate, mockPortingRequestEventCreate, mockResolveRecipients } = vi.hoisted(
-  () => ({
-    mockNotificationCreate: vi.fn(),
-    mockPortingRequestEventCreate: vi.fn(),
-    mockResolveRecipients: vi.fn(),
-  }),
-)
+const {
+  mockNotificationCreate,
+  mockPortingRequestEventCreate,
+  mockResolveRecipients,
+  mockSendInternalEmail,
+  mockSendInternalTeamsWebhook,
+} = vi.hoisted(() => ({
+  mockNotificationCreate: vi.fn(),
+  mockPortingRequestEventCreate: vi.fn(),
+  mockResolveRecipients: vi.fn(),
+  mockSendInternalEmail: vi.fn(),
+  mockSendInternalTeamsWebhook: vi.fn(),
+}))
 
 vi.mock('../../../config/database', () => ({
   prisma: {
@@ -23,15 +29,49 @@ vi.mock('../porting-notification-recipient-resolver', () => ({
   resolvePortingNotificationRecipients: (...args: unknown[]) => mockResolveRecipients(...args),
 }))
 
+vi.mock('../internal-notification.adapter', () => ({
+  sendInternalEmail: (...args: unknown[]) => mockSendInternalEmail(...args),
+  sendInternalTeamsWebhook: (...args: unknown[]) => mockSendInternalTeamsWebhook(...args),
+}))
+
 import { PORTING_NOTIFICATION_EVENT } from '../porting-notification-events'
 import { dispatchPortingNotification } from '../porting-notification.service'
+
+// ============================================================
+// DEFAULTS
+// ============================================================
+
+const STUB_EMAIL_RESULT = {
+  channel: 'EMAIL',
+  recipient: 'stub@np-manager.local',
+  outcome: 'STUBBED',
+  mode: 'STUB',
+  messageId: 'stub-email-123',
+  errorMessage: null,
+}
+
+const STUB_TEAMS_RESULT = {
+  channel: 'TEAMS',
+  recipient: 'https://teams.example/stub',
+  outcome: 'STUBBED',
+  mode: 'STUB',
+  errorMessage: null,
+}
+
+// ============================================================
+// TESTS
+// ============================================================
 
 describe('dispatchPortingNotification', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockNotificationCreate.mockResolvedValue(undefined)
     mockPortingRequestEventCreate.mockResolvedValue(undefined)
+    mockSendInternalEmail.mockResolvedValue(STUB_EMAIL_RESULT)
+    mockSendInternalTeamsWebhook.mockResolvedValue(STUB_TEAMS_RESULT)
   })
+
+  // -------- USER recipient --------
 
   it('creates Notification for active owner recipient on STATUS_CHANGED', async () => {
     mockResolveRecipients.mockResolvedValueOnce([
@@ -62,8 +102,79 @@ describe('dispatchPortingNotification', () => {
         relatedEntityId: 'request-1',
       },
     })
-    expect(mockPortingRequestEventCreate).not.toHaveBeenCalled()
+    // PR13B: audit NOTE is written after email dispatch (no routing NOTE for USER path)
+    expect(mockPortingRequestEventCreate).toHaveBeenCalledTimes(1)
+    expect(mockPortingRequestEventCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ title: '[Dispatch] Zmiana statusu sprawy' }),
+      }),
+    )
   })
+
+  it('sends email to USER recipient address', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      {
+        kind: 'USER',
+        userId: 'sales-1',
+        email: 'sales@np-manager.local',
+        displayName: 'Jan Sprzedaz',
+      },
+    ])
+
+    await dispatchPortingNotification({
+      requestId: 'request-1',
+      caseNumber: 'FNP-20260409-AAA111',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: 'sales-1',
+      metadata: { newStatus: 'CONFIRMED' },
+    })
+
+    expect(mockSendInternalEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ['sales@np-manager.local'] }),
+    )
+    expect(mockSendInternalTeamsWebhook).not.toHaveBeenCalled()
+  })
+
+  it('writes transport audit NOTE after USER email dispatch', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      {
+        kind: 'USER',
+        userId: 'sales-1',
+        email: 'sales@np.pl',
+        displayName: 'Jan',
+      },
+    ])
+    mockSendInternalEmail.mockResolvedValueOnce({
+      channel: 'EMAIL',
+      recipient: 'sales@np.pl',
+      outcome: 'SENT',
+      mode: 'REAL',
+      messageId: 'msg-abc123',
+      errorMessage: null,
+    })
+
+    await dispatchPortingNotification({
+      requestId: 'request-audit',
+      caseNumber: 'FNP-2026-AUDIT',
+      event: PORTING_NOTIFICATION_EVENT.COMMERCIAL_OWNER_CHANGED,
+      commercialOwnerUserId: 'sales-1',
+      actorUserId: 'actor-1',
+      metadata: { newOwnerName: 'Jan Kowalski' },
+    })
+
+    // USER path: only audit NOTE (no routing NOTE)
+    expect(mockPortingRequestEventCreate).toHaveBeenCalledTimes(1)
+    expect(mockPortingRequestEventCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          title: '[Dispatch] Zmiana opiekuna handlowego',
+          description: expect.stringContaining('SENT'),
+        }),
+      }),
+    )
+  })
+
+  // -------- TEAM_EMAIL recipient --------
 
   it('creates fallback timeline note for TEAM_EMAIL recipients', async () => {
     mockResolveRecipients.mockResolvedValueOnce([
@@ -91,6 +202,29 @@ describe('dispatchPortingNotification', () => {
     )
   })
 
+  it('sends email to TEAM_EMAIL address list', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'TEAM_EMAIL', emails: ['bok@multiplay.pl', 'sud@multiplay.pl'] },
+    ])
+
+    await dispatchPortingNotification({
+      requestId: 'request-2',
+      caseNumber: 'FNP-20260409-BBB222',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: null,
+      metadata: { newStatus: 'PENDING_DONOR' },
+    })
+
+    expect(mockSendInternalEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: ['bok@multiplay.pl', 'sud@multiplay.pl'] }),
+    )
+    expect(mockSendInternalTeamsWebhook).not.toHaveBeenCalled()
+    // routing NOTE + audit NOTE = 2 calls
+    expect(mockPortingRequestEventCreate).toHaveBeenCalledTimes(2)
+  })
+
+  // -------- TEAM_WEBHOOK recipient --------
+
   it('creates fallback timeline note for TEAM_WEBHOOK recipients', async () => {
     mockResolveRecipients.mockResolvedValueOnce([
       { kind: 'TEAM_WEBHOOK', webhookUrl: 'https://teams.example/hook' },
@@ -114,6 +248,111 @@ describe('dispatchPortingNotification', () => {
     )
   })
 
+  it('sends Teams webhook POST for TEAM_WEBHOOK recipient', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'TEAM_WEBHOOK', webhookUrl: 'https://teams.example/hook' },
+    ])
+
+    await dispatchPortingNotification({
+      requestId: 'request-3',
+      caseNumber: 'FNP-20260409-CCC333',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: null,
+      metadata: { newStatus: 'PORTED' },
+    })
+
+    expect(mockSendInternalTeamsWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({ webhookUrl: 'https://teams.example/hook' }),
+    )
+    expect(mockSendInternalEmail).not.toHaveBeenCalled()
+    // routing NOTE + audit NOTE = 2 calls
+    expect(mockPortingRequestEventCreate).toHaveBeenCalledTimes(2)
+  })
+
+  // -------- TEAM_EMAIL + TEAM_WEBHOOK combined --------
+
+  it('dispatches email and Teams when both TEAM_EMAIL and TEAM_WEBHOOK recipients configured', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'TEAM_EMAIL', emails: ['bok@np.pl'] },
+      { kind: 'TEAM_WEBHOOK', webhookUrl: 'https://teams.example/hook' },
+    ])
+
+    await dispatchPortingNotification({
+      requestId: 'request-combined',
+      caseNumber: 'FNP-2026-COMBINED',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: null,
+      metadata: { newStatus: 'CONFIRMED' },
+    })
+
+    expect(mockSendInternalEmail).toHaveBeenCalledTimes(1)
+    expect(mockSendInternalTeamsWebhook).toHaveBeenCalledTimes(1)
+    // 2 routing NOTEs (one per team recipient) + 1 audit NOTE = 3 calls
+    expect(mockPortingRequestEventCreate).toHaveBeenCalledTimes(3)
+  })
+
+  // -------- Transport audit trace --------
+
+  it('audit NOTE description includes channel, recipient, outcome, and mode', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'TEAM_EMAIL', emails: ['bok@np.pl'] },
+    ])
+    mockSendInternalEmail.mockResolvedValueOnce({
+      channel: 'EMAIL',
+      recipient: 'bok@np.pl',
+      outcome: 'SENT',
+      mode: 'REAL',
+      messageId: 'msg-real-999',
+      errorMessage: null,
+    })
+
+    await dispatchPortingNotification({
+      requestId: 'request-trace',
+      caseNumber: 'FNP-2026-TRACE',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: null,
+      metadata: { newStatus: 'PORTED' },
+    })
+
+    const auditCall = mockPortingRequestEventCreate.mock.calls.find(
+      (call) => call[0].data.title === '[Dispatch] Zmiana statusu sprawy',
+    )
+    expect(auditCall).toBeDefined()
+    const description: string = auditCall![0].data.description
+    expect(description).toContain('EMAIL')
+    expect(description).toContain('bok@np.pl')
+    expect(description).toContain('SENT')
+    expect(description).toContain('REAL')
+  })
+
+  it('audit NOTE description includes error message on FAILED outcome', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'TEAM_EMAIL', emails: ['bok@np.pl'] },
+    ])
+    mockSendInternalEmail.mockResolvedValueOnce({
+      channel: 'EMAIL',
+      recipient: 'bok@np.pl',
+      outcome: 'FAILED',
+      mode: 'REAL',
+      messageId: null,
+      errorMessage: 'SMTP connection refused',
+    })
+
+    await dispatchPortingNotification({
+      requestId: 'request-fail',
+      caseNumber: 'FNP-2026-FAIL',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: null,
+    })
+
+    const auditCall = mockPortingRequestEventCreate.mock.calls.find(
+      (call) => call[0].data.title === '[Dispatch] Zmiana statusu sprawy',
+    )
+    expect(auditCall![0].data.description).toContain('SMTP connection refused')
+  })
+
+  // -------- Resilience --------
+
   it('does nothing when resolver returns no recipients', async () => {
     mockResolveRecipients.mockResolvedValueOnce([])
 
@@ -126,5 +365,118 @@ describe('dispatchPortingNotification', () => {
 
     expect(mockNotificationCreate).not.toHaveBeenCalled()
     expect(mockPortingRequestEventCreate).not.toHaveBeenCalled()
+    expect(mockSendInternalEmail).not.toHaveBeenCalled()
+    expect(mockSendInternalTeamsWebhook).not.toHaveBeenCalled()
+  })
+
+  it('resolves without error even when email transport returns FAILED', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'USER', userId: 'sales-1', email: 'sales@np.pl', displayName: 'Jan' },
+    ])
+    mockSendInternalEmail.mockResolvedValueOnce({
+      channel: 'EMAIL',
+      recipient: 'sales@np.pl',
+      outcome: 'FAILED',
+      mode: 'REAL',
+      messageId: null,
+      errorMessage: 'SMTP connection refused',
+    })
+
+    await expect(
+      dispatchPortingNotification({
+        requestId: 'request-resilience',
+        caseNumber: 'FNP-2026-RESILIENCE',
+        event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+        commercialOwnerUserId: 'sales-1',
+        metadata: { newStatus: 'REJECTED' },
+      }),
+    ).resolves.toBeUndefined()
+
+    // In-app Notification was created despite email failure
+    expect(mockNotificationCreate).toHaveBeenCalled()
+    // Audit NOTE was written with failure info
+    expect(mockPortingRequestEventCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          description: expect.stringContaining('FAILED'),
+        }),
+      }),
+    )
+  })
+
+  it('resolves without error even when Teams transport returns FAILED', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'TEAM_WEBHOOK', webhookUrl: 'https://teams.example/hook' },
+    ])
+    mockSendInternalTeamsWebhook.mockResolvedValueOnce({
+      channel: 'TEAMS',
+      recipient: 'https://teams.example/hook',
+      outcome: 'FAILED',
+      mode: 'REAL',
+      errorMessage: 'Network error',
+    })
+
+    await expect(
+      dispatchPortingNotification({
+        requestId: 'request-teams-fail',
+        caseNumber: 'FNP-2026-TEAMSFAIL',
+        event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+        commercialOwnerUserId: null,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  // -------- COMMERCIAL_OWNER_CHANGED --------
+
+  it('creates Notification for COMMERCIAL_OWNER_CHANGED with owner name in body', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      {
+        kind: 'USER',
+        userId: 'sales-2',
+        email: 'new-owner@np-manager.local',
+        displayName: 'Anna Handlowa',
+      },
+    ])
+
+    await dispatchPortingNotification({
+      requestId: 'request-co',
+      caseNumber: 'FNP-20260409-EEE555',
+      event: PORTING_NOTIFICATION_EVENT.COMMERCIAL_OWNER_CHANGED,
+      commercialOwnerUserId: 'sales-2',
+      actorUserId: 'actor-3',
+      metadata: { newOwnerName: 'Anna Handlowa' },
+    })
+
+    expect(mockNotificationCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          type: PORTING_NOTIFICATION_EVENT.COMMERCIAL_OWNER_CHANGED,
+          body: 'Opiekun handlowy sprawy zostal zmieniony na: Anna Handlowa.',
+        }),
+      }),
+    )
+  })
+
+  it('formats email for COMMERCIAL_OWNER_CHANGED event', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      {
+        kind: 'USER',
+        userId: 'sales-2',
+        email: 'new-owner@np.pl',
+        displayName: 'Anna',
+      },
+    ])
+
+    await dispatchPortingNotification({
+      requestId: 'request-co2',
+      caseNumber: 'FNP-2026-CO2',
+      event: PORTING_NOTIFICATION_EVENT.COMMERCIAL_OWNER_CHANGED,
+      commercialOwnerUserId: 'sales-2',
+      metadata: { newOwnerName: 'Anna Handlowa' },
+    })
+
+    const emailCall = mockSendInternalEmail.mock.calls[0]?.[0] as { subject: string; text: string }
+    expect(emailCall.subject).toContain('Zmiana opiekuna handlowego')
+    expect(emailCall.text).toContain('Anna Handlowa')
   })
 })

--- a/apps/backend/src/modules/porting-requests/internal-notification-formatter.ts
+++ b/apps/backend/src/modules/porting-requests/internal-notification-formatter.ts
@@ -1,0 +1,83 @@
+/**
+ * Message content formatter for internal porting notifications (PR13B).
+ *
+ * Produces professional plain-text messages suitable for both email body
+ * and Microsoft Teams MessageCard text field.
+ * No template engine — simple switch-based formatting per event type.
+ */
+
+import {
+  PORTING_NOTIFICATION_EVENT_LABELS,
+  type PortingNotificationEvent,
+} from './porting-notification-events'
+
+export interface InternalNotificationMessage {
+  subject: string
+  text: string
+}
+
+/**
+ * Builds subject and plain-text body for an internal notification.
+ */
+export function formatInternalNotification(
+  event: PortingNotificationEvent,
+  caseNumber: string,
+  metadata?: Record<string, unknown>,
+): InternalNotificationMessage {
+  const label = PORTING_NOTIFICATION_EVENT_LABELS[event]
+  const subject = `[NP-Manager] ${label} — sprawa ${caseNumber}`
+  const text = buildMessageText(event, caseNumber, label, metadata)
+  return { subject, text }
+}
+
+function buildMessageText(
+  event: PortingNotificationEvent,
+  caseNumber: string,
+  label: string,
+  metadata?: Record<string, unknown>,
+): string {
+  const lines: string[] = []
+
+  lines.push(`Powiadomienie wewnetrzne: ${label}`)
+  lines.push(`Sprawa: ${caseNumber}`)
+  lines.push('')
+
+  switch (event) {
+    case 'STATUS_CHANGED': {
+      const newStatus = metadata?.newStatus ?? '—'
+      const oldStatus = metadata?.oldStatus
+      lines.push(`Nowy status sprawy: ${newStatus}`)
+      if (oldStatus) {
+        lines.push(`Poprzedni status: ${oldStatus}`)
+      }
+      break
+    }
+
+    case 'COMMERCIAL_OWNER_CHANGED': {
+      const ownerName = metadata?.newOwnerName
+      if (ownerName) {
+        lines.push(`Nowy opiekun handlowy: ${ownerName}`)
+      } else {
+        lines.push('Opiekun handlowy zostal usuniety ze sprawy.')
+      }
+      break
+    }
+
+    case 'REQUEST_CREATED': {
+      lines.push('Zarejestrowano nowa sprawe portowania.')
+      break
+    }
+
+    default: {
+      lines.push(`Zdarzenie: ${label}`)
+      break
+    }
+  }
+
+  lines.push('')
+  lines.push('---')
+  lines.push('Ta wiadomosc zostala wygenerowana automatycznie przez system NP-Manager.')
+  lines.push('Prosimy nie odpowiadac na ta wiadomosc.')
+
+  return lines.join('\n')
+}

--- a/apps/backend/src/modules/porting-requests/internal-notification.adapter.ts
+++ b/apps/backend/src/modules/porting-requests/internal-notification.adapter.ts
@@ -1,0 +1,222 @@
+/**
+ * Internal notification transport adapters (PR13B).
+ *
+ * Handles email (SMTP via nodemailer) and Microsoft Teams webhook dispatch
+ * for internal porting request notifications.
+ *
+ * Intentionally separate from the customer communication pipeline
+ * (communication-delivery.adapter.ts) — do not mix.
+ *
+ * Mode selection (email):
+ *   env INTERNAL_NOTIFICATION_EMAIL_ADAPTER = STUB (default) | REAL | DISABLED
+ *
+ * Teams transport is always attempted when a webhook URL is supplied
+ * (its enablement is governed by the PORTING_STATUS_TEAMS_ENABLED system setting
+ * which is evaluated upstream in the recipient resolver).
+ */
+
+// ============================================================
+// TYPY
+// ============================================================
+
+export type InternalNotificationMode = 'REAL' | 'STUB' | 'DISABLED'
+export type InternalNotificationOutcome = 'SENT' | 'STUBBED' | 'DISABLED' | 'MISCONFIGURED' | 'FAILED'
+
+export interface InternalEmailEnvelope {
+  to: string[]
+  subject: string
+  text: string
+}
+
+export interface InternalTeamsEnvelope {
+  webhookUrl: string
+  title: string
+  text: string
+}
+
+export interface InternalEmailDispatchResult {
+  channel: 'EMAIL'
+  recipient: string
+  outcome: InternalNotificationOutcome
+  mode: InternalNotificationMode
+  messageId: string | null
+  errorMessage: string | null
+}
+
+export interface InternalTeamsDispatchResult {
+  channel: 'TEAMS'
+  recipient: string
+  outcome: InternalNotificationOutcome
+  mode: InternalNotificationMode
+  errorMessage: string | null
+}
+
+export type InternalNotificationDispatchResult =
+  | InternalEmailDispatchResult
+  | InternalTeamsDispatchResult
+
+// ============================================================
+// EMAIL TRANSPORT
+// ============================================================
+
+export async function sendInternalEmail(
+  envelope: InternalEmailEnvelope,
+): Promise<InternalEmailDispatchResult> {
+  const mode = resolveEmailAdapterMode()
+  const recipient = envelope.to.join(', ')
+
+  if (mode === 'DISABLED') {
+    return {
+      channel: 'EMAIL',
+      recipient,
+      outcome: 'DISABLED',
+      mode,
+      messageId: null,
+      errorMessage: null,
+    }
+  }
+
+  if (mode === 'STUB') {
+    return {
+      channel: 'EMAIL',
+      recipient,
+      outcome: 'STUBBED',
+      mode,
+      messageId: `stub-email-${Date.now()}`,
+      errorMessage: null,
+    }
+  }
+
+  // REAL mode — dynamiczny import nodemailer (nie laduj w trybach STUB/DISABLED)
+  const smtpConfig = resolveSmtpConfig()
+  if (!smtpConfig) {
+    return {
+      channel: 'EMAIL',
+      recipient,
+      outcome: 'MISCONFIGURED',
+      mode,
+      messageId: null,
+      errorMessage: 'Brak konfiguracji SMTP: zmienna SMTP_HOST nie jest ustawiona.',
+    }
+  }
+
+  try {
+    const nodemailer = await import('nodemailer')
+    const transporter = nodemailer.createTransport({
+      host: smtpConfig.host,
+      port: smtpConfig.port,
+      secure: smtpConfig.port === 465,
+      ...(smtpConfig.user
+        ? { auth: { user: smtpConfig.user, pass: smtpConfig.pass ?? '' } }
+        : {}),
+    })
+
+    const info = await transporter.sendMail({
+      from: smtpConfig.from,
+      to: envelope.to.join(', '),
+      subject: envelope.subject,
+      text: envelope.text,
+    })
+
+    return {
+      channel: 'EMAIL',
+      recipient,
+      outcome: 'SENT',
+      mode,
+      messageId: (info as { messageId?: string }).messageId ?? null,
+      errorMessage: null,
+    }
+  } catch (err) {
+    return {
+      channel: 'EMAIL',
+      recipient,
+      outcome: 'FAILED',
+      mode,
+      messageId: null,
+      errorMessage: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+// ============================================================
+// TEAMS WEBHOOK TRANSPORT
+// ============================================================
+
+export async function sendInternalTeamsWebhook(
+  envelope: InternalTeamsEnvelope,
+): Promise<InternalTeamsDispatchResult> {
+  const recipient = envelope.webhookUrl
+
+  try {
+    const response = await fetch(envelope.webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        '@type': 'MessageCard',
+        '@context': 'http://schema.org/extensions',
+        summary: envelope.title,
+        themeColor: '0076D7',
+        title: envelope.title,
+        text: envelope.text,
+      }),
+    })
+
+    if (!response.ok) {
+      return {
+        channel: 'TEAMS',
+        recipient,
+        outcome: 'FAILED',
+        mode: 'REAL',
+        errorMessage: `HTTP ${response.status} ${response.statusText}`.trim(),
+      }
+    }
+
+    return {
+      channel: 'TEAMS',
+      recipient,
+      outcome: 'SENT',
+      mode: 'REAL',
+      errorMessage: null,
+    }
+  } catch (err) {
+    return {
+      channel: 'TEAMS',
+      recipient,
+      outcome: 'FAILED',
+      mode: 'REAL',
+      errorMessage: err instanceof Error ? err.message : String(err),
+    }
+  }
+}
+
+// ============================================================
+// KONFIGURACJA — eksportowane dla testowalnosci
+// ============================================================
+
+export function resolveEmailAdapterMode(): InternalNotificationMode {
+  const raw = (process.env.INTERNAL_NOTIFICATION_EMAIL_ADAPTER ?? 'STUB').toUpperCase().trim()
+  if (raw === 'REAL') return 'REAL'
+  if (raw === 'DISABLED') return 'DISABLED'
+  return 'STUB'
+}
+
+interface SmtpConfig {
+  host: string
+  port: number
+  user: string | null
+  pass: string | null
+  from: string
+}
+
+export function resolveSmtpConfig(): SmtpConfig | null {
+  const host = process.env.SMTP_HOST?.trim()
+  if (!host) return null
+
+  return {
+    host,
+    port: parseInt(process.env.SMTP_PORT || '587', 10) || 587,
+    user: process.env.SMTP_USER?.trim() || null,
+    pass: process.env.SMTP_PASS?.trim() || null,
+    from: process.env.SMTP_FROM?.trim() || 'noreply@np-manager.local',
+  }
+}

--- a/apps/backend/src/modules/porting-requests/porting-notification.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-notification.service.ts
@@ -1,11 +1,14 @@
 /**
- * Foundation internal notification dispatcher for porting requests.
+ * Internal notification dispatcher for porting requests.
  *
  * Responsibilities:
  * - resolve recipients (commercial owner or team fallback),
  * - persist Notification for named user recipients,
- * - persist timeline note for shared recipients,
- * - build event-specific notification copy.
+ * - persist timeline note for shared recipients (routing intent trace),
+ * - dispatch real email/Teams transport (PR13B),
+ * - persist transport audit trace as PortingRequestEvent NOTE.
+ *
+ * Non-blocking by design — callers use `.catch(() => {})`.
  */
 
 import { prisma } from '../../config/database'
@@ -14,6 +17,12 @@ import {
   type PortingNotificationEvent,
 } from './porting-notification-events'
 import { resolvePortingNotificationRecipients } from './porting-notification-recipient-resolver'
+import { formatInternalNotification } from './internal-notification-formatter'
+import {
+  sendInternalEmail,
+  sendInternalTeamsWebhook,
+  type InternalNotificationDispatchResult,
+} from './internal-notification.adapter'
 
 export interface DispatchPortingNotificationParams {
   requestId: string
@@ -40,9 +49,13 @@ export async function dispatchPortingNotification(
   const eventLabel = PORTING_NOTIFICATION_EVENT_LABELS[event]
   const title = `${eventLabel} - sprawa ${caseNumber}`
   const body = buildNotificationBody(event, metadata)
+  const message = formatInternalNotification(event, caseNumber, metadata)
+
+  const transportResults: InternalNotificationDispatchResult[] = []
 
   for (const recipient of recipients) {
     if (recipient.kind === 'USER') {
+      // 1. Domain trace — in-app Notification for the named user
       await prisma.notification.create({
         data: {
           userId: recipient.userId,
@@ -53,9 +66,18 @@ export async function dispatchPortingNotification(
           relatedEntityId: requestId,
         },
       })
+
+      // 2. Transport — email to the user's address
+      const emailResult = await sendInternalEmail({
+        to: [recipient.email],
+        subject: message.subject,
+        text: message.text,
+      })
+      transportResults.push(emailResult)
       continue
     }
 
+    // 3. Domain trace — timeline NOTE recording routing intent for team recipients
     await prisma.portingRequestEvent.create({
       data: {
         request: { connect: { id: requestId } },
@@ -66,8 +88,46 @@ export async function dispatchPortingNotification(
         ...(actorUserId ? { createdBy: { connect: { id: actorUserId } } } : {}),
       },
     })
+
+    if (recipient.kind === 'TEAM_EMAIL') {
+      // 4. Transport — email to the shared team address list
+      const emailResult = await sendInternalEmail({
+        to: recipient.emails,
+        subject: message.subject,
+        text: message.text,
+      })
+      transportResults.push(emailResult)
+    }
+
+    if (recipient.kind === 'TEAM_WEBHOOK') {
+      // 5. Transport — Teams webhook POST
+      const teamsResult = await sendInternalTeamsWebhook({
+        webhookUrl: recipient.webhookUrl,
+        title,
+        text: message.text,
+      })
+      transportResults.push(teamsResult)
+    }
+  }
+
+  // 6. Transport audit trace — one NOTE per dispatch summarising all outcomes
+  if (transportResults.length > 0) {
+    await prisma.portingRequestEvent.create({
+      data: {
+        request: { connect: { id: requestId } },
+        eventSource: 'INTERNAL',
+        eventType: 'NOTE',
+        title: `[Dispatch] ${eventLabel}`,
+        description: buildTransportAuditDescription(transportResults),
+        ...(actorUserId ? { createdBy: { connect: { id: actorUserId } } } : {}),
+      },
+    })
   }
 }
+
+// ============================================================
+// POMOCNICZE
+// ============================================================
 
 function buildFallbackDescription(
   recipient: { kind: 'TEAM_EMAIL'; emails: string[] } | { kind: 'TEAM_WEBHOOK'; webhookUrl: string },
@@ -80,6 +140,20 @@ function buildFallbackDescription(
 
   const metadataText = metadata ? ` Kontekst: ${safeJson(metadata)}.` : ''
   return `${destination}${metadataText}`.trim()
+}
+
+function buildTransportAuditDescription(results: InternalNotificationDispatchResult[]): string {
+  const lines = results.map((r) => {
+    const base = `${r.channel} → ${r.recipient}: ${r.outcome} (tryb: ${r.mode})`
+    if (r.errorMessage) {
+      return `${base} — blad: ${r.errorMessage}`
+    }
+    if ('messageId' in r && r.messageId) {
+      return `${base}, msgId: ${r.messageId}`
+    }
+    return base
+  })
+  return lines.join('\n')
 }
 
 function safeJson(value: unknown): string {

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -15,6 +15,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR12C | Assignment-users endpoint + reassignment z detail flow              | DONE   |
 | PR12D | Ownership filter (MINE/UNASSIGNED) przeniesiony na backend          | DONE   |
 | PR13A | Commercial owner (SALES) + foundation internal event notifications  | DONE   |
+| PR13B | Realny transport wewnetrznych powiadomien email/Teams               | DONE   |
 
 ---
 
@@ -30,17 +31,34 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 Future note:
 - W kolejnych etapach mozna rozwazyc domyslnego commercial ownera na poziomie `Client`, ale PR13A celowo wdraza foundation na poziomie `PortingRequest`.
 
-### Notyfikacje wewnetrzne (event-driven foundation)
+### Notyfikacje wewnetrzne (PR13A foundation + PR13B transport)
 
-Architektura rozdziela trzy warstwy:
+Architektura rozdziela cztery warstwy:
 
 1. **Event domenowy** (`PortingNotificationEvent`)
 2. **Resolver odbiorcow** (owner -> USER, fallback -> TEAM_EMAIL / TEAM_WEBHOOK)
-3. **Trace**
+3. **Trace domenowy**
    - `Notification` dla odbiorcy typu USER,
-   - `PortingRequestEvent` typu NOTE dla fallbacku zespolowego bez konkretnego `userId`.
+   - `PortingRequestEvent` typu NOTE (routing intent) dla fallbacku zespolowego.
+4. **Transport realny (PR13B)**
+   - Email via nodemailer (`sendInternalEmail`) — tryb STUB/REAL/DISABLED
+   - Teams webhook via native fetch (`sendInternalTeamsWebhook`)
+   - Po kazdym dispatchie: `PortingRequestEvent NOTE [Dispatch]` z wynikiem (kanal, odbiorca, outcome, tryb, ewentualny blad)
 
 Dispatch jest non-blocking (`.catch(() => {})`) i nie blokuje glownego flow API.
+
+#### Konfiguracja transportu email
+
+```env
+INTERNAL_NOTIFICATION_EMAIL_ADAPTER=STUB  # STUB (domyslnie) | REAL | DISABLED
+SMTP_HOST=smtp.example.com                # wymagane dla REAL
+SMTP_PORT=587
+SMTP_USER=user@example.com
+SMTP_PASS=secret
+SMTP_FROM=noreply@np-manager.local
+```
+
+Teams: webhook URL pochodzi z `SystemSetting.porting_status_notify_shared_teams_webhook`; wlaczenie przez `porting_status_teams_enabled=true`.
 
 ### Katalog eventow foundation
 
@@ -89,7 +107,9 @@ apps/backend/src/modules/porting-requests/
   porting-requests.schema.ts
   porting-notification-events.ts
   porting-notification-recipient-resolver.ts
-  porting-notification.service.ts
+  porting-notification.service.ts          # dispatcher (PR13A+PR13B)
+  internal-notification.adapter.ts         # email + Teams transport (PR13B)
+  internal-notification-formatter.ts       # formatter tresci wiadomosci (PR13B)
 
 apps/backend/prisma/
   schema.prisma
@@ -118,11 +138,11 @@ apps/frontend/src/
 
 ---
 
-## Kolejne kroki (poza PR13A)
+## Kolejne kroki
 
-- PR13B: realny transport adapter dla fallbacku (email/Teams)
-- PR14: historia notyfikacji wewnetrznych i ustawienia systemowe w UI admina
+- PR14: historia powiadomien wewnetrznych w UI + panel ustawien systemowych dla admina
 - PR15: raportowanie i widoki operacyjne dla modelu commercial owner
+- Future: podlaczenie pozostalych eventow z katalogu (E03, E06, E12, E13, NUMBER_PORTED, CASE_REJECTED)
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,11 +40,13 @@
         "bcrypt": "^5.1.1",
         "dotenv": "^16.4.5",
         "fastify": "^4.28.1",
+        "nodemailer": "^6.9.0",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/bcrypt": "^5.0.2",
         "@types/node": "^22.0.0",
+        "@types/nodemailer": "^6.4.0",
         "pino-pretty": "^11.2.2",
         "prisma": "^5.17.0",
         "rimraf": "^3.0.2",
@@ -1820,6 +1822,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.23",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.23.tgz",
+      "integrity": "sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/prop-types": {
@@ -5971,6 +5983,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",


### PR DESCRIPTION
## Cel

Wdrożenie PR13B: realny transport wewnętrznych powiadomień dla eventów portingowych, bez mieszania tego z komunikacją do klienta.

## Zakres

- dodanie adaptera transportowego `internal-notification.adapter.ts`
  - email przez nodemailer
  - Teams webhook przez native `fetch`
  - tryby email: `STUB` / `REAL` / `DISABLED`
- dodanie formattera treści `internal-notification-formatter.ts`
- rozszerzenie `dispatchPortingNotification()` o realny dispatch transportowy
- zachowanie śladu domenowego z PR13A
- dodanie NOTE `[Dispatch] ...` z wynikami transportu
- aktualizacja `.env.example`, `package.json`, `package-lock.json`
- aktualizacja `AGENTS.md` i `docs/PROJECT_CONTINUITY.md`

## Zachowanie

- USER recipient -> in-app `Notification` + email transport
- TEAM_EMAIL -> routing NOTE + email transport
- TEAM_WEBHOOK -> routing NOTE + Teams webhook transport
- transport jest non-blocking dla głównego flow
- po dispatchu zostaje diagnostyczny ślad z kanałem, odbiorcą, wynikiem, trybem i błędem (jeśli wystąpił)

## Testy

- nowe testy adaptera email / Teams
- nowe testy formattera treści
- rozszerzone testy `porting-notification.service`
- lokalnie raportowane:
  - backend: 303 testów PASS
  - frontend: 80 testów PASS
  - TypeScript clean

## Uwagi

- branch jest obecnie 1 commit behind `main`, więc przed merge warto zaktualizować branch względem `main`
- PR13B nadal dotyczy wyłącznie powiadomień wewnętrznych, nie komunikacji do klienta