### PR TITLE
feat(PR19A-2): add internal notification attempts read API and detail panel

### DIFF
--- a/apps/backend/src/__tests__/app.internal-notification-attempts.routes.test.ts
+++ b/apps/backend/src/__tests__/app.internal-notification-attempts.routes.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGetAttempts } = vi.hoisted(() => ({
+  mockGetAttempts: vi.fn(),
+}))
+
+vi.mock('../config/env', () => ({
+  env: {
+    NODE_ENV: 'test',
+    PORT: 3001,
+    FRONTEND_URL: 'http://localhost:5173',
+    DATABASE_URL: 'postgresql://test:test@localhost:5432/test',
+    JWT_SECRET: 'test-secret-that-is-at-least-32-characters-long',
+    JWT_EXPIRES_IN: '8h',
+    UPLOAD_DIR: './uploads',
+    MAX_FILE_SIZE_MB: 10,
+    LOG_LEVEL: 'error',
+    PLI_CBD_TRANSPORT_MODE: 'STUB',
+  },
+}))
+
+vi.mock('../shared/audit/audit.service', () => ({
+  logAuditEvent: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../modules/auth/auth.router', () => ({ authRouter: async () => {} }))
+vi.mock('../modules/users/users.router', () => ({ usersRouter: async () => {} }))
+vi.mock('../modules/clients/clients.router', () => ({ clientsRouter: async () => {} }))
+vi.mock('../modules/operators/operators.router', () => ({ operatorsRouter: async () => {} }))
+vi.mock('../modules/communications/communication-templates.router', () => ({
+  communicationTemplatesRouter: async () => {},
+}))
+vi.mock('../modules/admin-users/admin-users.router', () => ({
+  adminUsersRouter: async () => {},
+}))
+vi.mock('../modules/admin-settings/admin-porting-notification-settings.router', () => ({
+  adminPortingNotificationSettingsRouter: async () => {},
+}))
+vi.mock('../modules/admin-settings/admin-notification-fallback-settings.router', () => ({
+  adminNotificationFallbackSettingsRouter: async () => {},
+}))
+
+vi.mock('../modules/porting-requests/porting-requests.service', () => ({
+  assignPortingRequestToMe: vi.fn(),
+  createPortingRequest: vi.fn(),
+  executePortingRequestExternalAction: vi.fn(),
+  exportPortingRequestToPliCbd: vi.fn(),
+  getPortingRequest: vi.fn(),
+  getPortingRequestAssignmentHistory: vi.fn(),
+  getPortingRequestIntegrationEvents: vi.fn(),
+  getPortingRequestsOperationalSummary: vi.fn(),
+  listAssignablePortingRequestUsers: vi.fn(),
+  listCommercialOwnerCandidates: vi.fn(),
+  listPortingRequests: vi.fn(),
+  syncPortingRequestFromPliCbd: vi.fn(),
+  updateCommercialOwner: vi.fn(),
+  updatePortingRequestAssignment: vi.fn(),
+  updatePortingRequestStatus: vi.fn(),
+}))
+
+vi.mock('../modules/porting-requests/porting-request-communication.service', () => ({
+  createPortingCommunicationDraft: vi.fn(),
+  getPortingCommunicationHistory: vi.fn(),
+  markPortingCommunicationAsSent: vi.fn(),
+  previewPortingCommunication: vi.fn(),
+}))
+
+vi.mock('../modules/porting-requests/communication-delivery.service', () => ({
+  cancelPortingCommunication: vi.fn(),
+  getPortingCommunicationDeliveryAttempts: vi.fn(),
+  retryPortingCommunication: vi.fn(),
+  sendPortingCommunication: vi.fn(),
+}))
+
+vi.mock('../modules/porting-requests/porting-events.service', () => ({
+  getPortingRequestTimeline: vi.fn(),
+}))
+
+vi.mock('../modules/porting-requests/porting-request-case-history.service', () => ({
+  getPortingRequestCaseHistory: vi.fn(),
+}))
+
+vi.mock('../modules/porting-requests/porting-internal-notification-history.service', () => ({
+  getPortingRequestInternalNotifications: vi.fn(),
+}))
+
+vi.mock('../modules/porting-requests/porting-notification-failure-history.service', () => ({
+  getPortingRequestNotificationFailures: vi.fn(),
+}))
+
+vi.mock('../modules/porting-requests/porting-internal-notification-attempts.service', () => ({
+  getPortingRequestInternalNotificationAttempts: (...args: unknown[]) => mockGetAttempts(...args),
+}))
+
+vi.mock('../modules/pli-cbd/fnp-process.service', () => ({
+  buildE03DraftForPortingRequest: vi.fn(),
+  buildE12DraftForPortingRequest: vi.fn(),
+  buildE18DraftForPortingRequest: vi.fn(),
+  buildE23DraftForPortingRequest: vi.fn(),
+  getPortingRequestProcessSnapshot: vi.fn(),
+}))
+
+vi.mock('../modules/pli-cbd/pli-cbd-technical-payload.service', () => ({
+  buildTechnicalPayloadForPortingRequest: vi.fn(),
+}))
+
+vi.mock('../modules/pli-cbd/pli-cbd-xml-preview.service', () => ({
+  buildXmlPreviewForPortingRequest: vi.fn(),
+}))
+
+vi.mock('../modules/pli-cbd/pli-cbd-export.service', () => ({
+  triggerManualPliCbdExport: vi.fn(),
+}))
+
+import { AppError } from '../shared/errors/app-error'
+import { buildApp } from '../app'
+
+const ATTEMPTS_RESULT = {
+  requestId: 'request-1',
+  items: [
+    {
+      id: 'attempt-1',
+      requestId: 'request-1',
+      eventCode: 'STATUS_CHANGED',
+      eventLabel: 'Zmiana statusu sprawy',
+      attemptOrigin: 'PRIMARY',
+      channel: 'EMAIL',
+      recipient: 'bok@multiplay.pl',
+      mode: 'REAL',
+      outcome: 'FAILED',
+      errorCode: 'SMTP_TIMEOUT',
+      errorMessage: 'Timeout SMTP',
+      failureKind: 'DELIVERY',
+      retryOfAttemptId: null,
+      retryCount: 0,
+      isLatestForChain: true,
+      triggeredByUserId: null,
+      triggeredByDisplayName: null,
+      createdAt: '2026-04-11T10:00:00.000Z',
+    },
+  ],
+}
+
+describe('GET /api/porting-requests/:id/internal-notification-attempts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetAttempts.mockResolvedValue(ATTEMPTS_RESULT)
+  })
+
+  it('returns 401 without JWT token', async () => {
+    const app = await buildApp()
+
+    try {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/porting-requests/request-1/internal-notification-attempts',
+      })
+
+      expect(response.statusCode).toBe(401)
+      expect(mockGetAttempts).not.toHaveBeenCalled()
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('returns 403 for an authenticated role outside read roles', async () => {
+    const app = await buildApp()
+
+    try {
+      const token = app.jwt.sign({ id: 'client-user-1', role: 'CLIENT' })
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/porting-requests/request-1/internal-notification-attempts',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(403)
+      expect(mockGetAttempts).not.toHaveBeenCalled()
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('returns request-level attempts for a read role and passes normalized limit', async () => {
+    const app = await buildApp()
+
+    try {
+      const token = app.jwt.sign({ id: 'manager-1', role: 'MANAGER' })
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/porting-requests/request-1/internal-notification-attempts?limit=5',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ success: true; data: typeof ATTEMPTS_RESULT }>()
+      expect(body.success).toBe(true)
+      expect(body.data.items).toHaveLength(1)
+      expect(body.data.items[0]?.attemptOrigin).toBe('PRIMARY')
+      expect(mockGetAttempts).toHaveBeenCalledWith('request-1', 5)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('returns an empty list without error', async () => {
+    mockGetAttempts.mockResolvedValueOnce({ requestId: 'request-empty', items: [] })
+    const app = await buildApp()
+
+    try {
+      const token = app.jwt.sign({ id: 'auditor-1', role: 'AUDITOR' })
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/porting-requests/request-empty/internal-notification-attempts',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json<{ success: true; data: { items: unknown[] } }>()
+      expect(body.data.items).toEqual([])
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('returns 404 when the request does not exist', async () => {
+    mockGetAttempts.mockRejectedValueOnce(
+      AppError.notFound('Sprawa portowania nie zostala znaleziona.'),
+    )
+    const app = await buildApp()
+
+    try {
+      const token = app.jwt.sign({ id: 'admin-1', role: 'ADMIN' })
+      const response = await app.inject({
+        method: 'GET',
+        url: '/api/porting-requests/missing/internal-notification-attempts',
+        headers: { authorization: `Bearer ${token}` },
+      })
+
+      expect(response.statusCode).toBe(404)
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-internal-notification-attempts.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-internal-notification-attempts.service.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockPortingRequestFindUnique, mockAttemptFindMany } = vi.hoisted(() => ({
+  mockPortingRequestFindUnique: vi.fn(),
+  mockAttemptFindMany: vi.fn(),
+}))
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    portingRequest: {
+      findUnique: (...args: unknown[]) => mockPortingRequestFindUnique(...args),
+    },
+    internalNotificationDeliveryAttempt: {
+      findMany: (...args: unknown[]) => mockAttemptFindMany(...args),
+    },
+  },
+}))
+
+import { getPortingRequestInternalNotificationAttempts } from '../porting-internal-notification-attempts.service'
+
+describe('getPortingRequestInternalNotificationAttempts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty attempt list for an existing request with no attempts', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce({ id: 'request-1' })
+    mockAttemptFindMany.mockResolvedValueOnce([])
+
+    const result = await getPortingRequestInternalNotificationAttempts('request-1')
+
+    expect(result).toEqual({
+      requestId: 'request-1',
+      items: [],
+    })
+    expect(mockAttemptFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { requestId: 'request-1' },
+        take: 50,
+      }),
+    )
+  })
+
+  it('maps PRIMARY and ERROR_FALLBACK attempts to DTOs', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce({ id: 'request-2' })
+    mockAttemptFindMany.mockResolvedValueOnce([
+      {
+        id: 'attempt-primary',
+        requestId: 'request-2',
+        eventCode: 'STATUS_CHANGED',
+        eventLabel: 'Zmiana statusu sprawy',
+        attemptOrigin: 'PRIMARY',
+        channel: 'EMAIL',
+        recipient: 'bok@multiplay.pl',
+        mode: 'REAL',
+        outcome: 'FAILED',
+        errorCode: 'SMTP_TIMEOUT',
+        errorMessage: 'Timeout SMTP',
+        failureKind: 'DELIVERY',
+        retryOfAttemptId: null,
+        retryCount: 0,
+        isLatestForChain: true,
+        triggeredByUserId: null,
+        triggeredByUser: null,
+        createdAt: new Date('2026-04-11T10:00:00.000Z'),
+      },
+      {
+        id: 'attempt-fallback',
+        requestId: 'request-2',
+        eventCode: 'STATUS_CHANGED',
+        eventLabel: 'Zmiana statusu sprawy',
+        attemptOrigin: 'ERROR_FALLBACK',
+        channel: 'EMAIL',
+        recipient: 'fallback@np-manager.local',
+        mode: 'STUB',
+        outcome: 'STUBBED',
+        errorCode: null,
+        errorMessage: null,
+        failureKind: null,
+        retryOfAttemptId: null,
+        retryCount: 0,
+        isLatestForChain: true,
+        triggeredByUserId: 'admin-1',
+        triggeredByUser: {
+          firstName: 'Adam',
+          lastName: 'Admin',
+          email: 'admin@np-manager.local',
+        },
+        createdAt: new Date('2026-04-11T10:01:00.000Z'),
+      },
+    ])
+
+    const result = await getPortingRequestInternalNotificationAttempts('request-2', 10)
+
+    expect(result.items).toHaveLength(2)
+    expect(result.items[0]).toMatchObject({
+      id: 'attempt-primary',
+      attemptOrigin: 'PRIMARY',
+      channel: 'EMAIL',
+      recipient: 'bok@multiplay.pl',
+      mode: 'REAL',
+      outcome: 'FAILED',
+      failureKind: 'DELIVERY',
+      errorMessage: 'Timeout SMTP',
+      triggeredByDisplayName: null,
+      createdAt: '2026-04-11T10:00:00.000Z',
+    })
+    expect(result.items[1]).toMatchObject({
+      id: 'attempt-fallback',
+      attemptOrigin: 'ERROR_FALLBACK',
+      outcome: 'STUBBED',
+      triggeredByDisplayName: 'Adam Admin (admin@np-manager.local)',
+    })
+  })
+
+  it('normalizes invalid limits and caps high limits', async () => {
+    mockPortingRequestFindUnique.mockResolvedValue({ id: 'request-3' })
+    mockAttemptFindMany.mockResolvedValue([])
+
+    await getPortingRequestInternalNotificationAttempts('request-3', -1)
+    await getPortingRequestInternalNotificationAttempts('request-3', 500)
+
+    expect(mockAttemptFindMany.mock.calls[0]?.[0]).toMatchObject({ take: 50 })
+    expect(mockAttemptFindMany.mock.calls[1]?.[0]).toMatchObject({ take: 100 })
+  })
+
+  it('throws NOT_FOUND when request does not exist', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce(null)
+
+    await expect(
+      getPortingRequestInternalNotificationAttempts('missing-request'),
+    ).rejects.toMatchObject({
+      statusCode: 404,
+    })
+    expect(mockAttemptFindMany).not.toHaveBeenCalled()
+  })
+})

--- a/apps/backend/src/modules/porting-requests/porting-internal-notification-attempts.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-internal-notification-attempts.service.ts
@@ -1,0 +1,113 @@
+import type {
+  InternalNotificationDeliveryAttemptDto,
+  InternalNotificationDeliveryAttemptsResultDto,
+} from '@np-manager/shared'
+import { prisma } from '../../config/database'
+import { AppError } from '../../shared/errors/app-error'
+
+const DEFAULT_ATTEMPTS_LIMIT = 50
+const HARD_ATTEMPTS_LIMIT = 100
+
+type InternalNotificationAttemptRecord = Awaited<
+  ReturnType<typeof findInternalNotificationAttempts>
+>[number]
+
+export async function getPortingRequestInternalNotificationAttempts(
+  requestId: string,
+  limit: number = DEFAULT_ATTEMPTS_LIMIT,
+): Promise<InternalNotificationDeliveryAttemptsResultDto> {
+  const request = await prisma.portingRequest.findUnique({
+    where: { id: requestId },
+    select: { id: true },
+  })
+
+  if (!request) {
+    throw AppError.notFound('Sprawa portowania nie zostala znaleziona.')
+  }
+
+  const items = (await findInternalNotificationAttempts(requestId, normalizeLimit(limit))).map(
+    mapAttemptToDto,
+  )
+
+  return {
+    requestId,
+    items,
+  }
+}
+
+function findInternalNotificationAttempts(requestId: string, limit: number) {
+  return prisma.internalNotificationDeliveryAttempt.findMany({
+    where: { requestId },
+    orderBy: [{ createdAt: 'desc' }, { id: 'asc' }],
+    take: limit,
+    select: {
+      id: true,
+      requestId: true,
+      eventCode: true,
+      eventLabel: true,
+      attemptOrigin: true,
+      channel: true,
+      recipient: true,
+      mode: true,
+      outcome: true,
+      errorCode: true,
+      errorMessage: true,
+      failureKind: true,
+      retryOfAttemptId: true,
+      retryCount: true,
+      isLatestForChain: true,
+      triggeredByUserId: true,
+      triggeredByUser: {
+        select: {
+          firstName: true,
+          lastName: true,
+          email: true,
+        },
+      },
+      createdAt: true,
+    },
+  })
+}
+
+function mapAttemptToDto(
+  attempt: InternalNotificationAttemptRecord,
+): InternalNotificationDeliveryAttemptDto {
+  return {
+    id: attempt.id,
+    requestId: attempt.requestId,
+    eventCode: attempt.eventCode,
+    eventLabel: attempt.eventLabel,
+    attemptOrigin: attempt.attemptOrigin,
+    channel: attempt.channel,
+    recipient: attempt.recipient,
+    mode: attempt.mode,
+    outcome: attempt.outcome,
+    errorCode: attempt.errorCode,
+    errorMessage: attempt.errorMessage,
+    failureKind: attempt.failureKind,
+    retryOfAttemptId: attempt.retryOfAttemptId,
+    retryCount: attempt.retryCount,
+    isLatestForChain: attempt.isLatestForChain,
+    triggeredByUserId: attempt.triggeredByUserId,
+    triggeredByDisplayName: formatTriggeredByDisplayName(attempt.triggeredByUser),
+    createdAt: attempt.createdAt.toISOString(),
+  }
+}
+
+function formatTriggeredByDisplayName(
+  user: { firstName: string; lastName: string; email: string } | null,
+): string | null {
+  if (!user) {
+    return null
+  }
+
+  return `${user.firstName} ${user.lastName} (${user.email})`
+}
+
+function normalizeLimit(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return DEFAULT_ATTEMPTS_LIMIT
+  }
+
+  return Math.min(Math.floor(value), HARD_ATTEMPTS_LIMIT)
+}

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -5,6 +5,7 @@ import { authorize } from '../../shared/middleware/authorize'
 import {
   createPortingRequestSchema,
   executePortingRequestExternalActionSchema,
+  internalNotificationAttemptsQuerySchema,
   markPortingCommunicationSentSchema,
   portingRequestListQuerySchema,
   portingRequestSummaryQuerySchema,
@@ -45,6 +46,7 @@ import {
 import { getPortingRequestTimeline } from './porting-events.service'
 import { getPortingRequestCaseHistory } from './porting-request-case-history.service'
 import { getPortingRequestInternalNotifications } from './porting-internal-notification-history.service'
+import { getPortingRequestInternalNotificationAttempts } from './porting-internal-notification-attempts.service'
 import { getPortingRequestNotificationFailures } from './porting-notification-failure-history.service'
 import {
   buildE03DraftForPortingRequest,
@@ -143,6 +145,19 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
     { preHandler: [authenticate, authorize(readRoles)] },
     async (request, reply) => {
       const result = await getPortingRequestInternalNotifications(request.params.id)
+      return reply.status(200).send({ success: true, data: result })
+    },
+  )
+
+  app.get<{ Params: { id: string } }>(
+    '/:id/internal-notification-attempts',
+    { preHandler: [authenticate, authorize(readRoles)] },
+    async (request, reply) => {
+      const query = internalNotificationAttemptsQuerySchema.parse(request.query)
+      const result = await getPortingRequestInternalNotificationAttempts(
+        request.params.id,
+        query.limit,
+      )
       return reply.status(200).send({ success: true, data: result })
     },
   )

--- a/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
@@ -368,6 +368,14 @@ export const portingRequestSummaryQuerySchema = portingRequestListQuerySchema.om
 
 export type PortingRequestSummaryQuery = z.input<typeof portingRequestSummaryQuerySchema>
 
+export const internalNotificationAttemptsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+})
+
+export type InternalNotificationAttemptsQuery = z.input<
+  typeof internalNotificationAttemptsQuerySchema
+>
+
 export const updatePortingRequestAssignmentSchema = z.object({
   assignedUserId: z.preprocess(
     (value) => (value === '' ? null : value),

--- a/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx
+++ b/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx
@@ -1,0 +1,73 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import type { InternalNotificationDeliveryAttemptDto } from '@np-manager/shared'
+import { InternalNotificationAttemptsPanel } from './InternalNotificationAttemptsPanel'
+
+const ITEMS: InternalNotificationDeliveryAttemptDto[] = [
+  {
+    id: 'attempt-1',
+    requestId: 'request-1',
+    eventCode: 'STATUS_CHANGED',
+    eventLabel: 'Zmiana statusu sprawy',
+    attemptOrigin: 'PRIMARY',
+    channel: 'EMAIL',
+    recipient: 'bok@multiplay.pl',
+    mode: 'REAL',
+    outcome: 'FAILED',
+    errorCode: 'SMTP_TIMEOUT',
+    errorMessage: 'Timeout SMTP',
+    failureKind: 'DELIVERY',
+    retryOfAttemptId: null,
+    retryCount: 0,
+    isLatestForChain: true,
+    triggeredByUserId: null,
+    triggeredByDisplayName: null,
+    createdAt: '2026-04-11T10:00:00.000Z',
+  },
+  {
+    id: 'attempt-2',
+    requestId: 'request-1',
+    eventCode: 'STATUS_CHANGED',
+    eventLabel: 'Zmiana statusu sprawy',
+    attemptOrigin: 'ERROR_FALLBACK',
+    channel: 'EMAIL',
+    recipient: 'fallback@np-manager.local',
+    mode: 'STUB',
+    outcome: 'STUBBED',
+    errorCode: null,
+    errorMessage: null,
+    failureKind: null,
+    retryOfAttemptId: null,
+    retryCount: 0,
+    isLatestForChain: true,
+    triggeredByUserId: null,
+    triggeredByDisplayName: null,
+    createdAt: '2026-04-11T10:01:00.000Z',
+  },
+]
+
+describe('InternalNotificationAttemptsPanel', () => {
+  it('renders delivery attempts without retry actions', () => {
+    const html = renderToStaticMarkup(
+      <InternalNotificationAttemptsPanel items={ITEMS} isLoading={false} error={null} />,
+    )
+
+    expect(html).toContain('Proby dostarczenia notyfikacji')
+    expect(html).toContain('Ledger wykonanych prob transportu')
+    expect(html).toContain('Primary dispatch')
+    expect(html).toContain('Error fallback')
+    expect(html).toContain('bok@multiplay.pl')
+    expect(html).toContain('Blad wysylki')
+    expect(html).toContain('Blad transportu: Timeout SMTP')
+    expect(html).not.toContain('Retryuj')
+    expect(html).not.toContain('Ponow')
+  })
+
+  it('renders empty state for request without persisted attempts', () => {
+    const html = renderToStaticMarkup(
+      <InternalNotificationAttemptsPanel items={[]} isLoading={false} error={null} />,
+    )
+
+    expect(html).toContain('Brak zapisanych prob transportu w modelu attempts dla tej sprawy.')
+  })
+})

--- a/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx
+++ b/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx
@@ -1,0 +1,134 @@
+import type { InternalNotificationDeliveryAttemptDto } from '@np-manager/shared'
+
+interface InternalNotificationAttemptsPanelProps {
+  items: InternalNotificationDeliveryAttemptDto[]
+  isLoading: boolean
+  error: string | null
+}
+
+function formatDateTime(value: string): string {
+  return new Date(value).toLocaleString('pl-PL', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatOrigin(origin: InternalNotificationDeliveryAttemptDto['attemptOrigin']): string {
+  if (origin === 'PRIMARY') return 'Primary dispatch'
+  if (origin === 'ERROR_FALLBACK') return 'Error fallback'
+  return 'Retry'
+}
+
+function formatChannel(channel: InternalNotificationDeliveryAttemptDto['channel']): string {
+  if (channel === 'EMAIL') return 'E-mail'
+  return 'Teams'
+}
+
+function formatFailureKind(
+  failureKind: InternalNotificationDeliveryAttemptDto['failureKind'],
+): string {
+  if (failureKind === 'DELIVERY') return 'Blad wysylki'
+  if (failureKind === 'CONFIGURATION') return 'Blad konfiguracji'
+  if (failureKind === 'POLICY') return 'Polityka'
+  return '-'
+}
+
+function getOutcomeClass(outcome: InternalNotificationDeliveryAttemptDto['outcome']): string {
+  if (outcome === 'FAILED') return 'bg-red-100 text-red-700'
+  if (outcome === 'MISCONFIGURED') return 'bg-amber-100 text-amber-700'
+  if (outcome === 'SENT' || outcome === 'STUBBED') return 'bg-emerald-100 text-emerald-700'
+  return 'bg-gray-100 text-gray-700'
+}
+
+export function InternalNotificationAttemptsPanel({
+  items,
+  isLoading,
+  error,
+}: InternalNotificationAttemptsPanelProps) {
+  return (
+    <div className="card p-5">
+      <div className="mb-4">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">
+          Proby dostarczenia notyfikacji
+        </h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Ledger wykonanych prob transportu internal notifications. Szersza historia routingu i
+          auditow pozostaje w panelu historii powiadomien wewnetrznych.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">
+          Ladowanie prob dostarczenia...
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+          Brak zapisanych prob transportu w modelu attempts dla tej sprawy.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {items.map((item) => (
+            <article key={item.id} className="rounded-lg border border-gray-200 bg-white p-4">
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div>
+                  <h3 className="text-sm font-semibold text-gray-900">{item.eventLabel}</h3>
+                  <p className="mt-0.5 text-xs text-gray-500">
+                    {formatDateTime(item.createdAt)}
+                    {item.eventCode ? ` | ${item.eventCode}` : ''}
+                  </p>
+                </div>
+                <span
+                  className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getOutcomeClass(
+                    item.outcome,
+                  )}`}
+                >
+                  {item.outcome}
+                </span>
+              </div>
+
+              <dl className="mt-3 grid grid-cols-1 gap-2 text-sm text-gray-700 sm:grid-cols-2">
+                <div>
+                  <dt className="text-xs text-gray-500">Pochodzenie proby</dt>
+                  <dd>{formatOrigin(item.attemptOrigin)}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Kanal</dt>
+                  <dd>{formatChannel(item.channel)}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Odbiorca</dt>
+                  <dd>{item.recipient}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Tryb</dt>
+                  <dd>{item.mode}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Rodzaj problemu</dt>
+                  <dd>{formatFailureKind(item.failureKind)}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-gray-500">Licznik retry</dt>
+                  <dd>{item.retryCount}</dd>
+                </div>
+              </dl>
+
+              {item.errorMessage && (
+                <p className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                  Blad transportu: {item.errorMessage}
+                </p>
+              )}
+            </article>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -14,6 +14,7 @@ import {
   getPortingRequestById,
   getPortingRequestCaseHistory,
   getPortingRequestCommunicationHistory,
+  getPortingRequestInternalNotificationAttempts,
   getPortingRequestInternalNotifications,
   getPortingRequestNotificationFailures,
   getPortingRequestE03Draft,
@@ -57,6 +58,7 @@ import {
   type PortingCommunicationDto,
   type PortingCommunicationPreviewDto,
   type PortingCommunicationSummaryDto,
+  type InternalNotificationDeliveryAttemptDto,
   type PortingInternalNotificationHistoryItemDto,
   type PortingRequestAssignmentUserOptionDto,
   type PortingRequestCaseHistoryItemDto,
@@ -81,6 +83,7 @@ import { PliCbdProcessSnapshot } from '@/components/PliCbdProcessSnapshot/PliCbd
 import { PliCbdTechnicalPayloadPreview } from '@/components/PliCbdTechnicalPayloadPreview/PliCbdTechnicalPayloadPreview'
 import { PliCbdXmlPreview } from '@/components/PliCbdXmlPreview/PliCbdXmlPreview'
 import { PortingInternalNotificationsPanel } from '@/components/PortingInternalNotificationsPanel/PortingInternalNotificationsPanel'
+import { InternalNotificationAttemptsPanel } from '@/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel'
 import { NotificationFailureHistoryPanel } from '@/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel'
 import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
 import {
@@ -405,6 +408,14 @@ export function RequestDetailPage() {
   >([])
   const [isInternalNotificationLoading, setIsInternalNotificationLoading] = useState(true)
   const [internalNotificationError, setInternalNotificationError] = useState<string | null>(null)
+  const [internalNotificationAttemptItems, setInternalNotificationAttemptItems] = useState<
+    InternalNotificationDeliveryAttemptDto[]
+  >([])
+  const [isInternalNotificationAttemptsLoading, setIsInternalNotificationAttemptsLoading] =
+    useState(true)
+  const [internalNotificationAttemptsError, setInternalNotificationAttemptsError] = useState<
+    string | null
+  >(null)
   const [notificationFailureItems, setNotificationFailureItems] = useState<
     NotificationFailureHistoryItemDto[]
   >([])
@@ -659,6 +670,23 @@ export function RequestDetailPage() {
       )
     } finally {
       setIsInternalNotificationLoading(false)
+    }
+  }, [id])
+
+  const loadInternalNotificationAttempts = useCallback(async () => {
+    if (!id) return
+
+    setIsInternalNotificationAttemptsLoading(true)
+    setInternalNotificationAttemptsError(null)
+
+    try {
+      const result = await getPortingRequestInternalNotificationAttempts(id)
+      setInternalNotificationAttemptItems(result.items)
+    } catch {
+      setInternalNotificationAttemptItems([])
+      setInternalNotificationAttemptsError('Nie udalo sie zaladowac prob dostarczenia notyfikacji.')
+    } finally {
+      setIsInternalNotificationAttemptsLoading(false)
     }
   }, [id])
 
@@ -918,6 +946,7 @@ export function RequestDetailPage() {
     void loadRequest()
     void loadCaseHistory()
     void loadInternalNotificationHistory()
+    void loadInternalNotificationAttempts()
     void loadNotificationFailures()
     void loadAssignmentHistory()
     void loadAssignableUsers()
@@ -934,6 +963,7 @@ export function RequestDetailPage() {
     loadAssignmentHistory,
     loadCaseHistory,
     loadInternalNotificationHistory,
+    loadInternalNotificationAttempts,
     loadNotificationFailures,
     loadCommercialOwnerCandidates,
     loadCommunicationHistory,
@@ -976,6 +1006,7 @@ export function RequestDetailPage() {
         setRequest(updatedRequest)
         setCommercialOwnerDraft(updatedRequest.commercialOwner?.id ?? '')
         void loadInternalNotificationHistory()
+        void loadInternalNotificationAttempts()
         void loadNotificationFailures()
         setCommercialOwnerFeedbackSuccess(
           newOwnerId ? 'Opiekun handlowy zostal przypisany.' : 'Opiekun handlowy zostal usunieto.',
@@ -996,6 +1027,7 @@ export function RequestDetailPage() {
       id,
       isUpdatingCommercialOwner,
       loadInternalNotificationHistory,
+      loadInternalNotificationAttempts,
       loadNotificationFailures,
     ],
   )
@@ -1112,6 +1144,7 @@ export function RequestDetailPage() {
       resetStatusActionForm()
       void loadCaseHistory()
       void loadInternalNotificationHistory()
+      void loadInternalNotificationAttempts()
       void loadNotificationFailures()
       if (isAdmin) {
         void loadProcessSnapshot()
@@ -1554,6 +1587,12 @@ export function RequestDetailPage() {
             items={internalNotificationItems}
             isLoading={isInternalNotificationLoading}
             error={internalNotificationError}
+          />
+
+          <InternalNotificationAttemptsPanel
+            items={internalNotificationAttemptItems}
+            isLoading={isInternalNotificationAttemptsLoading}
+            error={internalNotificationAttemptsError}
           />
 
           {isAdmin && (

--- a/apps/frontend/src/services/portingRequests.api.test.ts
+++ b/apps/frontend/src/services/portingRequests.api.test.ts
@@ -16,6 +16,7 @@ vi.mock('./api.client', () => ({
 
 import {
   assignPortingRequestToMe,
+  getPortingRequestInternalNotificationAttempts,
   getPortingRequestNotificationFailures,
   getPortingRequestAssignmentHistory,
   getPortingRequestAssignmentUsers,
@@ -148,6 +149,16 @@ describe('portingRequests.api assignment flow', () => {
     await getPortingRequestInternalNotifications('request-1')
 
     expect(getMock).toHaveBeenCalledWith('/porting-requests/request-1/internal-notifications')
+  })
+
+  it('calls internal notification attempts endpoint with optional limit', async () => {
+    getMock.mockResolvedValueOnce({ data: { data: { requestId: 'request-1', items: [] } } })
+
+    await getPortingRequestInternalNotificationAttempts('request-1', 10)
+
+    expect(getMock).toHaveBeenCalledWith(
+      '/porting-requests/request-1/internal-notification-attempts?limit=10',
+    )
   })
 
   it('calls notification failures endpoint', async () => {

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -24,6 +24,7 @@ import type {
   PortingRequestDetailDto,
   NotificationFailureHistoryResultDto,
   PortingInternalNotificationHistoryResultDto,
+  InternalNotificationDeliveryAttemptsResultDto,
   PortingRequestListQueryDto,
   PortingRequestListResultDto,
   PortingRequestOperationalSummaryDto,
@@ -219,6 +220,26 @@ export async function getPortingRequestInternalNotifications(
     success: true
     data: PortingInternalNotificationHistoryResultDto
   }>(`/porting-requests/${id}/internal-notifications`)
+
+  return response.data.data
+}
+
+export async function getPortingRequestInternalNotificationAttempts(
+  id: string,
+  limit?: number,
+): Promise<InternalNotificationDeliveryAttemptsResultDto> {
+  const query = new URLSearchParams()
+  if (limit) query.set('limit', String(limit))
+
+  const suffix = query.toString()
+  const response = await apiClient.get<{
+    success: true
+    data: InternalNotificationDeliveryAttemptsResultDto
+  }>(
+    suffix
+      ? `/porting-requests/${id}/internal-notification-attempts?${suffix}`
+      : `/porting-requests/${id}/internal-notification-attempts`,
+  )
 
   return response.data.data
 }

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -22,6 +22,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR17  | Operacyjna historia problemow notyfikacji w szczegolach sprawy      | DONE   |
 | PR18A | Fallback runtime completion (error fallback execution + audit)       | DONE   |
 | PR19A-1 | NotificationOps foundation: first-class delivery attempts + dual-write | DONE   |
+| PR19A-2 | Request-level read layer dla internal notification attempts        | DONE   |
 
 ---
 
@@ -143,6 +144,23 @@ Dispatch jest non-blocking (`.catch(() => {})`) i nie blokuje glownego flow API.
   - queue/listy operacyjnej,
   - backfill historycznych NOTE do nowej tabeli.
 
+### PR19A-2 - request-level read layer dla attempts
+
+- Dodano request-level endpoint:
+  - `GET /api/porting-requests/:id/internal-notification-attempts`
+  - endpoint zwraca first-class ledger wykonanych prob transportu z tabeli `InternalNotificationDeliveryAttempt`.
+- Dodano shared DTO dla internal notification attempts:
+  - origin/channel/mode/outcome/failureKind,
+  - dane request/event/recipient/error/retry-chain jako read-only kontrakt pod PR19B.
+- Frontend `RequestDetailPage` ma minimalny panel read-only `Proby dostarczenia notyfikacji`.
+- Semantyka UI:
+  - `Historia powiadomien wewnetrznych` = szersza historia eventow, routingu i audit NOTE,
+  - `Proby dostarczenia notyfikacji` = ledger wykonanych prob transportu z modelu attempts.
+- Zachowano kompatybilnosc:
+  - istniejace panele `internal-notifications` i `notification-failures` nadal dzialaja rownolegle,
+  - NOTE parsing nie zostal usuniety,
+  - brak retry endpointu, retry buttona, global queue UI i backfillu historycznych NOTE.
+
 ### PR15 - operacyjne raportowanie commercial owner i health notyfikacji
 
 - Backend:
@@ -229,6 +247,7 @@ apps/backend/src/modules/porting-requests/
   porting-notification-recipient-resolver.ts
   porting-notification.service.ts          # dispatcher (PR13A+PR13B)
   # od PR19A-1: dual-write attempt records (PRIMARY + ERROR_FALLBACK)
+  porting-internal-notification-attempts.service.ts # od PR19A-2: read layer attempts
   internal-notification.adapter.ts         # email + Teams transport (PR13B)
   internal-notification-formatter.ts       # formatter tresci wiadomosci (PR13B)
   porting-notification-health.helper.ts    # single source of truth dla health computation (PR16)
@@ -243,8 +262,10 @@ apps/backend/prisma/
 packages/shared/src/
   constants/index.ts
   dto/porting-requests.dto.ts
+  dto/porting-internal-notifications.dto.ts # historia + DTO attempts (PR19A-2)
 
 apps/frontend/src/
+  components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx
   components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.tsx
   pages/Requests/RequestDetailPage.tsx
   pages/Requests/RequestsPage.tsx
@@ -267,8 +288,7 @@ apps/frontend/src/
 
 ## Kolejne kroki
 
-- **PR19A-2**: read path na nowym modelu attempts (bez usuwania kompatybilnosci NOTE na starcie).
-- **PR19B**: retry actions + operator-facing failure queue.
+- **PR19B**: retry actions oparte o `InternalNotificationDeliveryAttempt.id` + operator-facing failure queue.
 - Future: podlaczenie pozostalych eventow z katalogu (E03, E06, E12, E13, NUMBER_PORTED, CASE_REJECTED)
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ Audit i diagnostyka:
 - `[Dispatch] ...` - primary transport audit (podstawa health/failure history),
 - `[ErrorFallback] ...` - decyzja i wynik error fallback (`TRIGGERED` lub `SKIPPED` z reason).
 
-## Notification Operations foundation (EPIC-19 / PR19A-1)
+## Notification Operations foundation (EPIC-19 / PR19A-1 + PR19A-2)
 
 Dodano addytywny, first-class model runtime:
 
@@ -53,3 +53,16 @@ Istotne zasady:
 - model attempts nie zmienia semantyki `ROUTING_TEAM` vs `ERROR_FALLBACK`,
 - NOTE audit pozostaje aktywny i jest utrzymany rownolegle jako warstwa kompatybilnosci,
 - brak retry endpointow i queue UI w PR19A-1 (to zakres kolejnych krokow EPIC-19).
+
+Read layer PR19A-2:
+
+- request-level endpoint: `GET /api/porting-requests/:id/internal-notification-attempts`,
+- shared DTO w `porting-internal-notifications.dto.ts`,
+- UI detail pokazuje osobny panel `Proby dostarczenia notyfikacji`.
+
+Semantyka read modelu:
+
+- `Historia powiadomien wewnetrznych` nadal pokazuje szersza historie eventow, routingu i audit NOTE,
+- `Proby dostarczenia notyfikacji` pokazuje first-class ledger wykonanych prob transportu,
+- PR19A-2 nie usuwa NOTE parsing i nie backfilluje historycznych NOTE,
+- retry endpoint, retry button i global queue pozostaja zakresem PR19B.

--- a/packages/shared/src/dto/porting-internal-notifications.dto.ts
+++ b/packages/shared/src/dto/porting-internal-notifications.dto.ts
@@ -34,3 +34,45 @@ export interface PortingInternalNotificationHistoryItemDto {
 export interface PortingInternalNotificationHistoryResultDto {
   items: PortingInternalNotificationHistoryItemDto[]
 }
+
+export type InternalNotificationAttemptOriginDto = 'PRIMARY' | 'ERROR_FALLBACK' | 'RETRY'
+
+export type InternalNotificationAttemptChannelDto = 'EMAIL' | 'TEAMS'
+
+export type InternalNotificationAttemptModeDto = 'REAL' | 'STUB' | 'DISABLED' | 'POLICY'
+
+export type InternalNotificationAttemptOutcomeDto =
+  | 'SENT'
+  | 'STUBBED'
+  | 'DISABLED'
+  | 'MISCONFIGURED'
+  | 'FAILED'
+  | 'SKIPPED'
+
+export type InternalNotificationFailureKindDto = 'DELIVERY' | 'CONFIGURATION' | 'POLICY' | null
+
+export interface InternalNotificationDeliveryAttemptDto {
+  id: string
+  requestId: string
+  eventCode: string
+  eventLabel: string
+  attemptOrigin: InternalNotificationAttemptOriginDto
+  channel: InternalNotificationAttemptChannelDto
+  recipient: string
+  mode: InternalNotificationAttemptModeDto
+  outcome: InternalNotificationAttemptOutcomeDto
+  errorCode: string | null
+  errorMessage: string | null
+  failureKind: InternalNotificationFailureKindDto
+  retryOfAttemptId: string | null
+  retryCount: number
+  isLatestForChain: boolean
+  triggeredByUserId: string | null
+  triggeredByDisplayName: string | null
+  createdAt: string
+}
+
+export interface InternalNotificationDeliveryAttemptsResultDto {
+  requestId: string
+  items: InternalNotificationDeliveryAttemptDto[]
+}


### PR DESCRIPTION
## Problem

Po PR19A-1 runtime zapisuje `InternalNotificationDeliveryAttempt`, ale brakowało jeszcze stabilnej warstwy odczytowej.
Operator nadal nie miał request-level read path opartego o first-class attempts, a przyszły retry w PR19B nadal nie miał gotowego punktu startowego opartego o `attemptId`.

## Co zostało zmienione

* dodano shared DTO dla internal notification attempts
* dodano backend service do odczytu attempts dla pojedynczej sprawy
* dodano endpoint:

  * `GET /api/porting-requests/:id/internal-notification-attempts`
* dodano minimalny request-level panel read-only w `RequestDetailPage`:

  * **„Próby dostarczenia notyfikacji”**
* zachowano istniejące NOTE-based panele bez destrukcyjnej zmiany
* zaktualizowano `PROJECT_CONTINUITY.md` i `architecture.md`

## Zakres świadomie NIEobjęty tym PR-em

* retry endpoint
* retry button
* global queue UI
* bulk retry
* backfill historycznych NOTE
* pełne przełączenie istniejących paneli na attempts-only
* zmiana semantyki routing fallback / error fallback / retry

## Ważna decyzja architektoniczna

PR19A-2 buduje **request-level read layer** oparty o `InternalNotificationDeliveryAttempt`, ale zachowuje kompatybilność z istniejącymi NOTE-based panelami.

To oznacza:

* „Historia powiadomień wewnętrznych” pozostaje szerszą historią eventów i auditów
* „Próby dostarczenia notyfikacji” pokazują ledger wykonanych prób transportu
* nie usuwamy jeszcze NOTE parsing
* nie przełączamy jeszcze wszystkiego na attempts-only

## Endpoint i zachowanie

`GET /api/porting-requests/:id/internal-notification-attempts?limit=50`

* request-level read API
* sortowanie: najnowsze próby jako pierwsze
* limit opcjonalny, domyślnie 50, maksymalnie 100
* dla istniejącej sprawy bez attempts: pusta lista
* dla brakującej sprawy: 404
* RBAC zgodny z read-only access do detailu sprawy

## Jak zweryfikowano zmianę

### Backend targeted

* `npx vitest run src/modules/porting-requests/__tests__/porting-internal-notification-attempts.service.test.ts src/__tests__/app.internal-notification-attempts.routes.test.ts`
* PASS: 2 files, 9 tests

### Frontend targeted

* panel attempts: PASS
* API client: PASS

### Full test suite

* backend vitest → PASS (55 files, 386 tests)
* frontend vitest → PASS (26 files, 116 tests)

### Typecheck / build

* backend `tsc --noEmit` → PASS
* frontend `tsc --noEmit` → PASS
* backend build → PASS
* frontend build → PASS

## Follow-up

Ten PR przygotowuje repo pod:

* PR19B: retry oparte o `attemptId`
* późniejsze operational read paths / queue, jeśli będą potrzebne

## Ważne

Do PR19A-2 nie mogą wejść:

* `.claude/worktrees/*`
* `package-lock.json`
* artefakty spoza zakresu
