### PR TITLE
feat(PR18A): Fallback Runtime Completion (error fallback execution + audit)

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-internal-notification-history.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-internal-notification-history.service.test.ts
@@ -65,7 +65,7 @@ describe('getPortingRequestInternalNotifications', () => {
     })
   })
 
-  it('maps team routing notes and dispatch audit notes to DTO entries', async () => {
+  it('maps team routing notes, dispatch notes and error fallback notes to DTO entries', async () => {
     mockPortingRequestFindUnique.mockResolvedValueOnce({ id: 'request-2' })
     mockNotificationFindMany.mockResolvedValueOnce([])
     mockPortingRequestEventFindMany.mockResolvedValueOnce([
@@ -73,21 +73,28 @@ describe('getPortingRequestInternalNotifications', () => {
         id: 'event-routing-1',
         title: 'Powiadomienie zespolowe: Zmiana statusu sprawy',
         description:
-          'Routing do e-mail: bok@multiplay.pl, sud@multiplay.pl. Kontekst: {"newStatus":"PORTED"}.',
+          'Rodzaj fallbacku: ROUTING_TEAM. Routing do e-mail: bok@multiplay.pl, sud@multiplay.pl. Kontekst: {"newStatus":"PORTED"}.',
         occurredAt: new Date('2026-04-09T10:00:00.000Z'),
       },
       {
         id: 'event-dispatch-1',
         title: '[Dispatch] Zmiana statusu sprawy',
         description:
-          'EMAIL â†’ bok@multiplay.pl: SENT (tryb: STUB), msgId: stub-123\nTEAMS â†’ https://teams.example/hook: FAILED (tryb: REAL) â€” blad: HTTP 500',
+          'EMAIL -> bok@multiplay.pl: SENT (tryb: STUB), msgId: stub-123\nTEAMS -> https://teams.example/hook: FAILED (tryb: REAL) - blad: HTTP 500',
         occurredAt: new Date('2026-04-09T10:01:00.000Z'),
+      },
+      {
+        id: 'event-fallback-1',
+        title: '[ErrorFallback] Zmiana statusu sprawy',
+        description:
+          'EMAIL -> fallback@np-manager.local: SKIPPED (tryb: POLICY) - powod: POLICY_DISABLED; sourceOutcomes=FAILED; matchedOutcomes=BRAK; readiness=DISABLED',
+        occurredAt: new Date('2026-04-09T10:02:00.000Z'),
       },
     ])
 
     const result = await getPortingRequestInternalNotifications('request-2')
 
-    expect(result.items).toHaveLength(3)
+    expect(result.items).toHaveLength(4)
 
     const routingEntry = result.items.find((item) => item.entryType === 'TEAM_ROUTING')
     expect(routingEntry).toMatchObject({
@@ -98,15 +105,23 @@ describe('getPortingRequestInternalNotifications', () => {
     })
 
     const dispatchEntries = result.items.filter((item) => item.entryType === 'TRANSPORT_AUDIT')
-    expect(dispatchEntries).toHaveLength(2)
+    expect(dispatchEntries).toHaveLength(3)
+
     expect(dispatchEntries[0]).toMatchObject({
+      channel: 'EMAIL',
+      recipient: 'fallback@np-manager.local',
+      outcome: 'SKIPPED',
+      mode: 'POLICY',
+      errorMessage: null,
+    })
+    expect(dispatchEntries[1]).toMatchObject({
       channel: 'EMAIL',
       recipient: 'bok@multiplay.pl',
       outcome: 'SENT',
       mode: 'STUB',
       errorMessage: null,
     })
-    expect(dispatchEntries[1]).toMatchObject({
+    expect(dispatchEntries[2]).toMatchObject({
       channel: 'TEAMS',
       recipient: 'https://teams.example/hook',
       outcome: 'FAILED',

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-notification-fallback-policy.resolver.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-notification-fallback-policy.resolver.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SYSTEM_SETTING_KEYS } from '@np-manager/shared'
+
+const { mockSystemSettingFindUnique } = vi.hoisted(() => ({
+  mockSystemSettingFindUnique: vi.fn(),
+}))
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    systemSetting: {
+      findUnique: (...args: unknown[]) => mockSystemSettingFindUnique(...args),
+    },
+  },
+}))
+
+import {
+  decideNotificationErrorFallback,
+  extractFailureOutcomesFromDispatch,
+  resolveNotificationFallbackPolicy,
+} from '../porting-notification-fallback-policy.resolver'
+
+describe('porting-notification-fallback-policy.resolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns disabled policy defaults when settings are missing', async () => {
+    mockSystemSettingFindUnique.mockResolvedValue(null)
+
+    const policy = await resolveNotificationFallbackPolicy()
+
+    expect(policy).toEqual({
+      fallbackEnabled: false,
+      fallbackRecipientEmail: '',
+      fallbackRecipientName: '',
+      applyToFailed: true,
+      applyToMisconfigured: true,
+      readiness: 'DISABLED',
+    })
+  })
+
+  it('marks policy as INCOMPLETE when fallback is enabled without recipient email', async () => {
+    const byKey = new Map<string, { value: string }>([
+      [SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_ENABLED, { value: 'true' }],
+      [SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_RECIPIENT_EMAIL, { value: '' }],
+      [SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_RECIPIENT_NAME, { value: 'BOK Fallback' }],
+      [SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_APPLY_TO_FAILED, { value: 'true' }],
+      [SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_APPLY_TO_MISCONFIGURED, { value: 'true' }],
+    ])
+
+    mockSystemSettingFindUnique.mockImplementation(async (args: { where: { key: string } }) => {
+      return byKey.get(args.where.key) ?? null
+    })
+
+    const policy = await resolveNotificationFallbackPolicy()
+    expect(policy.readiness).toBe('INCOMPLETE')
+  })
+
+  it('extracts unique FAILED/MISCONFIGURED outcomes from dispatch results', () => {
+    const outcomes = extractFailureOutcomesFromDispatch([
+      {
+        channel: 'EMAIL',
+        recipient: 'a@np-manager.local',
+        outcome: 'FAILED',
+        mode: 'REAL',
+        messageId: null,
+        errorMessage: 'SMTP error',
+      },
+      {
+        channel: 'EMAIL',
+        recipient: 'b@np-manager.local',
+        outcome: 'FAILED',
+        mode: 'REAL',
+        messageId: null,
+        errorMessage: 'SMTP error',
+      },
+      {
+        channel: 'TEAMS',
+        recipient: 'https://teams.example/hook',
+        outcome: 'MISCONFIGURED',
+        mode: 'REAL',
+        errorMessage: 'Webhook missing',
+      },
+      {
+        channel: 'EMAIL',
+        recipient: 'c@np-manager.local',
+        outcome: 'SENT',
+        mode: 'REAL',
+        messageId: 'msg-1',
+        errorMessage: null,
+      },
+    ])
+
+    expect(outcomes).toEqual(['FAILED', 'MISCONFIGURED'])
+  })
+
+  it('returns TRIGGERED when FAILED outcome is allowed by policy', () => {
+    const decision = decideNotificationErrorFallback(
+      {
+        fallbackEnabled: true,
+        fallbackRecipientEmail: 'fallback@np-manager.local',
+        fallbackRecipientName: 'Fallback BOK',
+        applyToFailed: true,
+        applyToMisconfigured: false,
+        readiness: 'READY',
+      },
+      ['FAILED'],
+    )
+
+    expect(decision).toEqual({
+      shouldTrigger: true,
+      reason: 'TRIGGERED',
+      failureOutcomes: ['FAILED'],
+      matchedOutcomes: ['FAILED'],
+    })
+  })
+
+  it('returns OUTCOME_NOT_ENABLED when policy does not cover detected outcomes', () => {
+    const decision = decideNotificationErrorFallback(
+      {
+        fallbackEnabled: true,
+        fallbackRecipientEmail: 'fallback@np-manager.local',
+        fallbackRecipientName: 'Fallback BOK',
+        applyToFailed: false,
+        applyToMisconfigured: false,
+        readiness: 'READY',
+      },
+      ['FAILED', 'MISCONFIGURED'],
+    )
+
+    expect(decision).toEqual({
+      shouldTrigger: false,
+      reason: 'OUTCOME_NOT_ENABLED',
+      failureOutcomes: ['FAILED', 'MISCONFIGURED'],
+      matchedOutcomes: [],
+    })
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-notification.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-notification.service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { SYSTEM_SETTING_KEYS } from '@np-manager/shared'
 
 const {
   mockNotificationCreate,
@@ -6,12 +7,14 @@ const {
   mockResolveRecipients,
   mockSendInternalEmail,
   mockSendInternalTeamsWebhook,
+  mockSystemSettingFindUnique,
 } = vi.hoisted(() => ({
   mockNotificationCreate: vi.fn(),
   mockPortingRequestEventCreate: vi.fn(),
   mockResolveRecipients: vi.fn(),
   mockSendInternalEmail: vi.fn(),
   mockSendInternalTeamsWebhook: vi.fn(),
+  mockSystemSettingFindUnique: vi.fn(),
 }))
 
 vi.mock('../../../config/database', () => ({
@@ -21,6 +24,9 @@ vi.mock('../../../config/database', () => ({
     },
     portingRequestEvent: {
       create: (...args: unknown[]) => mockPortingRequestEventCreate(...args),
+    },
+    systemSetting: {
+      findUnique: (...args: unknown[]) => mockSystemSettingFindUnique(...args),
     },
   },
 }))
@@ -58,6 +64,38 @@ const STUB_TEAMS_RESULT = {
   errorMessage: null,
 }
 
+function mockFallbackPolicySettings(values: {
+  enabled?: string
+  recipientEmail?: string
+  recipientName?: string
+  applyToFailed?: string
+  applyToMisconfigured?: string
+}) {
+  const byKey = new Map<string, { value: string }>([
+    [SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_ENABLED, { value: values.enabled ?? 'false' }],
+    [
+      SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_RECIPIENT_EMAIL,
+      { value: values.recipientEmail ?? '' },
+    ],
+    [
+      SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_RECIPIENT_NAME,
+      { value: values.recipientName ?? '' },
+    ],
+    [
+      SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_APPLY_TO_FAILED,
+      { value: values.applyToFailed ?? 'true' },
+    ],
+    [
+      SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_APPLY_TO_MISCONFIGURED,
+      { value: values.applyToMisconfigured ?? 'true' },
+    ],
+  ])
+
+  mockSystemSettingFindUnique.mockImplementation(async (args: { where: { key: string } }) => {
+    return byKey.get(args.where.key) ?? null
+  })
+}
+
 // ============================================================
 // TESTS
 // ============================================================
@@ -69,6 +107,7 @@ describe('dispatchPortingNotification', () => {
     mockPortingRequestEventCreate.mockResolvedValue(undefined)
     mockSendInternalEmail.mockResolvedValue(STUB_EMAIL_RESULT)
     mockSendInternalTeamsWebhook.mockResolvedValue(STUB_TEAMS_RESULT)
+    mockFallbackPolicySettings({ enabled: 'false' })
   })
 
   // -------- USER recipient --------
@@ -349,6 +388,133 @@ describe('dispatchPortingNotification', () => {
       (call) => call[0].data.title === '[Dispatch] Zmiana statusu sprawy',
     )
     expect(auditCall![0].data.description).toContain('SMTP connection refused')
+  })
+
+  // -------- Error fallback execution --------
+
+  it('triggers error fallback email when primary dispatch returns FAILED and policy allows it', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'USER', userId: 'sales-1', email: 'sales@np.pl', displayName: 'Jan' },
+    ])
+    mockSendInternalEmail
+      .mockResolvedValueOnce({
+        channel: 'EMAIL',
+        recipient: 'sales@np.pl',
+        outcome: 'FAILED',
+        mode: 'REAL',
+        messageId: null,
+        errorMessage: 'SMTP primary failure',
+      })
+      .mockResolvedValueOnce({
+        channel: 'EMAIL',
+        recipient: 'fallback@np-manager.local',
+        outcome: 'SENT',
+        mode: 'REAL',
+        messageId: 'fallback-msg-1',
+        errorMessage: null,
+      })
+
+    mockFallbackPolicySettings({
+      enabled: 'true',
+      recipientEmail: 'fallback@np-manager.local',
+      recipientName: 'Fallback BOK',
+      applyToFailed: 'true',
+      applyToMisconfigured: 'false',
+    })
+
+    await dispatchPortingNotification({
+      requestId: 'request-fallback-trigger',
+      caseNumber: 'FNP-2026-FALLBACK-TRIGGER',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: 'sales-1',
+    })
+
+    expect(mockSendInternalEmail).toHaveBeenCalledTimes(2)
+    expect(mockSendInternalEmail.mock.calls[1]?.[0]).toMatchObject({
+      to: ['fallback@np-manager.local'],
+    })
+
+    const fallbackAuditCall = mockPortingRequestEventCreate.mock.calls.find(
+      (call) => call[0].data.title === '[ErrorFallback] Zmiana statusu sprawy',
+    )
+    expect(fallbackAuditCall).toBeDefined()
+    expect(fallbackAuditCall?.[0]?.data?.description).toContain('ERROR_FALLBACK_TRIGGERED')
+    expect(fallbackAuditCall?.[0]?.data?.description).toContain('fallback@np-manager.local')
+  })
+
+  it('writes skipped error fallback audit note when policy is disabled', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'USER', userId: 'sales-1', email: 'sales@np.pl', displayName: 'Jan' },
+    ])
+    mockSendInternalEmail.mockResolvedValueOnce({
+      channel: 'EMAIL',
+      recipient: 'sales@np.pl',
+      outcome: 'FAILED',
+      mode: 'REAL',
+      messageId: null,
+      errorMessage: 'SMTP down',
+    })
+
+    mockFallbackPolicySettings({ enabled: 'false' })
+
+    await dispatchPortingNotification({
+      requestId: 'request-fallback-skip',
+      caseNumber: 'FNP-2026-FALLBACK-SKIP',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: 'sales-1',
+    })
+
+    const fallbackAuditCall = mockPortingRequestEventCreate.mock.calls.find(
+      (call) => call[0].data.title === '[ErrorFallback] Zmiana statusu sprawy',
+    )
+    expect(fallbackAuditCall).toBeDefined()
+    expect(fallbackAuditCall?.[0]?.data?.description).toContain('SKIPPED')
+    expect(fallbackAuditCall?.[0]?.data?.description).toContain('POLICY_DISABLED')
+    expect(mockSendInternalEmail).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not create fallback loop when fallback email itself fails', async () => {
+    mockResolveRecipients.mockResolvedValueOnce([
+      { kind: 'USER', userId: 'sales-1', email: 'sales@np.pl', displayName: 'Jan' },
+    ])
+    mockSendInternalEmail
+      .mockResolvedValueOnce({
+        channel: 'EMAIL',
+        recipient: 'sales@np.pl',
+        outcome: 'FAILED',
+        mode: 'REAL',
+        messageId: null,
+        errorMessage: 'SMTP primary failure',
+      })
+      .mockResolvedValueOnce({
+        channel: 'EMAIL',
+        recipient: 'fallback@np-manager.local',
+        outcome: 'FAILED',
+        mode: 'REAL',
+        messageId: null,
+        errorMessage: 'SMTP fallback failure',
+      })
+
+    mockFallbackPolicySettings({
+      enabled: 'true',
+      recipientEmail: 'fallback@np-manager.local',
+      recipientName: 'Fallback BOK',
+      applyToFailed: 'true',
+      applyToMisconfigured: 'true',
+    })
+
+    await dispatchPortingNotification({
+      requestId: 'request-fallback-no-loop',
+      caseNumber: 'FNP-2026-FALLBACK-NO-LOOP',
+      event: PORTING_NOTIFICATION_EVENT.STATUS_CHANGED,
+      commercialOwnerUserId: 'sales-1',
+    })
+
+    expect(mockSendInternalEmail).toHaveBeenCalledTimes(2)
+    const fallbackAuditCall = mockPortingRequestEventCreate.mock.calls.find(
+      (call) => call[0].data.title === '[ErrorFallback] Zmiana statusu sprawy',
+    )
+    expect(fallbackAuditCall?.[0]?.data?.description).toContain('SMTP fallback failure')
   })
 
   // -------- Resilience --------

--- a/apps/backend/src/modules/porting-requests/porting-internal-notification-history.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-internal-notification-history.service.ts
@@ -11,6 +11,7 @@ import {
 
 const TEAM_ROUTING_TITLE_PREFIX = 'Powiadomienie zespolowe:'
 const DISPATCH_TITLE_PREFIX = '[Dispatch] '
+const ERROR_FALLBACK_TITLE_PREFIX = '[ErrorFallback] '
 
 const INTERNAL_NOTIFICATION_ENTRY_TYPES = {
   USER_NOTIFICATION: 'USER_NOTIFICATION',
@@ -83,6 +84,7 @@ export async function getPortingRequestInternalNotifications(
         OR: [
           { title: { startsWith: TEAM_ROUTING_TITLE_PREFIX } },
           { title: { startsWith: DISPATCH_TITLE_PREFIX } },
+          { title: { startsWith: ERROR_FALLBACK_TITLE_PREFIX } },
         ],
       },
       orderBy: { occurredAt: 'desc' },
@@ -149,7 +151,12 @@ function mapNoteEvents(
     }
 
     if (note.title.startsWith(DISPATCH_TITLE_PREFIX)) {
-      items.push(...mapDispatchNote(note))
+      items.push(...mapTransportAuditNote(note, DISPATCH_TITLE_PREFIX))
+      continue
+    }
+
+    if (note.title.startsWith(ERROR_FALLBACK_TITLE_PREFIX)) {
+      items.push(...mapTransportAuditNote(note, ERROR_FALLBACK_TITLE_PREFIX))
     }
   }
 
@@ -197,13 +204,16 @@ function mapTeamRoutingNote(note: {
   }
 }
 
-function mapDispatchNote(note: {
-  id: string
-  title: string
-  description: string | null
-  occurredAt: Date
-}): PortingInternalNotificationHistoryItemDto[] {
-  const eventLabel = note.title.slice(DISPATCH_TITLE_PREFIX.length).trim() || 'Powiadomienie wewnetrzne'
+function mapTransportAuditNote(
+  note: {
+    id: string
+    title: string
+    description: string | null
+    occurredAt: Date
+  },
+  titlePrefix: string,
+): PortingInternalNotificationHistoryItemDto[] {
+  const eventLabel = note.title.slice(titlePrefix.length).trim() || 'Powiadomienie wewnetrzne'
   const eventCode = EVENT_LABEL_TO_CODE[eventLabel] ?? null
   const lines = (note.description ?? '')
     .split(/\r?\n/)
@@ -249,8 +259,9 @@ function mapDispatchNote(note: {
 
 function parseDispatchLine(line: string): DispatchLineMapping {
   const baseMatch =
-    /^([A-Z]+)\s*(?:->|â†’)\s*(.+?):\s*([A-Z_]+)\s*\(tryb:\s*([A-Z_]+)\)(.*)$/i.exec(line) ??
-    /^([A-Z]+)\s+(.+?):\s*([A-Z_]+)\s*\(tryb:\s*([A-Z_]+)\)(.*)$/i.exec(line)
+    /^([A-Z]+)\s*(?:->|[^\w\s]{1,4})\s*(.+?):\s*([A-Z_]+)\s*\(tryb:\s*([A-Z_]+)\)(.*)$/i.exec(
+      line,
+    ) ?? /^([A-Z]+)\s+(.+?):\s*([A-Z_]+)\s*\(tryb:\s*([A-Z_]+)\)(.*)$/i.exec(line)
 
   if (!baseMatch) {
     return {

--- a/apps/backend/src/modules/porting-requests/porting-notification-fallback-policy.resolver.ts
+++ b/apps/backend/src/modules/porting-requests/porting-notification-fallback-policy.resolver.ts
@@ -1,0 +1,161 @@
+import { SYSTEM_SETTING_KEYS, type NotificationFallbackReadiness } from '@np-manager/shared'
+import { prisma } from '../../config/database'
+import type { InternalNotificationDispatchResult } from './internal-notification.adapter'
+import type { NotificationFailureOutcome } from './porting-notification-health.helper'
+
+export interface NotificationFallbackPolicy {
+  fallbackEnabled: boolean
+  fallbackRecipientEmail: string
+  fallbackRecipientName: string
+  applyToFailed: boolean
+  applyToMisconfigured: boolean
+  readiness: NotificationFallbackReadiness
+}
+
+export type NotificationErrorFallbackReason =
+  | 'TRIGGERED'
+  | 'NO_FAILURE_OUTCOMES'
+  | 'POLICY_DISABLED'
+  | 'POLICY_INCOMPLETE'
+  | 'OUTCOME_NOT_ENABLED'
+
+export interface NotificationErrorFallbackDecision {
+  shouldTrigger: boolean
+  reason: NotificationErrorFallbackReason
+  failureOutcomes: NotificationFailureOutcome[]
+  matchedOutcomes: NotificationFailureOutcome[]
+}
+
+const FALLBACK_SETTING_DEFAULTS = {
+  fallbackEnabled: 'false',
+  fallbackRecipientEmail: '',
+  fallbackRecipientName: '',
+  applyToFailed: 'true',
+  applyToMisconfigured: 'true',
+} as const
+
+export async function resolveNotificationFallbackPolicy(): Promise<NotificationFallbackPolicy> {
+  const [enabledRaw, recipientEmail, recipientName, applyToFailedRaw, applyToMisconfiguredRaw] =
+    await Promise.all([
+      readSetting(SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_ENABLED, FALLBACK_SETTING_DEFAULTS.fallbackEnabled),
+      readSetting(
+        SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_RECIPIENT_EMAIL,
+        FALLBACK_SETTING_DEFAULTS.fallbackRecipientEmail,
+      ),
+      readSetting(
+        SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_RECIPIENT_NAME,
+        FALLBACK_SETTING_DEFAULTS.fallbackRecipientName,
+      ),
+      readSetting(
+        SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_APPLY_TO_FAILED,
+        FALLBACK_SETTING_DEFAULTS.applyToFailed,
+      ),
+      readSetting(
+        SYSTEM_SETTING_KEYS.NOTIFICATION_FALLBACK_APPLY_TO_MISCONFIGURED,
+        FALLBACK_SETTING_DEFAULTS.applyToMisconfigured,
+      ),
+    ])
+
+  const fallbackEnabled = parseBooleanSetting(enabledRaw)
+  const applyToFailed = parseBooleanSetting(applyToFailedRaw)
+  const applyToMisconfigured = parseBooleanSetting(applyToMisconfiguredRaw)
+
+  return {
+    fallbackEnabled,
+    fallbackRecipientEmail: recipientEmail.trim(),
+    fallbackRecipientName: recipientName.trim(),
+    applyToFailed,
+    applyToMisconfigured,
+    readiness: computeReadiness(fallbackEnabled, recipientEmail),
+  }
+}
+
+export function extractFailureOutcomesFromDispatch(
+  results: InternalNotificationDispatchResult[],
+): NotificationFailureOutcome[] {
+  const outcomes = new Set<NotificationFailureOutcome>()
+
+  for (const result of results) {
+    if (result.outcome === 'FAILED' || result.outcome === 'MISCONFIGURED') {
+      outcomes.add(result.outcome)
+    }
+  }
+
+  return [...outcomes]
+}
+
+export function decideNotificationErrorFallback(
+  policy: NotificationFallbackPolicy,
+  failureOutcomes: NotificationFailureOutcome[],
+): NotificationErrorFallbackDecision {
+  if (failureOutcomes.length === 0) {
+    return {
+      shouldTrigger: false,
+      reason: 'NO_FAILURE_OUTCOMES',
+      failureOutcomes,
+      matchedOutcomes: [],
+    }
+  }
+
+  if (policy.readiness === 'DISABLED') {
+    return {
+      shouldTrigger: false,
+      reason: 'POLICY_DISABLED',
+      failureOutcomes,
+      matchedOutcomes: [],
+    }
+  }
+
+  if (policy.readiness === 'INCOMPLETE') {
+    return {
+      shouldTrigger: false,
+      reason: 'POLICY_INCOMPLETE',
+      failureOutcomes,
+      matchedOutcomes: [],
+    }
+  }
+
+  const matchedOutcomes = failureOutcomes.filter((outcome) => {
+    if (outcome === 'FAILED') return policy.applyToFailed
+    return policy.applyToMisconfigured
+  })
+
+  if (matchedOutcomes.length === 0) {
+    return {
+      shouldTrigger: false,
+      reason: 'OUTCOME_NOT_ENABLED',
+      failureOutcomes,
+      matchedOutcomes: [],
+    }
+  }
+
+  return {
+    shouldTrigger: true,
+    reason: 'TRIGGERED',
+    failureOutcomes,
+    matchedOutcomes,
+  }
+}
+
+async function readSetting(key: string, fallbackValue: string): Promise<string> {
+  const result = await prisma.systemSetting.findUnique({
+    where: { key },
+    select: { value: true },
+  })
+
+  return result?.value ?? fallbackValue
+}
+
+function parseBooleanSetting(rawValue: string): boolean {
+  const normalized = rawValue.trim().toLowerCase()
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on'
+}
+
+function computeReadiness(
+  fallbackEnabled: boolean,
+  fallbackRecipientEmail: string,
+): NotificationFallbackReadiness {
+  if (!fallbackEnabled) return 'DISABLED'
+  if (!fallbackRecipientEmail.trim()) return 'INCOMPLETE'
+  return 'READY'
+}

--- a/apps/backend/src/modules/porting-requests/porting-notification.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-notification.service.ts
@@ -2,13 +2,14 @@
  * Internal notification dispatcher for porting requests.
  *
  * Responsibilities:
- * - resolve recipients (commercial owner or team fallback),
+ * - resolve recipients (commercial owner or team routing fallback),
  * - persist Notification for named user recipients,
  * - persist timeline note for shared recipients (routing intent trace),
- * - dispatch real email/Teams transport (PR13B),
- * - persist transport audit trace as PortingRequestEvent NOTE.
+ * - dispatch email/Teams transport,
+ * - persist transport audit trace as PortingRequestEvent NOTE,
+ * - execute optional error fallback (notification_fallback_*) after FAILED/MISCONFIGURED outcomes.
  *
- * Non-blocking by design — callers use `.catch(() => {})`.
+ * Non-blocking by design - callers use `.catch(() => {})`.
  */
 
 import { prisma } from '../../config/database'
@@ -23,6 +24,13 @@ import {
   sendInternalTeamsWebhook,
   type InternalNotificationDispatchResult,
 } from './internal-notification.adapter'
+import {
+  decideNotificationErrorFallback,
+  extractFailureOutcomesFromDispatch,
+  resolveNotificationFallbackPolicy,
+  type NotificationErrorFallbackDecision,
+  type NotificationFallbackPolicy,
+} from './porting-notification-fallback-policy.resolver'
 
 export interface DispatchPortingNotificationParams {
   requestId: string
@@ -55,7 +63,7 @@ export async function dispatchPortingNotification(
 
   for (const recipient of recipients) {
     if (recipient.kind === 'USER') {
-      // 1. Domain trace — in-app Notification for the named user
+      // 1. Domain trace - in-app Notification for the named user
       await prisma.notification.create({
         data: {
           userId: recipient.userId,
@@ -67,7 +75,7 @@ export async function dispatchPortingNotification(
         },
       })
 
-      // 2. Transport — email to the user's address
+      // 2. Transport - email to the user's address
       const emailResult = await sendInternalEmail({
         to: [recipient.email],
         subject: message.subject,
@@ -77,20 +85,20 @@ export async function dispatchPortingNotification(
       continue
     }
 
-    // 3. Domain trace — timeline NOTE recording routing intent for team recipients
+    // 3. Domain trace - timeline NOTE recording routing intent for team recipients
     await prisma.portingRequestEvent.create({
       data: {
         request: { connect: { id: requestId } },
         eventSource: 'INTERNAL',
         eventType: 'NOTE',
         title: `Powiadomienie zespolowe: ${eventLabel}`,
-        description: buildFallbackDescription(recipient, metadata),
+        description: buildTeamRoutingFallbackDescription(recipient, metadata),
         ...(actorUserId ? { createdBy: { connect: { id: actorUserId } } } : {}),
       },
     })
 
     if (recipient.kind === 'TEAM_EMAIL') {
-      // 4. Transport — email to the shared team address list
+      // 4. Transport - email to the shared team address list
       const emailResult = await sendInternalEmail({
         to: recipient.emails,
         subject: message.subject,
@@ -100,7 +108,7 @@ export async function dispatchPortingNotification(
     }
 
     if (recipient.kind === 'TEAM_WEBHOOK') {
-      // 5. Transport — Teams webhook POST
+      // 5. Transport - Teams webhook POST
       const teamsResult = await sendInternalTeamsWebhook({
         webhookUrl: recipient.webhookUrl,
         title,
@@ -110,7 +118,7 @@ export async function dispatchPortingNotification(
     }
   }
 
-  // 6. Transport audit trace — one NOTE per dispatch summarising all outcomes
+  // 6. Transport audit trace - one NOTE per dispatch summarizing primary outcomes
   if (transportResults.length > 0) {
     await prisma.portingRequestEvent.create({
       data: {
@@ -118,18 +126,26 @@ export async function dispatchPortingNotification(
         eventSource: 'INTERNAL',
         eventType: 'NOTE',
         title: `[Dispatch] ${eventLabel}`,
-        description: buildTransportAuditDescription(transportResults),
+        description: buildPrimaryDispatchAuditDescription(transportResults),
         ...(actorUserId ? { createdBy: { connect: { id: actorUserId } } } : {}),
       },
     })
   }
+
+  await handleNotificationErrorFallback({
+    requestId,
+    actorUserId,
+    eventLabel,
+    message,
+    transportResults,
+  })
 }
 
 // ============================================================
-// POMOCNICZE
+// HELPERY
 // ============================================================
 
-function buildFallbackDescription(
+function buildTeamRoutingFallbackDescription(
   recipient: { kind: 'TEAM_EMAIL'; emails: string[] } | { kind: 'TEAM_WEBHOOK'; webhookUrl: string },
   metadata?: Record<string, unknown>,
 ): string {
@@ -139,21 +155,84 @@ function buildFallbackDescription(
       : `Routing do Teams webhook: ${recipient.webhookUrl}.`
 
   const metadataText = metadata ? ` Kontekst: ${safeJson(metadata)}.` : ''
-  return `${destination}${metadataText}`.trim()
+  return `Rodzaj fallbacku: ROUTING_TEAM. ${destination}${metadataText}`.trim()
 }
 
-function buildTransportAuditDescription(results: InternalNotificationDispatchResult[]): string {
-  const lines = results.map((r) => {
-    const base = `${r.channel} → ${r.recipient}: ${r.outcome} (tryb: ${r.mode})`
-    if (r.errorMessage) {
-      return `${base} — blad: ${r.errorMessage}`
+function buildPrimaryDispatchAuditDescription(results: InternalNotificationDispatchResult[]): string {
+  const lines = results.map((result) => {
+    const base = `${result.channel} -> ${result.recipient}: ${result.outcome} (tryb: ${result.mode})`
+    if (result.errorMessage) {
+      return `${base} - blad: ${result.errorMessage}`
     }
-    if ('messageId' in r && r.messageId) {
-      return `${base}, msgId: ${r.messageId}`
+    if ('messageId' in result && result.messageId) {
+      return `${base}, msgId: ${result.messageId}`
     }
     return base
   })
   return lines.join('\n')
+}
+
+async function handleNotificationErrorFallback(params: {
+  requestId: string
+  actorUserId?: string
+  eventLabel: string
+  message: { subject: string; text: string }
+  transportResults: InternalNotificationDispatchResult[]
+}): Promise<void> {
+  const failureOutcomes = extractFailureOutcomesFromDispatch(params.transportResults)
+  if (failureOutcomes.length === 0) {
+    return
+  }
+
+  const policy = await resolveNotificationFallbackPolicy()
+  const decision = decideNotificationErrorFallback(policy, failureOutcomes)
+
+  let fallbackDispatchResult: InternalNotificationDispatchResult | null = null
+  if (decision.shouldTrigger) {
+    fallbackDispatchResult = await sendInternalEmail({
+      to: [policy.fallbackRecipientEmail],
+      subject: params.message.subject,
+      text: params.message.text,
+    })
+  }
+
+  await prisma.portingRequestEvent.create({
+    data: {
+      request: { connect: { id: params.requestId } },
+      eventSource: 'INTERNAL',
+      eventType: 'NOTE',
+      title: `[ErrorFallback] ${params.eventLabel}`,
+      description: buildErrorFallbackAuditDescription(policy, decision, fallbackDispatchResult),
+      ...(params.actorUserId ? { createdBy: { connect: { id: params.actorUserId } } } : {}),
+    },
+  })
+}
+
+function buildErrorFallbackAuditDescription(
+  policy: NotificationFallbackPolicy,
+  decision: NotificationErrorFallbackDecision,
+  fallbackDispatchResult: InternalNotificationDispatchResult | null,
+): string {
+  const outcomesLabel = decision.failureOutcomes.length > 0 ? decision.failureOutcomes.join(',') : 'BRAK'
+  const matchedLabel = decision.matchedOutcomes.length > 0 ? decision.matchedOutcomes.join(',') : 'BRAK'
+
+  if (fallbackDispatchResult) {
+    const base = `${fallbackDispatchResult.channel} -> ${fallbackDispatchResult.recipient}: ${fallbackDispatchResult.outcome} (tryb: ${fallbackDispatchResult.mode})`
+    const reasonPart = `powod: ERROR_FALLBACK_TRIGGERED; sourceOutcomes=${outcomesLabel}; matchedOutcomes=${matchedLabel}; readiness=${policy.readiness}`
+
+    if (fallbackDispatchResult.errorMessage) {
+      return `${base} - blad: ${fallbackDispatchResult.errorMessage}; ${reasonPart}`
+    }
+
+    if ('messageId' in fallbackDispatchResult && fallbackDispatchResult.messageId) {
+      return `${base}, msgId: ${fallbackDispatchResult.messageId} - ${reasonPart}`
+    }
+
+    return `${base} - ${reasonPart}`
+  }
+
+  const recipient = policy.fallbackRecipientEmail || '-'
+  return `EMAIL -> ${recipient}: SKIPPED (tryb: POLICY) - powod: ${decision.reason}; sourceOutcomes=${outcomesLabel}; matchedOutcomes=${matchedLabel}; readiness=${policy.readiness}`
 }
 
 function safeJson(value: unknown): string {

--- a/apps/frontend/src/components/PortingInternalNotificationsPanel/PortingInternalNotificationsPanel.tsx
+++ b/apps/frontend/src/components/PortingInternalNotificationsPanel/PortingInternalNotificationsPanel.tsx
@@ -23,6 +23,12 @@ function formatChannel(channel: PortingInternalNotificationHistoryItemDto['chann
   return 'Nieznany'
 }
 
+function formatEntryType(entryType: PortingInternalNotificationHistoryItemDto['entryType']): string {
+  if (entryType === 'USER_NOTIFICATION') return 'Powiadomienie uzytkownika'
+  if (entryType === 'TEAM_ROUTING') return 'Routing zespolowy (fallback)'
+  return 'Audit transportu'
+}
+
 export function PortingInternalNotificationsPanel({
   items,
   isLoading,
@@ -35,7 +41,7 @@ export function PortingInternalNotificationsPanel({
           Historia powiadomien wewnetrznych
         </h2>
         <p className="mt-1 text-sm text-gray-500">
-          Chronologiczny podglad routingu i wynikow dispatchu dla sprawy.
+          Chronologiczny podglad routingu fallbacku zespolowego oraz wynikow dispatchu i error-fallback.
         </p>
       </div>
 
@@ -61,7 +67,7 @@ export function PortingInternalNotificationsPanel({
                   <p className="mt-0.5 text-xs text-gray-500">{formatDateTime(item.createdAt)}</p>
                 </div>
                 <span className="rounded-full bg-gray-100 px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide text-gray-700">
-                  {item.entryType}
+                  {formatEntryType(item.entryType)}
                 </span>
               </div>
 

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -20,6 +20,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR15  | Raportowanie i widoki operacyjne commercial owner                    | DONE   |
 | PR16  | Diagnostyka zdrowia notyfikacji (health helper + 4-state badge)     | DONE   |
 | PR17  | Operacyjna historia problemow notyfikacji w szczegolach sprawy      | DONE   |
+| PR18A | Fallback runtime completion (error fallback execution + audit)       | DONE   |
 
 ---
 
@@ -101,6 +102,26 @@ Dispatch jest non-blocking (`.catch(() => {})`) i nie blokuje glownego flow API.
   - frontend: 102 testy PASS,
   - `npx tsc --noEmit` PASS w obu appkach,
   - `npm run build` (shared + backend + frontend) PASS.
+
+### PR18A - fallback runtime completion (error fallback execution)
+
+- Domknieto runtime gap miedzy admin fallback settings a dispatch pipeline wewnetrznych notyfikacji.
+- Dodano kanoniczny resolver polityki fallbacku oparty o `notification_fallback_*`:
+  - `notification_fallback_enabled`
+  - `notification_fallback_recipient_email`
+  - `notification_fallback_recipient_name`
+  - `notification_fallback_apply_to_failed`
+  - `notification_fallback_apply_to_misconfigured`
+- Error fallback uruchamia sie po primary dispatch tylko dla outcome `FAILED` / `MISCONFIGURED` zgodnie z policy.
+- V1 fallback transport: email (`sendInternalEmail`) na `fallbackRecipientEmail`.
+- Brak petli retry fallbacku: fallback to pojedyncza akcja na jeden dispatch.
+- Audit trail:
+  - primary dispatch pozostaje w `[Dispatch] ...`,
+  - nowy wpis `[ErrorFallback] ...` zawiera decyzje: `TRIGGERED` albo `SKIPPED` z reason.
+- Rozroznienie semantyk fallbacku:
+  - `ROUTING_TEAM` (owner missing/inactive -> team recipients) - notatki `Powiadomienie zespolowe: ...`,
+  - `ERROR_FALLBACK` (po bledzie transportu) - notatki `[ErrorFallback] ...`.
+- UI detail (`Historia powiadomien wewnetrznych`) pokazuje rowniez wpisy `[ErrorFallback]`.
 
 ### PR15 - operacyjne raportowanie commercial owner i health notyfikacji
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,24 +1,35 @@
 # Architektura NP-Manager
 
-Dokument opisujący decyzje architektoniczne i strukturę systemu.
+Dokument opisujacy decyzje architektoniczne i strukture systemu.
 
 ## Stack technologiczny
 
 | Warstwa | Technologia | Uzasadnienie |
 |---|---|---|
-| Backend | Node.js 20 + Fastify 4 + TypeScript | Wydajny, wbudowana walidacja schematów, lepsza typizacja niż Express |
-| ORM | Prisma 5 | Type-safe queries, wersjonowane migracje, Prisma Studio |
-| Baza danych | PostgreSQL 16 | ACID, JSONB, enum arrays, pełnotekstowe wyszukiwanie |
-| Frontend | React 18 + Vite 5 + TypeScript | Dojrzały ekosystem, HMR, szybki build |
-| Styling | Tailwind CSS 3 | Utility-first, brak vendor lock-in |
-| State | Zustand | Prosty, bez boilerplate |
-| Walidacja | Zod (współdzielona) | Jeden schemat → frontend + backend |
-| Auth | JWT (@fastify/jwt) | Bezstanowy, skalowalny |
+| Backend | Node.js 20 + Fastify 4 + TypeScript | Wydajny runtime, dobra typizacja i modularny routing |
+| ORM | Prisma 5 | Type-safe queries, migracje i spojny model danych |
+| Baza danych | PostgreSQL 16 | ACID, dobre wsparcie dla danych procesowych i auditowych |
+| Frontend | React 18 + Vite 5 + TypeScript | Szybki build, HMR i dojrzaly ekosystem |
+| Styling | Tailwind CSS 3 | Utility-first i szybka iteracja UI |
+| State | Zustand | Lekki store dla stanu aplikacji |
+| Walidacja | Zod | Jeden kontrakt walidacyjny frontend + backend |
+| Auth | JWT (@fastify/jwt) | Bezstanowy model autoryzacji |
 
-## Dokumenty analityczne
+## Semantyka fallbacku notyfikacji wewnetrznych (EPIC-18)
 
-- Etap 1: Analiza biznesowa i procesowa
-- Etap 2: Plan techniczny i model danych
-- Etap 3: Reguły biznesowe i zgodność procesowa
+W systemie funkcjonuja dwa rozne fallbacki i nie nalezy ich mieszac:
 
-Szczegółowe dokumenty dostępne u architekta systemu.
+1. `ROUTING_TEAM` (owner fallback)
+- Uruchamiany, gdy sprawa nie ma aktywnego opiekuna handlowego.
+- Resolver odbiorcow przechodzi na odbiorcow zespolowych (`TEAM_EMAIL` / `TEAM_WEBHOOK`).
+- Konfiguracja: `porting_status_*` (+ legacy `porting_notify_*`).
+
+2. `ERROR_FALLBACK` (delivery/config fallback)
+- Uruchamiany po primary dispatch, gdy wystapi `FAILED` lub `MISCONFIGURED`.
+- Konfiguracja kanoniczna: `notification_fallback_*`.
+- V1 transport: fallback email na `notification_fallback_recipient_email`.
+- Jedna akcja fallback na jeden dispatch (bez petli fallback->fallback).
+
+Audit i diagnostyka:
+- `[Dispatch] ...` - primary transport audit (podstawa health/failure history),
+- `[ErrorFallback] ...` - decyzja i wynik error fallback (`TRIGGERED` lub `SKIPPED` z reason).


### PR DESCRIPTION
## Problem / root cause

Panel admin dla fallback settings był gotowy, ale runtime dispatch wewnętrznych notyfikacji nie wykorzystywał jeszcze kanonicznie `notification_fallback_*` do automatycznej reakcji na błędy transportu (`FAILED` / `MISCONFIGURED`).

## Co zostało zmienione

* Dodano resolver polityki error fallback (`notification_fallback_*`) z readiness: `DISABLED | INCOMPLETE | READY`
* Wpięto execution error fallback po primary dispatch:

  * trigger tylko dla kwalifikowanych outcome
  * jedna akcja fallback na dispatch
  * fallback v1: email na `fallbackRecipientEmail`
* Rozszerzono audit trail:

  * primary transport pozostaje w `[Dispatch] ...`
  * nowy wpis `[ErrorFallback] ...` z decyzją `TRIGGERED/SKIPPED` i `reason`
* Rozszerzono istniejący read model historii notyfikacji o wpisy `[ErrorFallback]`
* Minimalnie poprawiono readability w `RequestDetailPage` (etykiety/tekst w istniejącym panelu historii)
* Uzupełniono dokumentację semantyki fallbacków

## Zakres świadomie NIEobjęty tym PR-em

* Retry failed notifications (EPIC-19)
* NotificationOps queue / operational center
* Nowe publiczne endpointy
* Nowe modele danych i migracje
* Duże zmiany UI

## Jak rozdzielono routing fallback vs error fallback

**routing fallback**

* mechanizm recipient resolvera oparty o `porting_status_*` / legacy `porting_notify_*`
* aktywuje się przy braku/nieaktywności ownera
* audit: `Powiadomienie zespolowe: ... (ROUTING_TEAM)`

**error fallback**

* mechanizm runtime po primary dispatch, oparty o `notification_fallback_*`
* aktywuje się tylko dla `FAILED / MISCONFIGURED` wg policy
* audit: `[ErrorFallback] ...`

## Jak zweryfikowano zmianę

* nowe testy unit dla resolvera polityki fallback i decision matrix
* rozszerzone testy serwisu dispatch:

  * trigger fallback
  * skip z reason
  * brak pętli fallback->fallback
* rozszerzone testy read modelu historii (`[ErrorFallback]`)
* pełna regresja backend/frontend testów i typechecków

## Manual QA steps

1. W admin settings ustaw `notification_fallback_enabled=true` i poprawny `fallbackRecipientEmail`
2. Wymuś błąd primary dispatch (np. konfiguracją adaptera), wywołaj akcję generującą internal notification
3. Sprawdź w historii sprawy:

   * wpis `[Dispatch] ...` z `FAILED` lub `MISCONFIGURED`
   * wpis `[ErrorFallback] ...` z `TRIGGERED` albo `SKIPPED` i `reason`
4. Powtórz z fallback disabled/incomplete i potwierdź `SKIPPED` z odpowiednim reason
5. Potwierdź, że routing fallback (owner missing -> team) działa niezależnie i bez zmian semantycznych

## Ryzyka / follow-up po merge

* V1 opiera się na audit NOTE parsing; docelowe uszczelnienie modelu operacyjnego planowane w EPIC-19
* W logach testowych pozostają znane warningi środowiskowe (nieblokujące)
* Follow-up: retry / ops queue, dalsze hardening observability w kolejnych epikach

## Testy

* `apps/backend: npx vitest run` → PASS (53 files, 373 tests)
* `apps/frontend: npx vitest run` → PASS (25 files, 109 tests)
* `apps/backend: npx tsc --noEmit` → PASS
* `apps/frontend: npx tsc --noEmit` → PASS

Pre-existing / non-blocking:

* ostrzeżenia `useLayoutEffect` w testach frontend
* `DEP0169 url.parse` / pojedyncze logi Prisma w testach backend