### PR TITLE
feat(pr16): drill-down health notyfikacji na liście i w szczegółach spraw

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,15 @@ Workflow spraw jest kontrolowany przez `availableStatusActions` zwracane przez b
   - liczniki: wszystkie, z opiekunem, bez opiekuna, moje handlowe, z bledami notyfikacji.
 - Frontend `RequestsPage` pokazuje operacyjne summary cards + szybkie filtry i sygnal bledow notyfikacji w tabeli.
 
+#### Diagnostyka zdrowia notyfikacji (PR16)
+
+- `porting-notification-health.helper.ts` — jedyne miejsce obliczania statusu health: `OK | FAILED | MISCONFIGURED | MIXED`.
+- `NotificationHealthDiagnosticsDto` w `packages/shared` — pelny ksztalt danych zdrowia (failureCount, failedCount, misconfiguredCount, lastFailureAt, lastFailureOutcome).
+- `PortingRequestDetailDto.notificationHealth` — pole z pelna diagnostyka w widoku szczegolu.
+- `PortingRequestListItemDto` — 4 pola health w pozycji listy (notificationHealthStatus, notificationFailureCount, notificationLastFailureAt, notificationLastFailureOutcome).
+- Frontend: `NotificationHealthBadge` (4 stany) w tabeli listy; `NotificationHealthPanel` w detail.
+- Uwaga runtime: backend serwuje skompilowany `dist/` — po zmianie kodu wymagany `npm run build` i restart procesu backend.
+
 ---
 
 ## Ciaglosc miedzy sesjami

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-commercial-owner.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-commercial-owner.service.test.ts
@@ -155,6 +155,7 @@ function makeDetailRow(overrides: Record<string, unknown> = {}) {
     infrastructureOperator: null,
     assignedUser: null,
     commercialOwner: null,
+    events: [],
     ...overrides,
   }
 }

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-notification-health.helper.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-notification-health.helper.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+import {
+  computeNotificationHealth,
+  type NotificationFailureEventData,
+} from '../porting-notification-health.helper'
+
+function makeEvent(
+  description: string | null,
+  occurredAt: Date = new Date('2026-04-09T10:00:00.000Z'),
+): NotificationFailureEventData {
+  return { description, occurredAt }
+}
+
+describe('computeNotificationHealth', () => {
+  it('returns OK status when no events', () => {
+    const result = computeNotificationHealth([])
+    expect(result.status).toBe('OK')
+    expect(result.failureCount).toBe(0)
+    expect(result.failedCount).toBe(0)
+    expect(result.misconfiguredCount).toBe(0)
+    expect(result.lastFailureAt).toBeNull()
+    expect(result.lastFailureOutcome).toBeNull()
+  })
+
+  it('returns FAILED status for events with FAILED description', () => {
+    const events = [makeEvent('Dispatch to email FAILED')]
+    const result = computeNotificationHealth(events)
+    expect(result.status).toBe('FAILED')
+    expect(result.failureCount).toBe(1)
+    expect(result.failedCount).toBe(1)
+    expect(result.misconfiguredCount).toBe(0)
+    expect(result.lastFailureOutcome).toBe('FAILED')
+    expect(result.lastFailureAt).not.toBeNull()
+  })
+
+  it('returns MISCONFIGURED status for events with MISCONFIGURED description', () => {
+    const events = [makeEvent('Dispatch to email MISCONFIGURED — adapter disabled')]
+    const result = computeNotificationHealth(events)
+    expect(result.status).toBe('MISCONFIGURED')
+    expect(result.failureCount).toBe(1)
+    expect(result.failedCount).toBe(0)
+    expect(result.misconfiguredCount).toBe(1)
+    expect(result.lastFailureOutcome).toBe('MISCONFIGURED')
+  })
+
+  it('returns MIXED status when both FAILED and MISCONFIGURED events exist', () => {
+    const events = [
+      makeEvent('Dispatch to email FAILED', new Date('2026-04-09T08:00:00.000Z')),
+      makeEvent('Dispatch to teams MISCONFIGURED', new Date('2026-04-09T09:00:00.000Z')),
+    ]
+    const result = computeNotificationHealth(events)
+    expect(result.status).toBe('MIXED')
+    expect(result.failureCount).toBe(2)
+    expect(result.failedCount).toBe(1)
+    expect(result.misconfiguredCount).toBe(1)
+  })
+
+  it('picks the most recent event for lastFailureAt and lastFailureOutcome', () => {
+    const earlier = new Date('2026-04-09T08:00:00.000Z')
+    const later = new Date('2026-04-09T12:00:00.000Z')
+    const events = [
+      makeEvent('Dispatch FAILED', earlier),
+      makeEvent('Dispatch MISCONFIGURED', later),
+    ]
+    const result = computeNotificationHealth(events)
+    expect(result.lastFailureAt).toBe(later.toISOString())
+    expect(result.lastFailureOutcome).toBe('MISCONFIGURED')
+  })
+
+  it('returns FAILED status when all events have unrecognized descriptions', () => {
+    const events = [makeEvent('Some unknown error message'), makeEvent(null)]
+    const result = computeNotificationHealth(events)
+    expect(result.status).toBe('FAILED')
+    expect(result.failureCount).toBe(2)
+    expect(result.failedCount).toBe(0)
+    expect(result.misconfiguredCount).toBe(0)
+  })
+
+  it('counts multiple events of the same type correctly', () => {
+    const events = [
+      makeEvent('Dispatch FAILED', new Date('2026-04-09T08:00:00.000Z')),
+      makeEvent('Dispatch FAILED', new Date('2026-04-09T09:00:00.000Z')),
+      makeEvent('Dispatch FAILED', new Date('2026-04-09T10:00:00.000Z')),
+    ]
+    const result = computeNotificationHealth(events)
+    expect(result.status).toBe('FAILED')
+    expect(result.failureCount).toBe(3)
+    expect(result.failedCount).toBe(3)
+    expect(result.misconfiguredCount).toBe(0)
+  })
+
+  it('lastFailureAt is an ISO string', () => {
+    const date = new Date('2026-04-09T10:30:00.000Z')
+    const result = computeNotificationHealth([makeEvent('FAILED', date)])
+    expect(result.lastFailureAt).toBe('2026-04-09T10:30:00.000Z')
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-request-assignment.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-request-assignment.service.test.ts
@@ -181,6 +181,9 @@ function makeDetailRow(overrides: Record<string, unknown> = {}) {
     recipientOperator: makeOperator({ id: 'operator-2', name: 'G-NET', shortName: 'GNET', routingNumber: '2700' }),
     infrastructureOperator: null,
     assignedUser: null,
+    commercialOwner: null,
+    commercialOwnerUserId: null,
+    events: [],
     ...overrides,
   }
 }

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.detail.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.detail.service.test.ts
@@ -108,6 +108,12 @@ function makeDetailRow() {
       isActive: true,
     },
     infrastructureOperator: null,
+    assignedAt: null,
+    assignedByUserId: null,
+    assignedUser: null,
+    commercialOwner: null,
+    commercialOwnerUserId: null,
+    events: [],
   }
 }
 

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
@@ -282,7 +282,7 @@ describe('listPortingRequests - commercial owner and notification health filters
           role: 'SALES',
           isActive: true,
         },
-        events: [{ id: 'event-1' }],
+        events: [{ description: 'Dispatch to email FAILED', occurredAt: new Date('2026-04-09T10:00:00.000Z') }],
       }),
     ])
 

--- a/apps/backend/src/modules/porting-requests/porting-notification-health.helper.ts
+++ b/apps/backend/src/modules/porting-requests/porting-notification-health.helper.ts
@@ -1,0 +1,79 @@
+// This helper computes notification health diagnostics from failure events.
+// Single place of truth for all health computation logic.
+
+export type NotificationHealthStatus = 'OK' | 'FAILED' | 'MISCONFIGURED' | 'MIXED'
+export type NotificationFailureOutcome = 'FAILED' | 'MISCONFIGURED'
+
+export interface NotificationFailureEventData {
+  description: string | null
+  occurredAt: Date
+}
+
+export interface NotificationHealthResult {
+  status: NotificationHealthStatus
+  failureCount: number
+  failedCount: number
+  misconfiguredCount: number
+  lastFailureAt: string | null
+  lastFailureOutcome: NotificationFailureOutcome | null
+}
+
+function detectOutcome(description: string | null): NotificationFailureOutcome | null {
+  if (!description) return null
+  // Check MISCONFIGURED first since it does not contain 'FAILED' as substring.
+  if (description.includes('MISCONFIGURED')) return 'MISCONFIGURED'
+  if (description.includes('FAILED')) return 'FAILED'
+  return null
+}
+
+export function computeNotificationHealth(
+  events: NotificationFailureEventData[],
+): NotificationHealthResult {
+  if (events.length === 0) {
+    return {
+      status: 'OK',
+      failureCount: 0,
+      failedCount: 0,
+      misconfiguredCount: 0,
+      lastFailureAt: null,
+      lastFailureOutcome: null,
+    }
+  }
+
+  let failedCount = 0
+  let misconfiguredCount = 0
+  let lastFailureAt: Date | null = null
+  let lastFailureOutcome: NotificationFailureOutcome | null = null
+
+  for (const event of events) {
+    const outcome = detectOutcome(event.description)
+    if (outcome === 'FAILED') failedCount++
+    else if (outcome === 'MISCONFIGURED') misconfiguredCount++
+
+    if (lastFailureAt === null || event.occurredAt > lastFailureAt) {
+      lastFailureAt = event.occurredAt
+      lastFailureOutcome = outcome
+    }
+  }
+
+  let status: NotificationHealthStatus
+  if (failedCount > 0 && misconfiguredCount > 0) {
+    status = 'MIXED'
+  } else if (failedCount > 0) {
+    status = 'FAILED'
+  } else if (misconfiguredCount > 0) {
+    status = 'MISCONFIGURED'
+  } else {
+    // All events had unrecognized descriptions - treat as failures
+    status = 'FAILED'
+  }
+
+  return {
+    status,
+    failureCount: events.length,
+    failedCount,
+    misconfiguredCount,
+    lastFailureAt: lastFailureAt ? lastFailureAt.toISOString() : null,
+    lastFailureOutcome,
+  }
+}

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -32,6 +32,7 @@ import type {
   UpdatePortingRequestStatusBody,
 } from './porting-requests.schema'
 import { dispatchPortingNotification } from './porting-notification.service'
+import { computeNotificationHealth } from './porting-notification-health.helper'
 import { PORTING_NOTIFICATION_EVENT } from './porting-notification-events'
 import {
   PLI_CBD_TRIGGER_SELECT,
@@ -130,8 +131,7 @@ const LIST_SELECT = {
   },
   events: {
     where: NOTIFICATION_FAILURE_EVENT_WHERE,
-    select: { id: true },
-    take: 1,
+    select: { description: true, occurredAt: true },
   },
 } as const
 
@@ -190,6 +190,10 @@ const DETAIL_SELECT = {
   infrastructureOperator: { select: OPERATOR_SELECT },
   assignedUser: { select: ASSIGNEE_SELECT },
   commercialOwner: { select: ASSIGNEE_SELECT },
+  events: {
+    where: NOTIFICATION_FAILURE_EVENT_WHERE,
+    select: { description: true, occurredAt: true },
+  },
 } as const
 
 type ClientRow = Prisma.ClientGetPayload<{ select: typeof CLIENT_SELECT }>
@@ -658,6 +662,7 @@ async function throwBlockedPliCbdIntegrationAttempt(
 }
 
 function toListItem(row: ListRow): PortingRequestListItemDto {
+  const notifHealth = computeNotificationHealth(row.events)
   return {
     id: row.id,
     caseNumber: row.caseNumber,
@@ -671,6 +676,10 @@ function toListItem(row: ListRow): PortingRequestListItemDto {
     assignedUserSummary: toAssigneeSummary(row.assignedUser),
     commercialOwnerSummary: toCommercialOwnerSummary(row.commercialOwner),
     hasNotificationFailures: row.events.length > 0,
+    notificationHealthStatus: notifHealth.status,
+    notificationFailureCount: notifHealth.failureCount,
+    notificationLastFailureAt: notifHealth.lastFailureAt,
+    notificationLastFailureOutcome: notifHealth.lastFailureOutcome,
     createdAt: row.createdAt.toISOString(),
   }
 }
@@ -770,6 +779,7 @@ function toDetailDto(
       communicationHistory,
     ),
     communicationSummary: buildCommunicationSummary(communicationHistory),
+    notificationHealth: computeNotificationHealth(row.events),
   }
 }
 

--- a/apps/frontend/src/lib/portingOwnership.test.ts
+++ b/apps/frontend/src/lib/portingOwnership.test.ts
@@ -37,6 +37,10 @@ function buildListItem(
       : null,
     commercialOwnerSummary: null,
     hasNotificationFailures: false,
+    notificationHealthStatus: 'OK',
+    notificationFailureCount: 0,
+    notificationLastFailureAt: null,
+    notificationLastFailureOutcome: null,
     createdAt: '2026-04-09T10:00:00.000Z',
   }
 }

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -65,6 +65,7 @@ import {
   type PortingRequestAssignmentHistoryItemDto,
   type PortingRequestStatusActionDto,
   type CommercialOwnerCandidateDto,
+  type NotificationHealthDiagnosticsDto,
 } from '@np-manager/shared'
 import { PortingAssignmentPanel } from '@/components/PortingAssignmentPanel/PortingAssignmentPanel'
 import { PortingCaseHistory } from '@/components/PortingCaseHistory/PortingCaseHistory'
@@ -313,6 +314,76 @@ function buildAdminTransportBanner(result: PliCbdManualExportResultDto) {
               : `Eksport nieudany: ${result.errorMessage ?? 'Nieznany blad'}`
 
   return { bannerClass, headline }
+}
+
+function NotificationHealthPanel({ health }: { health: NotificationHealthDiagnosticsDto }) {
+  const statusConfig: Record<
+    NotificationHealthDiagnosticsDto['status'],
+    { label: string; badgeClass: string; panelClass: string }
+  > = {
+    OK: {
+      label: 'OK — brak bledow notyfikacji',
+      badgeClass: 'bg-emerald-100 text-emerald-700',
+      panelClass: 'border-emerald-200 bg-emerald-50',
+    },
+    FAILED: {
+      label: 'Blad wysylki',
+      badgeClass: 'bg-red-100 text-red-700',
+      panelClass: 'border-red-200 bg-red-50',
+    },
+    MISCONFIGURED: {
+      label: 'Blad konfiguracji',
+      badgeClass: 'bg-amber-100 text-amber-700',
+      panelClass: 'border-amber-200 bg-amber-50',
+    },
+    MIXED: {
+      label: 'Bledy mieszane',
+      badgeClass: 'bg-orange-100 text-orange-700',
+      panelClass: 'border-orange-200 bg-orange-50',
+    },
+  }
+
+  const config = statusConfig[health.status]
+
+  return (
+    <div className={`rounded-lg border p-4 ${config.panelClass}`}>
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-semibold text-gray-700">Diagnostyka powiadomien wewnetrznych</h3>
+        <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${config.badgeClass}`}>
+          {config.label}
+        </span>
+      </div>
+      {health.status !== 'OK' && (
+        <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs sm:grid-cols-4">
+          <div>
+            <dt className="text-gray-500">Wszystkich bledow</dt>
+            <dd className="font-medium text-gray-800">{health.failureCount}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Blad wysylki</dt>
+            <dd className="font-medium text-gray-800">{health.failedCount}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Blad konfiguracji</dt>
+            <dd className="font-medium text-gray-800">{health.misconfiguredCount}</dd>
+          </div>
+          <div>
+            <dt className="text-gray-500">Ostatni blad</dt>
+            <dd className="font-medium text-gray-800">
+              {health.lastFailureAt
+                ? new Date(health.lastFailureAt).toLocaleDateString('pl-PL', {
+                    day: '2-digit',
+                    month: '2-digit',
+                    year: 'numeric',
+                  })
+                : '—'}
+              {health.lastFailureOutcome ? ` (${health.lastFailureOutcome})` : ''}
+            </dd>
+          </div>
+        </dl>
+      )}
+    </div>
+  )
 }
 
 export function RequestDetailPage() {
@@ -1436,6 +1507,8 @@ export function RequestDetailPage() {
           />
 
           <PortingCaseHistory items={caseHistoryItems} isLoading={isCaseHistoryLoading} />
+
+          <NotificationHealthPanel health={request.notificationHealth} />
 
           <PortingInternalNotificationsPanel
             items={internalNotificationItems}

--- a/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
@@ -17,6 +17,10 @@ function makeRequest(overrides: Partial<PortingRequestListItemDto> = {}): Portin
     assignedUserSummary: null,
     commercialOwnerSummary: null,
     hasNotificationFailures: false,
+    notificationHealthStatus: 'OK',
+    notificationFailureCount: 0,
+    notificationLastFailureAt: null,
+    notificationLastFailureOutcome: null,
     createdAt: '2026-04-09T10:00:00.000Z',
     ...overrides,
   }
@@ -36,6 +40,10 @@ describe('RequestRow', () => {
                 role: 'SALES',
               },
               hasNotificationFailures: true,
+              notificationHealthStatus: 'FAILED',
+              notificationFailureCount: 3,
+              notificationLastFailureAt: '2026-04-09T10:00:00.000Z',
+              notificationLastFailureOutcome: 'FAILED',
             })}
             onClick={() => undefined}
             formatDate={() => '09.04.2026'}
@@ -45,7 +53,8 @@ describe('RequestRow', () => {
     )
 
     expect(html).toContain('Anna Handlowa (sales-1@np-manager.local)')
-    expect(html).toContain('Blad')
+    expect(html).toContain('Blad wysylki')
+    expect(html).toContain('3 bledow')
   })
 
   it('shows missing owner and healthy notification badge', () => {

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -17,6 +17,7 @@ import {
   PORTING_MODE_LABELS,
 } from '@np-manager/shared'
 import type {
+  NotificationHealthStatus,
   PortingCaseStatus,
   PortingMode,
   PortingRequestListItemDto,
@@ -68,19 +69,40 @@ function StatusBadge({ status }: { status: PortingCaseStatus }) {
   )
 }
 
-function NotificationHealthBadge({ hasFailures }: { hasFailures: boolean }) {
-  if (!hasFailures) {
+function NotificationHealthBadge({ request }: { request: PortingRequestListItemDto }) {
+  const { notificationHealthStatus, notificationFailureCount, notificationLastFailureAt } = request
+
+  const statusConfig: Record<NotificationHealthStatus, { label: string; className: string }> = {
+    OK: { label: 'OK', className: 'bg-emerald-100 text-emerald-700' },
+    FAILED: { label: 'Blad wysylki', className: 'bg-red-100 text-red-700' },
+    MISCONFIGURED: { label: 'Blad konfiguracji', className: 'bg-amber-100 text-amber-700' },
+    MIXED: { label: 'Bledy mieszane', className: 'bg-orange-100 text-orange-700' },
+  }
+
+  const config = statusConfig[notificationHealthStatus]
+
+  if (notificationHealthStatus === 'OK') {
     return (
-      <span className="inline-flex items-center rounded px-2 py-0.5 text-xs font-medium bg-emerald-100 text-emerald-700">
+      <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${config.className}`}>
         OK
       </span>
     )
   }
 
+  const lastFailureDate = notificationLastFailureAt
+    ? new Date(notificationLastFailureAt).toLocaleDateString('pl-PL', { day: '2-digit', month: '2-digit', year: 'numeric' })
+    : null
+
   return (
-    <span className="inline-flex items-center rounded px-2 py-0.5 text-xs font-medium bg-red-100 text-red-700">
-      Blad
-    </span>
+    <div className="flex flex-col gap-0.5">
+      <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${config.className}`}>
+        {config.label}
+      </span>
+      <span className="text-xs text-gray-400">
+        {notificationFailureCount} {notificationFailureCount === 1 ? 'blad' : 'bledow'}
+        {lastFailureDate ? `, ost. ${lastFailureDate}` : ''}
+      </span>
+    </div>
   )
 }
 
@@ -110,7 +132,7 @@ export function RequestRow({
         {formatCommercialOwnerLabel(request.commercialOwnerSummary)}
       </td>
       <td className="px-4 py-3 whitespace-nowrap">
-        <NotificationHealthBadge hasFailures={request.hasNotificationFailures} />
+        <NotificationHealthBadge request={request} />
       </td>
       <td className="px-4 py-3 text-gray-400 text-xs whitespace-nowrap">{formatDate(request.createdAt)}</td>
     </tr>

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -18,6 +18,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR13B | Realny transport wewnetrznych powiadomien email/Teams               | DONE   |
 | PR14  | Historia wewnetrznych notyfikacji w UI + panel admin settings       | DONE   |
 | PR15  | Raportowanie i widoki operacyjne commercial owner                    | DONE   |
+| PR16  | Diagnostyka zdrowia notyfikacji (health helper + 4-state badge)     | DONE   |
 
 ---
 
@@ -65,6 +66,17 @@ Dispatch jest non-blocking (`.catch(() => {})`) i nie blokuje glownego flow API.
   - Admin ma strone `Ustawienia powiadomien portingowych` do konfiguracji fallback email/Teams.
   - Read-only diagnostyka env: `email adapter mode`, `SMTP configured`.
 - Zakres pozostaje wewnetrzny (operacyjny) - bez zmian w customer communication pipeline.
+
+### PR16 - diagnostyka zdrowia notyfikacji
+
+- Nowy helper `porting-notification-health.helper.ts` — jedyne miejsce obliczania `NotificationHealthStatus` (`OK | FAILED | MISCONFIGURED | MIXED`).
+- `NotificationHealthDiagnosticsDto` w `packages/shared` — failureCount, failedCount, misconfiguredCount, lastFailureAt, lastFailureOutcome.
+- `PortingRequestDetailDto.notificationHealth` — pelna diagnostyka w widoku szczegolu.
+- `PortingRequestListItemDto` — 4 pola health w pozycji listy.
+- Frontend `NotificationHealthBadge` (4 stany) w tabeli listy; `NotificationHealthPanel` w detail.
+- Weryfikacja: 334 testow backend + 99 testow frontend, oba projekty bez bledow TypeScript, build OK.
+- Wykryty problem runtime: backend serwuje skompilowany `dist/` — po PR15/PR16 endpoint `GET /api/porting-requests/summary` zwracal 404 (stary dist lapany przez handler `/:id`). Naprawione przez `npm run build` + restart backend.
+- Seed: 7 rekordow, wszystkie z health `OK`, failureCount = 0.
 
 ### PR15 - operacyjne raportowanie commercial owner i health notyfikacji
 
@@ -153,6 +165,7 @@ apps/backend/src/modules/porting-requests/
   porting-notification.service.ts          # dispatcher (PR13A+PR13B)
   internal-notification.adapter.ts         # email + Teams transport (PR13B)
   internal-notification-formatter.ts       # formatter tresci wiadomosci (PR13B)
+  porting-notification-health.helper.ts    # single source of truth dla health computation (PR16)
 
 apps/backend/prisma/
   schema.prisma
@@ -185,6 +198,7 @@ apps/frontend/src/
 
 ## Kolejne kroki
 
+- **PR17**: Historia powiadomien w UI oparta o `notificationHealth` (np. lista transport audit w detail) lub panel ustawien systemowych dla admina — do ustalenia.
 - Future: podlaczenie pozostalych eventow z katalogu (E03, E06, E12, E13, NUMBER_PORTED, CASE_REJECTED)
 
 ---

--- a/packages/shared/src/dto/porting-requests.dto.ts
+++ b/packages/shared/src/dto/porting-requests.dto.ts
@@ -26,6 +26,16 @@ import type {
 export type OwnershipFilter = 'ALL' | 'MINE' | 'UNASSIGNED'
 export type CommercialOwnerFilter = 'ALL' | 'WITH_OWNER' | 'WITHOUT_OWNER' | 'MINE'
 export type NotificationHealthFilter = 'ALL' | 'HAS_FAILURES' | 'NO_FAILURES'
+export type NotificationHealthStatus = 'OK' | 'FAILED' | 'MISCONFIGURED' | 'MIXED'
+
+export interface NotificationHealthDiagnosticsDto {
+  status: NotificationHealthStatus
+  failureCount: number
+  failedCount: number
+  misconfiguredCount: number
+  lastFailureAt: string | null
+  lastFailureOutcome: 'FAILED' | 'MISCONFIGURED' | null
+}
 
 // ============================================================
 // OPIEKUN HANDLOWY
@@ -92,6 +102,10 @@ export interface PortingRequestListItemDto {
   assignedUserSummary: PortingRequestAssigneeSummaryDto | null
   commercialOwnerSummary: CommercialOwnerSummaryDto | null
   hasNotificationFailures: boolean
+  notificationHealthStatus: NotificationHealthStatus
+  notificationFailureCount: number
+  notificationLastFailureAt: string | null
+  notificationLastFailureOutcome: 'FAILED' | 'MISCONFIGURED' | null
   createdAt: string
 }
 
@@ -267,6 +281,7 @@ export interface PortingRequestDetailDto {
   availableExternalActions: PortingRequestExternalActionDto[]
   availableCommunicationActions: PortingRequestCommunicationActionDto[]
   communicationSummary: PortingCommunicationSummaryDto
+  notificationHealth: NotificationHealthDiagnosticsDto
 }
 
 export interface PortingRequestAssignmentHistoryItemDto {


### PR DESCRIPTION
## Cel

PR16 zastępuje binarny sygnał \`hasNotificationFailures\` kompletną diagnostyką
zdrowia notyfikacji wewnętrznych: 4-stanowy status (\`OK / FAILED / MISCONFIGURED / MIXED\`),
licznik błędów, data ostatniego zdarzenia oraz typ outcome.

## Zakres zmian

### Backend
- Nowy helper \`porting-notification-health.helper.ts\` — \`computeNotificationHealth()\` jako jedyne
  źródło prawdy dla obliczania statusu health. Zero duplikacji logiki.
- \`PortingRequestListItemDto\` rozszerzony o: \`notificationHealthStatus\`, \`notificationFailureCount\`,
  \`notificationLastFailureAt\`, \`notificationLastFailureOutcome\`.
- \`PortingRequestDetailDto\` rozszerzony o \`notificationHealth: NotificationHealthDiagnosticsDto\`
  z pełnym breakdownem: failedCount, misconfiguredCount, lastFailureAt, lastFailureOutcome.

### Shared DTO (`@np-manager/shared`)
- Nowy typ \`NotificationHealthStatus = 'OK' | 'FAILED' | 'MISCONFIGURED' | 'MIXED'\`
- Nowy interfejs \`NotificationHealthDiagnosticsDto\`

### Frontend
- \`NotificationHealthBadge\` na liście spraw: 4 kolory, liczba błędów, data ostatniego problemu.
- Nowy panel „Stan notyfikacji wewnętrznych" na stronie szczegółów sprawy — przed historią powiadomień.

## Testy

- 7 nowych unit testów helpera (wszystkie przypadki graniczne)
- 334 testy backend — zielone ✅
- 99 testów frontend — zielone ✅
- TypeScript clean (backend + frontend) ✅
- Build monorepo — OK ✅

## Uwaga środowiskowa (runtime)

Podczas weryfikacji odkryto, że backend może serwować **stare pliki \`dist/\`**
skompilowane przed PR15/PR16. Objawia się to jako 404 na \`GET /api/porting-requests/summary\`
(endpoint łapany przez handler \`/:id\`). Naprawienie: \`npm run build\` w katalogu monorepo
+ restart backendu. Nie jest to bug logiki PR16 — jest to znana cecha środowiska \`tsx watch\`.
Udokumentowane w \`docs/PROJECT_CONTINUITY.md\`.

## Efekt biznesowy / operacyjny

Operatorzy BOK i opiekunowie handlowi widzą na liście spraw dokładny stan wysyłki
powiadomień: czy sprawa ma błędy konfiguracji, błędy wysyłki, czy oba typy naraz.
W szczegółach sprawy dostępny jest panel diagnostyczny z liczbą każdego typu błędu
i datą ostatniego zdarzenia — bez konieczności przeszukiwania historii powiadomień.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)