### PR TITLE
feat(PR20A): add global notification failure queue v1

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -12,6 +12,7 @@ import { communicationTemplatesRouter } from './modules/communications/communica
 import { adminUsersRouter } from './modules/admin-users/admin-users.router'
 import { adminPortingNotificationSettingsRouter } from './modules/admin-settings/admin-porting-notification-settings.router'
 import { adminNotificationFallbackSettingsRouter } from './modules/admin-settings/admin-notification-fallback-settings.router'
+import { internalNotificationFailuresRouter } from './modules/porting-requests/internal-notification-failures.router'
 import { errorHandler } from './shared/errors/error-handler'
 import { buildReadinessResult } from './shared/health/readiness'
 import type { FastifyInstance } from 'fastify'
@@ -104,6 +105,7 @@ export async function buildApp() {
   await app.register(adminUsersRouter, { prefix: '/api/admin' })
   await app.register(adminPortingNotificationSettingsRouter, { prefix: '/api/admin' })
   await app.register(adminNotificationFallbackSettingsRouter, { prefix: '/api/admin' })
+  await app.register(internalNotificationFailuresRouter, { prefix: '/api/internal-notification-failures' })
 
   app.get('/health', async () => {
     return {

--- a/apps/backend/src/modules/porting-requests/__tests__/global-notification-failure-queue.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/global-notification-failure-queue.service.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockAttemptFindMany, mockAttemptCount } = vi.hoisted(() => ({
+  mockAttemptFindMany: vi.fn(),
+  mockAttemptCount: vi.fn(),
+}))
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    internalNotificationDeliveryAttempt: {
+      findMany: (...args: unknown[]) => mockAttemptFindMany(...args),
+      count: (...args: unknown[]) => mockAttemptCount(...args),
+    },
+  },
+}))
+
+import { getGlobalNotificationFailureQueue } from '../global-notification-failure-queue.service'
+
+function buildAttempt(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'attempt-1',
+    requestId: 'request-1',
+    eventCode: 'STATUS_CHANGED',
+    eventLabel: 'Zmiana statusu sprawy',
+    attemptOrigin: 'PRIMARY',
+    channel: 'EMAIL',
+    recipient: 'bok@test.pl',
+    outcome: 'FAILED',
+    failureKind: 'DELIVERY',
+    retryCount: 0,
+    isLatestForChain: true,
+    createdAt: new Date('2026-04-11T10:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+describe('getGlobalNotificationFailureQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns items and total with defaults', async () => {
+    const attempt = buildAttempt()
+    mockAttemptFindMany.mockResolvedValue([attempt])
+    mockAttemptCount.mockResolvedValue(1)
+
+    const result = await getGlobalNotificationFailureQueue()
+
+    expect(result.total).toBe(1)
+    expect(result.items).toHaveLength(1)
+    const item = result.items[0]
+    expect(item).toBeDefined()
+    expect(item).toMatchObject({
+      attemptId: 'attempt-1',
+      requestId: 'request-1',
+      outcome: 'FAILED',
+      canRetry: true,
+      retryBlockedReasonCode: null,
+    })
+  })
+
+  it('maps createdAt to ISO string', async () => {
+    mockAttemptFindMany.mockResolvedValue([buildAttempt()])
+    mockAttemptCount.mockResolvedValue(1)
+
+    const result = await getGlobalNotificationFailureQueue()
+
+    expect(result.items[0]?.createdAt).toBe('2026-04-11T10:00:00.000Z')
+  })
+
+  it('filters by outcome=FAILED only', async () => {
+    mockAttemptFindMany.mockResolvedValue([])
+    mockAttemptCount.mockResolvedValue(0)
+
+    await getGlobalNotificationFailureQueue({ outcomes: ['FAILED'] })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const whereArg = mockAttemptFindMany.mock.calls[0]![0].where
+    expect(whereArg.outcome).toEqual({ in: ['FAILED'] })
+  })
+
+  it('adds canRetry=true filter (origin + retryCount)', async () => {
+    mockAttemptFindMany.mockResolvedValue([])
+    mockAttemptCount.mockResolvedValue(0)
+
+    await getGlobalNotificationFailureQueue({ canRetry: true })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const whereArg = mockAttemptFindMany.mock.calls[0]![0].where
+    expect(whereArg.attemptOrigin).toEqual({ in: ['PRIMARY', 'RETRY'] })
+    expect(whereArg.retryCount).toEqual({ lt: 3 })
+  })
+
+  it('adds canRetry=false filter (OR clause)', async () => {
+    mockAttemptFindMany.mockResolvedValue([])
+    mockAttemptCount.mockResolvedValue(0)
+
+    await getGlobalNotificationFailureQueue({ canRetry: false })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const whereArg = mockAttemptFindMany.mock.calls[0]![0].where
+    expect(whereArg.OR).toBeDefined()
+  })
+
+  it('uses newest sort by default (createdAt desc)', async () => {
+    mockAttemptFindMany.mockResolvedValue([])
+    mockAttemptCount.mockResolvedValue(0)
+
+    await getGlobalNotificationFailureQueue()
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const orderByArg = mockAttemptFindMany.mock.calls[0]![0].orderBy
+    expect(orderByArg[0]).toEqual({ createdAt: 'desc' })
+  })
+
+  it('sort=retryAvailable: canRetry=true items appear before canRetry=false', async () => {
+    const older = new Date('2026-04-10T08:00:00.000Z')
+    const newer = new Date('2026-04-11T10:00:00.000Z')
+
+    mockAttemptFindMany.mockResolvedValue([
+      // canRetry=false (RETRY_LIMIT_REACHED) — newer timestamp
+      buildAttempt({ id: 'a1', retryCount: 3, createdAt: newer }),
+      // canRetry=true — older timestamp
+      buildAttempt({ id: 'a2', retryCount: 0, createdAt: older }),
+    ])
+    mockAttemptCount.mockResolvedValue(2)
+
+    const result = await getGlobalNotificationFailureQueue({ sort: 'retryAvailable' })
+
+    expect(result.items[0]?.attemptId).toBe('a2') // canRetry=true first
+    expect(result.items[1]?.attemptId).toBe('a1') // canRetry=false second
+  })
+
+  it('sort=retryAvailable: within each group orders by createdAt DESC', async () => {
+    const t1 = new Date('2026-04-09T08:00:00.000Z')
+    const t2 = new Date('2026-04-10T10:00:00.000Z')
+    const t3 = new Date('2026-04-09T09:00:00.000Z')
+    const t4 = new Date('2026-04-11T12:00:00.000Z')
+
+    mockAttemptFindMany.mockResolvedValue([
+      // DB returns createdAt DESC, so newer first
+      buildAttempt({ id: 'canRetry-newer', retryCount: 0, createdAt: t2 }),
+      buildAttempt({ id: 'canRetry-older', retryCount: 1, createdAt: t1 }),
+      buildAttempt({ id: 'blocked-newer', retryCount: 3, createdAt: t4 }),
+      buildAttempt({ id: 'blocked-older', retryCount: 3, createdAt: t3 }),
+    ])
+    mockAttemptCount.mockResolvedValue(4)
+
+    const result = await getGlobalNotificationFailureQueue({ sort: 'retryAvailable' })
+    const ids = result.items.map((i) => i.attemptId)
+
+    // canRetry=true group first (createdAt DESC within group)
+    expect(ids[0]).toBe('canRetry-newer')
+    expect(ids[1]).toBe('canRetry-older')
+    // canRetry=false group second
+    expect(ids[2]).toBe('blocked-newer')
+    expect(ids[3]).toBe('blocked-older')
+  })
+
+  it('sort=retryAvailable: low retryCount but canRetry=false does not precede canRetry=true', async () => {
+    // ERROR_FALLBACK origin: retryCount=0 but canRetry=false (ORIGIN_NOT_RETRYABLE)
+    const fallback = buildAttempt({ id: 'fallback', attemptOrigin: 'ERROR_FALLBACK', retryCount: 0 })
+    const retryable = buildAttempt({ id: 'retryable', attemptOrigin: 'PRIMARY', retryCount: 2 })
+
+    mockAttemptFindMany.mockResolvedValue([fallback, retryable])
+    mockAttemptCount.mockResolvedValue(2)
+
+    const result = await getGlobalNotificationFailureQueue({ sort: 'retryAvailable' })
+
+    expect(result.items[0]?.attemptId).toBe('retryable') // canRetry=true, retryCount=2
+    expect(result.items[1]?.attemptId).toBe('fallback')  // canRetry=false despite retryCount=0
+  })
+
+  it('sort=retryAvailable: DB query uses createdAt DESC (no retryCount proxy)', async () => {
+    mockAttemptFindMany.mockResolvedValue([])
+    mockAttemptCount.mockResolvedValue(0)
+
+    await getGlobalNotificationFailureQueue({ sort: 'retryAvailable' })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const orderByArg = mockAttemptFindMany.mock.calls[0]![0].orderBy
+    expect(orderByArg[0]).toEqual({ createdAt: 'desc' })
+    // must NOT use retryCount as DB-level sort proxy
+    expect(orderByArg.find((o: Record<string, unknown>) => 'retryCount' in o)).toBeUndefined()
+  })
+
+  it('applies limit and offset', async () => {
+    mockAttemptFindMany.mockResolvedValue([])
+    mockAttemptCount.mockResolvedValue(0)
+
+    await getGlobalNotificationFailureQueue({ limit: 10, offset: 20 })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const callArg = mockAttemptFindMany.mock.calls[0]![0]
+    expect(callArg.take).toBe(10)
+    expect(callArg.skip).toBe(20)
+  })
+
+  it('caps limit at 100', async () => {
+    mockAttemptFindMany.mockResolvedValue([])
+    mockAttemptCount.mockResolvedValue(0)
+
+    await getGlobalNotificationFailureQueue({ limit: 999 })
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(mockAttemptFindMany.mock.calls[0]![0].take).toBe(100)
+  })
+
+  it('sets canRetry=false and RETRY_LIMIT_REACHED when retryCount >= 3', async () => {
+    mockAttemptFindMany.mockResolvedValue([buildAttempt({ retryCount: 3 })])
+    mockAttemptCount.mockResolvedValue(1)
+
+    const result = await getGlobalNotificationFailureQueue()
+    const item = result.items[0]
+
+    expect(item).toBeDefined()
+    expect(item?.canRetry).toBe(false)
+    expect(item?.retryBlockedReasonCode).toBe('RETRY_LIMIT_REACHED')
+  })
+
+  it('sets canRetry=false and ORIGIN_NOT_RETRYABLE for ERROR_FALLBACK origin', async () => {
+    mockAttemptFindMany.mockResolvedValue([buildAttempt({ attemptOrigin: 'ERROR_FALLBACK' })])
+    mockAttemptCount.mockResolvedValue(1)
+
+    const result = await getGlobalNotificationFailureQueue()
+    const item = result.items[0]
+
+    expect(item).toBeDefined()
+    expect(item?.canRetry).toBe(false)
+    expect(item?.retryBlockedReasonCode).toBe('ORIGIN_NOT_RETRYABLE')
+  })
+})

--- a/apps/backend/src/modules/porting-requests/global-notification-failure-queue.service.ts
+++ b/apps/backend/src/modules/porting-requests/global-notification-failure-queue.service.ts
@@ -1,0 +1,144 @@
+import type { GlobalNotificationFailureQueueItemDto, GlobalNotificationFailureQueueResultDto } from '@np-manager/shared'
+import { prisma } from '../../config/database'
+import { resolveInternalNotificationRetryEligibility } from './porting-internal-notification-retry-eligibility.helper'
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 100
+
+export type GlobalFailureQueueOutcomeFilter = 'FAILED' | 'MISCONFIGURED'
+export type GlobalFailureQueueSort = 'newest' | 'retryAvailable'
+
+export interface GlobalNotificationFailureQueueParams {
+  outcomes?: GlobalFailureQueueOutcomeFilter[]
+  canRetry?: boolean
+  sort?: GlobalFailureQueueSort
+  limit?: number
+  offset?: number
+}
+
+type FailureAttemptRecord = {
+  id: string
+  requestId: string
+  eventCode: string
+  eventLabel: string
+  attemptOrigin: 'PRIMARY' | 'ERROR_FALLBACK' | 'RETRY'
+  channel: 'EMAIL' | 'TEAMS'
+  recipient: string
+  outcome: 'SENT' | 'STUBBED' | 'DISABLED' | 'MISCONFIGURED' | 'FAILED' | 'SKIPPED'
+  failureKind: 'DELIVERY' | 'CONFIGURATION' | 'POLICY' | null
+  retryCount: number
+  isLatestForChain: boolean
+  createdAt: Date
+}
+
+export async function getGlobalNotificationFailureQueue(
+  params: GlobalNotificationFailureQueueParams = {},
+): Promise<GlobalNotificationFailureQueueResultDto> {
+  const outcomes = params.outcomes ?? ['FAILED', 'MISCONFIGURED']
+  const sort = params.sort ?? 'newest'
+  const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT)
+  const offset = params.offset ?? 0
+
+  const baseWhere = buildWhereClause(outcomes, params.canRetry)
+  const dbSelect = {
+    id: true,
+    requestId: true,
+    eventCode: true,
+    eventLabel: true,
+    attemptOrigin: true,
+    channel: true,
+    recipient: true,
+    outcome: true,
+    failureKind: true,
+    retryCount: true,
+    isLatestForChain: true,
+    createdAt: true,
+  }
+
+  if (sort === 'retryAvailable') {
+    // canRetry is a computed field — sort in-memory after mapping to DTO
+    const [allRecords, total] = await Promise.all([
+      prisma.internalNotificationDeliveryAttempt.findMany({
+        where: baseWhere,
+        orderBy: [{ createdAt: 'desc' }],
+        select: dbSelect,
+      }),
+      prisma.internalNotificationDeliveryAttempt.count({ where: baseWhere }),
+    ])
+
+    const items = allRecords
+      .map(mapToDto)
+      .sort((a, b) => {
+        if (a.canRetry === b.canRetry) return 0
+        return a.canRetry ? -1 : 1
+      })
+      .slice(offset, offset + limit)
+
+    return { items, total }
+  }
+
+  const [records, total] = await Promise.all([
+    prisma.internalNotificationDeliveryAttempt.findMany({
+      where: baseWhere,
+      orderBy: [{ createdAt: 'desc' }],
+      take: limit,
+      skip: offset,
+      select: dbSelect,
+    }),
+    prisma.internalNotificationDeliveryAttempt.count({ where: baseWhere }),
+  ])
+
+  return {
+    items: records.map(mapToDto),
+    total,
+  }
+}
+
+function buildWhereClause(
+  outcomes: GlobalFailureQueueOutcomeFilter[],
+  canRetry?: boolean,
+) {
+  const base = {
+    isLatestForChain: true,
+    outcome: { in: outcomes as ('FAILED' | 'MISCONFIGURED')[] },
+  }
+
+  if (canRetry === true) {
+    return {
+      ...base,
+      attemptOrigin: { in: ['PRIMARY', 'RETRY'] as ('PRIMARY' | 'RETRY')[] },
+      retryCount: { lt: 3 },
+    }
+  }
+
+  if (canRetry === false) {
+    return {
+      ...base,
+      OR: [
+        { attemptOrigin: 'ERROR_FALLBACK' as const },
+        { retryCount: { gte: 3 } },
+      ],
+    }
+  }
+
+  return base
+}
+
+function mapToDto(record: FailureAttemptRecord): GlobalNotificationFailureQueueItemDto {
+  const { canRetry, retryBlockedReasonCode } = resolveInternalNotificationRetryEligibility(record)
+  return {
+    attemptId: record.id,
+    requestId: record.requestId,
+    eventCode: record.eventCode,
+    eventLabel: record.eventLabel,
+    attemptOrigin: record.attemptOrigin,
+    channel: record.channel,
+    recipient: record.recipient,
+    outcome: record.outcome,
+    failureKind: record.failureKind,
+    retryCount: record.retryCount,
+    canRetry,
+    retryBlockedReasonCode,
+    createdAt: record.createdAt.toISOString(),
+  }
+}

--- a/apps/backend/src/modules/porting-requests/internal-notification-failures.router.ts
+++ b/apps/backend/src/modules/porting-requests/internal-notification-failures.router.ts
@@ -1,0 +1,53 @@
+import type { FastifyInstance } from 'fastify'
+import { z } from 'zod'
+import { authenticate } from '../../shared/middleware/authenticate'
+import { authorize } from '../../shared/middleware/authorize'
+import type { UserRole } from '@np-manager/shared'
+import {
+  getGlobalNotificationFailureQueue,
+  type GlobalFailureQueueOutcomeFilter,
+  type GlobalFailureQueueSort,
+} from './global-notification-failure-queue.service'
+
+const globalFailureQueueRoles: UserRole[] = ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER']
+
+const globalFailureQueueQuerySchema = z.object({
+  outcome: z
+    .string()
+    .optional()
+    .transform((val) => {
+      if (!val) return ['FAILED', 'MISCONFIGURED'] as GlobalFailureQueueOutcomeFilter[]
+      return val.split(',').filter((o): o is GlobalFailureQueueOutcomeFilter =>
+        o === 'FAILED' || o === 'MISCONFIGURED',
+      )
+    }),
+  canRetry: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform((val) => {
+      if (val === 'true') return true
+      if (val === 'false') return false
+      return undefined
+    }),
+  sort: z.enum(['newest', 'retryAvailable']).default('newest') as z.ZodType<GlobalFailureQueueSort>,
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+})
+
+export async function internalNotificationFailuresRouter(app: FastifyInstance) {
+  app.get(
+    '/',
+    { preHandler: [authenticate, authorize(globalFailureQueueRoles)] },
+    async (request, reply) => {
+      const query = globalFailureQueueQuerySchema.parse(request.query)
+      const result = await getGlobalNotificationFailureQueue({
+        outcomes: query.outcome,
+        canRetry: query.canRetry,
+        sort: query.sort,
+        limit: query.limit,
+        offset: query.offset,
+      })
+      return reply.status(200).send({ success: true, data: result })
+    },
+  )
+}

--- a/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.test.tsx
+++ b/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.test.tsx
@@ -1,0 +1,119 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import { MemoryRouter } from 'react-router-dom'
+import type { GlobalNotificationFailureQueueItemDto } from '@np-manager/shared'
+import { NotificationFailureQueueTable } from './NotificationFailureQueueTable'
+
+function makeItem(
+  overrides: Partial<GlobalNotificationFailureQueueItemDto> = {},
+): GlobalNotificationFailureQueueItemDto {
+  return {
+    attemptId: 'attempt-1',
+    requestId: 'request-abc-123',
+    eventCode: 'STATUS_CHANGED',
+    eventLabel: 'Zmiana statusu sprawy',
+    attemptOrigin: 'PRIMARY',
+    channel: 'EMAIL',
+    recipient: 'bok@test.pl',
+    outcome: 'FAILED',
+    failureKind: 'DELIVERY',
+    retryCount: 0,
+    canRetry: true,
+    retryBlockedReasonCode: null,
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+function render(ui: React.ReactElement) {
+  return renderToStaticMarkup(<MemoryRouter>{ui}</MemoryRouter>)
+}
+
+describe('NotificationFailureQueueTable', () => {
+  it('renders loading state', () => {
+    const html = render(<NotificationFailureQueueTable items={[]} isLoading error={null} />)
+    expect(html).toContain('Ładowanie')
+  })
+
+  it('renders error state', () => {
+    const html = render(
+      <NotificationFailureQueueTable items={[]} isLoading={false} error="Blad serwera" />,
+    )
+    expect(html).toContain('Blad serwera')
+  })
+
+  it('renders empty state', () => {
+    const html = render(<NotificationFailureQueueTable items={[]} isLoading={false} error={null} />)
+    expect(html).toContain('Brak problematycznych prób notyfikacji')
+  })
+
+  it('renders FAILED outcome badge', () => {
+    const html = render(
+      <NotificationFailureQueueTable
+        items={[makeItem({ outcome: 'FAILED' })]}
+        isLoading={false}
+        error={null}
+      />,
+    )
+    expect(html).toContain('Błąd wysyłki')
+  })
+
+  it('renders MISCONFIGURED outcome badge', () => {
+    const html = render(
+      <NotificationFailureQueueTable
+        items={[makeItem({ outcome: 'MISCONFIGURED', failureKind: 'CONFIGURATION' })]}
+        isLoading={false}
+        error={null}
+      />,
+    )
+    expect(html).toContain('Błędna konfiguracja')
+    expect(html).toContain('Konfiguracja')
+  })
+
+  it('renders canRetry=true as Dostepny', () => {
+    const html = render(
+      <NotificationFailureQueueTable
+        items={[makeItem({ canRetry: true, retryBlockedReasonCode: null })]}
+        isLoading={false}
+        error={null}
+      />,
+    )
+    expect(html).toContain('Dostępny')
+  })
+
+  it('renders RETRY_LIMIT_REACHED as Wyczerpany', () => {
+    const html = render(
+      <NotificationFailureQueueTable
+        items={[
+          makeItem({ canRetry: false, retryBlockedReasonCode: 'RETRY_LIMIT_REACHED', retryCount: 3 }),
+        ]}
+        isLoading={false}
+        error={null}
+      />,
+    )
+    expect(html).toContain('Wyczerpany')
+    expect(html).toContain('3 / 3')
+  })
+
+  it('renders link to RequestDetailPage', () => {
+    const html = render(
+      <NotificationFailureQueueTable
+        items={[makeItem({ requestId: 'request-abc-123' })]}
+        isLoading={false}
+        error={null}
+      />,
+    )
+    expect(html).toContain('/requests/request-abc-123')
+  })
+
+  it('renders eventLabel', () => {
+    const html = render(
+      <NotificationFailureQueueTable
+        items={[makeItem({ eventLabel: 'Zmiana statusu sprawy' })]}
+        isLoading={false}
+        error={null}
+      />,
+    )
+    expect(html).toContain('Zmiana statusu sprawy')
+  })
+})

--- a/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx
+++ b/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx
@@ -1,0 +1,135 @@
+import { Link } from 'react-router-dom'
+import type { GlobalNotificationFailureQueueItemDto } from '@np-manager/shared'
+import { buildPath, ROUTES } from '@/constants/routes'
+
+interface NotificationFailureQueueTableProps {
+  items: GlobalNotificationFailureQueueItemDto[]
+  isLoading: boolean
+  error: string | null
+}
+
+function getOutcomeClass(outcome: GlobalNotificationFailureQueueItemDto['outcome']): string {
+  if (outcome === 'FAILED') return 'bg-red-100 text-red-700'
+  if (outcome === 'MISCONFIGURED') return 'bg-amber-100 text-amber-700'
+  return 'bg-gray-100 text-gray-700'
+}
+
+function getOutcomeLabel(outcome: GlobalNotificationFailureQueueItemDto['outcome']): string {
+  if (outcome === 'FAILED') return 'Błąd wysyłki'
+  if (outcome === 'MISCONFIGURED') return 'Błędna konfiguracja'
+  return outcome
+}
+
+function getFailureKindLabel(
+  failureKind: GlobalNotificationFailureQueueItemDto['failureKind'],
+): string {
+  if (failureKind === 'DELIVERY') return 'Błąd transportu'
+  if (failureKind === 'CONFIGURATION') return 'Konfiguracja'
+  if (failureKind === 'POLICY') return 'Polityka'
+  return '—'
+}
+
+function getRetryStatusLabel(item: GlobalNotificationFailureQueueItemDto): string {
+  if (item.canRetry) return 'Dostępny'
+  if (item.retryBlockedReasonCode === 'RETRY_LIMIT_REACHED') return 'Wyczerpany'
+  if (item.retryBlockedReasonCode === 'ORIGIN_NOT_RETRYABLE') return 'Niedostępny (fallback)'
+  return 'Niedostępny'
+}
+
+function getRetryStatusClass(item: GlobalNotificationFailureQueueItemDto): string {
+  if (item.canRetry) return 'bg-emerald-100 text-emerald-700'
+  if (item.retryBlockedReasonCode === 'RETRY_LIMIT_REACHED') return 'bg-red-100 text-red-700'
+  return 'bg-gray-100 text-gray-600'
+}
+
+function formatRelativeTime(isoString: string): string {
+  const diff = Date.now() - new Date(isoString).getTime()
+  const minutes = Math.floor(diff / 60000)
+  if (minutes < 1) return 'przed chwilą'
+  if (minutes < 60) return `${minutes} min temu`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours} godz temu`
+  const days = Math.floor(hours / 24)
+  return `${days} dni temu`
+}
+
+export function NotificationFailureQueueTable({
+  items,
+  isLoading,
+  error,
+}: NotificationFailureQueueTableProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-gray-500">
+        Ładowanie...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        {error}
+      </div>
+    )
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-14 text-center">
+        <p className="text-sm text-gray-500">Brak problematycznych prób notyfikacji.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+            <th className="px-4 py-3">Sprawa</th>
+            <th className="px-4 py-3">Zdarzenie</th>
+            <th className="px-4 py-3">Wynik</th>
+            <th className="px-4 py-3">Rodzaj błędu</th>
+            <th className="px-4 py-3">Ponowienia</th>
+            <th className="px-4 py-3">Status retry</th>
+            <th className="px-4 py-3">Czas</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {items.map((item) => (
+            <tr key={item.attemptId} className="bg-white hover:bg-gray-50">
+              <td className="px-4 py-3 font-mono text-xs">
+                <Link
+                  to={buildPath(ROUTES.REQUEST_DETAIL, item.requestId)}
+                  className="text-blue-600 hover:underline"
+                >
+                  {item.requestId.slice(0, 8)}...
+                </Link>
+              </td>
+              <td className="px-4 py-3 text-gray-900">{item.eventLabel}</td>
+              <td className="px-4 py-3">
+                <span
+                  className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getOutcomeClass(item.outcome)}`}
+                >
+                  {getOutcomeLabel(item.outcome)}
+                </span>
+              </td>
+              <td className="px-4 py-3 text-gray-600">{getFailureKindLabel(item.failureKind)}</td>
+              <td className="px-4 py-3 text-gray-600">{item.retryCount} / 3</td>
+              <td className="px-4 py-3">
+                <span
+                  className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${getRetryStatusClass(item)}`}
+                  title={item.retryBlockedReasonCode ?? undefined}
+                >
+                  {getRetryStatusLabel(item)}
+                </span>
+              </td>
+              <td className="px-4 py-3 text-gray-400">{formatRelativeTime(item.createdAt)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/apps/frontend/src/components/layout/AppLayout.tsx
+++ b/apps/frontend/src/components/layout/AppLayout.tsx
@@ -18,6 +18,12 @@ const primaryNavItems: NavItem[] = [
   { label: 'Klienci', path: ROUTES.CLIENTS, icon: 'K' },
   { label: 'Zadania', path: ROUTES.TASKS, icon: 'Z' },
   { label: 'Raporty', path: ROUTES.REPORTS, icon: 'R', roles: ['ADMIN', 'MANAGER', 'AUDITOR'] },
+  {
+    label: 'Błędy notyfikacji',
+    path: ROUTES.NOTIFICATION_FAILURES,
+    icon: '!',
+    roles: ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER'],
+  },
   { label: 'Operatorzy', path: ROUTES.OPERATORS, icon: 'O' },
 ]
 

--- a/apps/frontend/src/constants/routes.ts
+++ b/apps/frontend/src/constants/routes.ts
@@ -42,6 +42,8 @@ export const ROUTES = {
   ADMIN_COMMUNICATION_TEMPLATE_NEW: '/admin/communication-templates/new',
   ADMIN_COMMUNICATION_TEMPLATE_DETAIL: '/admin/communication-templates/:id',
   ADMIN_COMMUNICATION_TEMPLATE_EDIT: '/admin/communication-templates/:id/edit',
+  NOTIFICATION_FAILURES: '/notifications/failures',
+
   ADMIN_DOCUMENT_TYPES: '/admin/document-types',
   ADMIN_SETTINGS: '/admin/settings',
   ADMIN_CALENDAR: '/admin/calendar',

--- a/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx
+++ b/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react'
+import type { GlobalNotificationFailureQueueItemDto } from '@np-manager/shared'
+import {
+  getGlobalNotificationFailureQueue,
+  type GetGlobalNotificationFailureQueueParams,
+} from '@/services/portingRequests.api'
+import { NotificationFailureQueueTable } from '@/components/NotificationFailureQueueTable/NotificationFailureQueueTable'
+
+const PAGE_SIZE = 50
+
+export function NotificationFailureQueuePage() {
+  const [items, setItems] = useState<GlobalNotificationFailureQueueItemDto[]>([])
+  const [total, setTotal] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [onlyRetryAvailable, setOnlyRetryAvailable] = useState(false)
+  const [offset, setOffset] = useState(0)
+
+  useEffect(() => {
+    setOffset(0)
+  }, [onlyRetryAvailable])
+
+  useEffect(() => {
+    setIsLoading(true)
+    setError(null)
+
+    const params: GetGlobalNotificationFailureQueueParams = {
+      limit: PAGE_SIZE,
+      offset,
+    }
+    if (onlyRetryAvailable) {
+      params.canRetry = true
+    }
+
+    getGlobalNotificationFailureQueue(params)
+      .then((result) => {
+        setItems(result.items)
+        setTotal(result.total)
+      })
+      .catch(() => {
+        setError('Nie udało się pobrać listy problematycznych notyfikacji.')
+      })
+      .finally(() => {
+        setIsLoading(false)
+      })
+  }, [onlyRetryAvailable, offset])
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1
+  const hasPrev = offset > 0
+  const hasNext = offset + PAGE_SIZE < total
+
+  return (
+    <div className="p-6">
+      <div className="mb-6">
+        <h1 className="text-xl font-semibold text-gray-900">Kolejka błędów notyfikacji</h1>
+        <p className="mt-1 text-sm text-gray-500">
+          Globalna lista spraw z ostatnio nieudanymi próbami dostarczenia notyfikacji.
+        </p>
+      </div>
+
+      <div className="mb-4 flex items-center justify-between">
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+          <input
+            type="checkbox"
+            checked={onlyRetryAvailable}
+            onChange={(e) => setOnlyRetryAvailable(e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300 text-blue-600"
+          />
+          Tylko z dostępnym retry
+        </label>
+
+        {!isLoading && !error && (
+          <span className="text-xs text-gray-400">
+            {total === 0 ? 'Brak wyników' : `${total} ${total === 1 ? 'wynik' : 'wyników'}`}
+          </span>
+        )}
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <NotificationFailureQueueTable items={items} isLoading={isLoading} error={error} />
+      </div>
+
+      {!isLoading && !error && total > PAGE_SIZE && (
+        <div className="mt-4 flex items-center justify-between text-sm text-gray-600">
+          <button
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            disabled={!hasPrev}
+            className="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 hover:bg-gray-100 disabled:cursor-not-allowed"
+          >
+            Poprzednia
+          </button>
+          <span className="text-xs text-gray-400">
+            Strona {currentPage} z {totalPages}
+          </span>
+          <button
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+            disabled={!hasNext}
+            className="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 hover:bg-gray-100 disabled:cursor-not-allowed"
+          >
+            Nastepna
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -16,6 +16,7 @@ import { CommunicationTemplatesAdminPage } from '@/pages/Admin/CommunicationTemp
 import { AdminUsersPage } from '@/pages/Admin/AdminUsersPage'
 import { PortingNotificationSettingsPage } from '@/pages/Admin/PortingNotificationSettingsPage'
 import { NotificationFallbackSettingsPage } from '@/pages/Admin/NotificationFallbackSettingsPage'
+import { NotificationFailureQueuePage } from '@/pages/Notifications/NotificationFailureQueuePage'
 import {
   getDefaultAuthenticatedRoute,
   getForcePasswordChangeRouteRedirect,
@@ -152,6 +153,10 @@ export const router = createBrowserRouter([
       {
         path: ROUTES.REQUEST_DETAIL,
         element: <RequestDetailPage />,
+      },
+      {
+        path: ROUTES.NOTIFICATION_FAILURES,
+        element: <NotificationFailureQueuePage />,
       },
       {
         path: ROUTES.TASKS,

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -1,5 +1,6 @@
 import { apiClient } from './api.client'
 import type {
+  GlobalNotificationFailureQueueResultDto,
   CommercialOwnerCandidatesResultDto,
   UpdatePortingRequestCommercialOwnerDto,
   CommunicationDeliveryAttemptsResultDto,
@@ -240,6 +241,37 @@ export async function getPortingRequestInternalNotificationAttempts(
       ? `/porting-requests/${id}/internal-notification-attempts?${suffix}`
       : `/porting-requests/${id}/internal-notification-attempts`,
   )
+
+  return response.data.data
+}
+
+export interface GetGlobalNotificationFailureQueueParams {
+  outcomes?: ('FAILED' | 'MISCONFIGURED')[]
+  canRetry?: boolean
+  sort?: 'newest' | 'retryAvailable'
+  limit?: number
+  offset?: number
+}
+
+export async function getGlobalNotificationFailureQueue(
+  params: GetGlobalNotificationFailureQueueParams = {},
+): Promise<GlobalNotificationFailureQueueResultDto> {
+  const query = new URLSearchParams()
+  if (params.outcomes && params.outcomes.length > 0) {
+    query.set('outcome', params.outcomes.join(','))
+  }
+  if (params.canRetry !== undefined) {
+    query.set('canRetry', String(params.canRetry))
+  }
+  if (params.sort) query.set('sort', params.sort)
+  if (params.limit) query.set('limit', String(params.limit))
+  if (params.offset) query.set('offset', String(params.offset))
+
+  const suffix = query.toString()
+  const response = await apiClient.get<{
+    success: true
+    data: GlobalNotificationFailureQueueResultDto
+  }>(suffix ? `/internal-notification-failures?${suffix}` : '/internal-notification-failures')
 
   return response.data.data
 }

--- a/packages/shared/src/dto/porting-internal-notifications.dto.ts
+++ b/packages/shared/src/dto/porting-internal-notifications.dto.ts
@@ -85,6 +85,27 @@ export interface InternalNotificationDeliveryAttemptsResultDto {
   items: InternalNotificationDeliveryAttemptDto[]
 }
 
+export interface GlobalNotificationFailureQueueItemDto {
+  attemptId: string
+  requestId: string
+  eventCode: string
+  eventLabel: string
+  attemptOrigin: InternalNotificationAttemptOriginDto
+  channel: InternalNotificationAttemptChannelDto
+  recipient: string
+  outcome: InternalNotificationAttemptOutcomeDto
+  failureKind: InternalNotificationFailureKindDto
+  retryCount: number
+  canRetry: boolean
+  retryBlockedReasonCode: InternalNotificationRetryBlockedReasonCodeDto | null
+  createdAt: string
+}
+
+export interface GlobalNotificationFailureQueueResultDto {
+  items: GlobalNotificationFailureQueueItemDto[]
+  total: number
+}
+
 export interface RetryInternalNotificationAttemptDto {
   reason?: string
 }


### PR DESCRIPTION
## Problem

Po domknięciu PR19B mamy retry v1 dla pojedynczej sprawy, ale nadal brakowało globalnego, operacyjnego widoku pokazującego, które sprawy mają aktualnie problematyczny latest attempt notyfikacyjny.

Operator nie miał jednego miejsca, w którym mógłby:
- zobaczyć cross-request listę problematycznych notyfikacji,
- odróżnić sprawy z dostępnym retry od tych wymagających ręcznej interwencji,
- szybko przejść do właściwego Request Detail.

## Zakres zmian

### Backend
- dodano globalny read-only endpoint:
  - `GET /api/internal-notification-failures`
- endpoint zwraca wyłącznie latest problematic attempts:
  - `isLatestForChain = true`
  - `outcome in (FAILED, MISCONFIGURED)`
- dodano filtrowanie:
  - `outcome`
  - `canRetry`
  - `sort`
  - `limit`
  - `offset`
- wykorzystano istniejącą logikę retry eligibility do wyliczenia:
  - `canRetry`
  - `retryBlockedReasonCode`

### Shared DTO
- dodano:
  - `GlobalNotificationFailureQueueItemDto`
  - `GlobalNotificationFailureQueueResultDto`

### Frontend
- dodano nową stronę:
  - `/notifications/failures`
- dodano tabelę global failure queue
- dodano filtr:
  - `Tylko z dostępnym retry`
- dodano link w sidebarze dla ról operacyjnych
- Request ID prowadzi do `/requests/:requestId`

## Endpoint

`GET /api/internal-notification-failures`

### Query params
- `outcome=FAILED,MISCONFIGURED` — domyślnie oba
- `canRetry=true|false` — opcjonalny
- `sort=newest|retryAvailable` — domyślnie `newest`
- `limit` — domyślnie 50, max 100
- `offset` — domyślnie 0

### Response
- `items`
- `total`

## UI

Nowa trasa:
- `/notifications/failures`

Tabela pokazuje:
- Sprawa
- Zdarzenie
- Wynik
- Rodzaj błędu
- Ponowienia
- Status retry
- Czas

Widok jest świadomie read-only.
Nie dodano retry buttona w global queue — operator przechodzi do `RequestDetailPage`.

## Ważne decyzje
- latest-only
- attempts-only
- bez NOTE parsing
- bez write actions
- bez bulk retry
- bez przebudowy `RequestDetailPage`
- bez migracji DB w v1

## Fix-pack po implementacji
- poprawiono semantykę `sort=retryAvailable`:
  - sortowanie odbywa się po wyliczeniu `canRetry`
  - `canRetry=true` trafia przed `canRetry=false`
  - w obrębie grup zachowane jest `createdAt DESC`
- poprawiono polskie znaki w sidebarze i na stronie

## Walidacja

### Backend
- `npx tsc --noEmit` ✅
- `npm run test` ✅
- `npm run build` ✅

### Frontend
- `npx tsc --noEmit` ✅
- `npm run test` ✅
- `npm run build` ✅

### Shared
- `npx tsc --noEmit` ✅

## Uwaga o testach backendu
Pełny backend test run zawiera 13 pre-existing env failures związanych z brakującym `DATABASE_URL` w środowisku testowym. Nie są one związane z zakresem PR20A. Testy dotyczące nowego zakresu oraz pozostała walidacja przechodzą.

## Znane ograniczenie
`sort=retryAvailable` jest realizowany przez post-sort w serwisie po wyliczeniu `canRetry`, a nie bezpośrednio w SQL. Dla v1 jest to akceptowalny trade-off przy małej tabeli.