### PR TITLE
fix(porting-settings): walidacja wymaganego emaila i warunkowego URL webhooka Teams

### DIFF
--- a/apps/backend/src/modules/admin-settings/__tests__/admin-porting-notification-settings.schema.test.ts
+++ b/apps/backend/src/modules/admin-settings/__tests__/admin-porting-notification-settings.schema.test.ts
@@ -44,8 +44,8 @@ describe('updatePortingNotificationSettingsBodySchema', () => {
     ).toThrowError(/Podaj poprawny URL webhooka Teams/)
   })
 
-  describe('walidacja wymaganych pol', () => {
-    it('rzuca blad gdy sharedEmails jest pustym stringiem', () => {
+  describe('walidacja wymaganych pól', () => {
+    it('rzuca błąd gdy sharedEmails jest pustym stringiem', () => {
       expect(() =>
         updatePortingNotificationSettingsBodySchema.parse({
           sharedEmails: '',
@@ -55,7 +55,7 @@ describe('updatePortingNotificationSettingsBodySchema', () => {
       ).toThrowError(/Podaj co najmniej jeden adres email/)
     })
 
-    it('rzuca blad gdy sharedEmails jest undefined', () => {
+    it('rzuca błąd gdy sharedEmails jest undefined', () => {
       expect(() =>
         updatePortingNotificationSettingsBodySchema.parse({
           teamsEnabled: false,
@@ -64,36 +64,36 @@ describe('updatePortingNotificationSettingsBodySchema', () => {
       ).toThrowError(/Podaj co najmniej jeden adres email/)
     })
 
-    it('rzuca blad gdy teamsEnabled=true i teamsWebhookUrl jest pustym stringiem', () => {
+    it('rzuca błąd gdy teamsEnabled=true i teamsWebhookUrl jest pustym stringiem', () => {
       expect(() =>
         updatePortingNotificationSettingsBodySchema.parse({
           sharedEmails: 'bok@multiplay.pl',
           teamsEnabled: true,
           teamsWebhookUrl: '',
         }),
-      ).toThrowError(/Podaj URL webhooka Teams gdy Teams jest wlaczony/)
+      ).toThrowError(/Podaj URL webhooka Teams gdy Teams jest włączony/)
     })
 
-    it('rzuca blad gdy teamsEnabled=true i teamsWebhookUrl jest undefined', () => {
+    it('rzuca błąd gdy teamsEnabled=true i teamsWebhookUrl jest undefined', () => {
       expect(() =>
         updatePortingNotificationSettingsBodySchema.parse({
           sharedEmails: 'bok@multiplay.pl',
           teamsEnabled: true,
         }),
-      ).toThrowError(/Podaj URL webhooka Teams gdy Teams jest wlaczony/)
+      ).toThrowError(/Podaj URL webhooka Teams gdy Teams jest włączony/)
     })
 
-    it('przechodzi gdy teamsEnabled=false i teamsWebhookUrl jest pustym stringiem', () => {
+    it('nie rzuca błędu dla teamsWebhookUrl gdy teamsEnabled=false', () => {
       expect(() =>
         updatePortingNotificationSettingsBodySchema.parse({
           sharedEmails: 'bok@multiplay.pl',
           teamsEnabled: false,
           teamsWebhookUrl: '',
         }),
-      ).not.toThrowError(/Podaj URL webhooka Teams gdy Teams jest wlaczony/)
+      ).not.toThrow()
     })
 
-    it('przechodzi gdy sharedEmails jest poprawnym emailem i teamsEnabled=false', () => {
+    it('akceptuje poprawny email i teamsEnabled=false bez webhooka', () => {
       const parsed = updatePortingNotificationSettingsBodySchema.parse({
         sharedEmails: 'bok@multiplay.pl',
         teamsEnabled: false,
@@ -104,7 +104,7 @@ describe('updatePortingNotificationSettingsBodySchema', () => {
       expect(parsed.teamsEnabled).toBe(false)
     })
 
-    it('przechodzi gdy sharedEmails jest poprawny, teamsEnabled=true i teamsWebhookUrl jest poprawnym URL', () => {
+    it('akceptuje poprawny email i teamsEnabled=true z poprawnym webhookiem', () => {
       const parsed = updatePortingNotificationSettingsBodySchema.parse({
         sharedEmails: 'bok@multiplay.pl',
         teamsEnabled: true,

--- a/apps/backend/src/modules/admin-settings/admin-porting-notification-settings.schema.ts
+++ b/apps/backend/src/modules/admin-settings/admin-porting-notification-settings.schema.ts
@@ -56,7 +56,7 @@ export const updatePortingNotificationSettingsBodySchema = z
       .refine((value) => isValidWebhookUrl(value), 'Podaj poprawny URL webhooka Teams.'),
   })
   .superRefine((data, ctx) => {
-    if (!data.sharedEmails) {
+    if (!data.sharedEmails || data.sharedEmails.trim() === '') {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Podaj co najmniej jeden adres email',
@@ -64,10 +64,10 @@ export const updatePortingNotificationSettingsBodySchema = z
       })
     }
 
-    if (data.teamsEnabled && !data.teamsWebhookUrl) {
+    if (data.teamsEnabled && (!data.teamsWebhookUrl || data.teamsWebhookUrl.trim() === '')) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Podaj URL webhooka Teams gdy Teams jest wlaczony',
+        message: 'Podaj URL webhooka Teams gdy Teams jest włączony',
         path: ['teamsWebhookUrl'],
       })
     }


### PR DESCRIPTION
## Problem

Dwa bugi znalezione przez QA w ekranie `/admin/porting-notification-settings`:

- **Bug #1:** `sharedEmails` = pusty string → walidacja przechodzi (200 OK)
- **Bug #2:** `teamsEnabled=true` + pusty `teamsWebhookUrl` → brak walidacji warunkowej (200 OK)

## Rozwiązanie

Dodano `.superRefine()` na schemacie `updatePortingNotificationSettingsBodySchema` — identyczny wzorzec jak w `admin-notification-fallback-settings.schema.ts`:

### A) `sharedEmails` wymagany
Gdy `sharedEmails` jest pustym stringiem lub brak wartości → błąd:
> `Podaj co najmniej jeden adres email`

### B) `teamsWebhookUrl` wymagany warunkowo
Gdy `teamsEnabled === true` && `teamsWebhookUrl` jest pusty lub undefined → błąd:
> `Podaj URL webhooka Teams gdy Teams jest włączony`

Gdy `teamsEnabled=false` — pusty webhook jest akceptowalny (bez zmian).

## Zakres zmian

- `apps/backend/src/modules/admin-settings/admin-porting-notification-settings.schema.ts` — dodano `.superRefine()`
- `apps/backend/src/modules/admin-settings/__tests__/admin-porting-notification-settings.schema.test.ts` — dopisano `describe('walidacja wymaganych pól', ...)` z 7 przypadkami testowymi

**NIE zmieniono:** serwisu, routera, shared DTO, frontendu, istniejących testów.

## Weryfikacja

- [ ] `npx tsc --noEmit -p apps/backend/tsconfig.json` → 0 błędów
- [ ] `vitest run` (backend, plik testowy schematu) → wszystkie passing
- [ ] `vitest run` (backend, admin-settings `__tests__`) → brak regresji