### PR TITLE
test(baseline): update validation message assertions

### DIFF
--- a/apps/backend/src/modules/admin-settings/__tests__/admin-porting-notification-settings.schema.test.ts
+++ b/apps/backend/src/modules/admin-settings/__tests__/admin-porting-notification-settings.schema.test.ts
@@ -61,7 +61,7 @@ describe('updatePortingNotificationSettingsBodySchema', () => {
           teamsEnabled: false,
           teamsWebhookUrl: '',
         }),
-      ).toThrowError(/Podaj co najmniej jeden adres email/)
+      ).toThrowError(/Lista e-maili fallback jest wymagana/)
     })
 
     it('rzuca błąd gdy teamsEnabled=true i teamsWebhookUrl jest pustym stringiem', () => {
@@ -80,7 +80,7 @@ describe('updatePortingNotificationSettingsBodySchema', () => {
           sharedEmails: 'bok@multiplay.pl',
           teamsEnabled: true,
         }),
-      ).toThrowError(/Podaj URL webhooka Teams gdy Teams jest włączony/)
+      ).toThrowError(/URL webhooka Teams jest wymagany/)
     })
 
     it('nie rzuca błędu dla teamsWebhookUrl gdy teamsEnabled=false', () => {


### PR DESCRIPTION
## Problem
Dwa testy w `admin-porting-notification-settings.schema.test.ts` oczekiwały starych komunikatów walidacyjnych.

## Co zmieniono
- zaktualizowano asercje regexów do aktualnych komunikatów zwracanych przez Zod
- bez zmian logiki biznesowej

## Weryfikacja
- backend vitest: PASS
- backend tsc --noEmit: PASS