### PR TITLE
feat(PR20B): dodaj retry w globalnej kolejce notyfikacji

### DIFF
--- a/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.test.tsx
+++ b/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+import type { ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import type { GlobalNotificationFailureQueueItemDto } from '@np-manager/shared'
 import { NotificationFailureQueueTable } from './NotificationFailureQueueTable'
@@ -25,95 +26,88 @@ function makeItem(
   }
 }
 
-function render(ui: React.ReactElement) {
-  return renderToStaticMarkup(<MemoryRouter>{ui}</MemoryRouter>)
+function renderTable(
+  props: Partial<ComponentProps<typeof NotificationFailureQueueTable>> = {},
+) {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <NotificationFailureQueueTable
+        items={[]}
+        isLoading={false}
+        error={null}
+        retryingAttemptIds={[]}
+        onRetryAttempt={vi.fn()}
+        {...props}
+      />
+    </MemoryRouter>,
+  )
 }
 
 describe('NotificationFailureQueueTable', () => {
   it('renders loading state', () => {
-    const html = render(<NotificationFailureQueueTable items={[]} isLoading error={null} />)
+    const html = renderTable({ isLoading: true })
     expect(html).toContain('Ładowanie')
   })
 
   it('renders error state', () => {
-    const html = render(
-      <NotificationFailureQueueTable items={[]} isLoading={false} error="Blad serwera" />,
-    )
+    const html = renderTable({ error: 'Blad serwera' })
     expect(html).toContain('Blad serwera')
   })
 
   it('renders empty state', () => {
-    const html = render(<NotificationFailureQueueTable items={[]} isLoading={false} error={null} />)
+    const html = renderTable()
     expect(html).toContain('Brak problematycznych prób notyfikacji')
   })
 
   it('renders FAILED outcome badge', () => {
-    const html = render(
-      <NotificationFailureQueueTable
-        items={[makeItem({ outcome: 'FAILED' })]}
-        isLoading={false}
-        error={null}
-      />,
-    )
+    const html = renderTable({ items: [makeItem({ outcome: 'FAILED' })] })
     expect(html).toContain('Błąd wysyłki')
   })
 
   it('renders MISCONFIGURED outcome badge', () => {
-    const html = render(
-      <NotificationFailureQueueTable
-        items={[makeItem({ outcome: 'MISCONFIGURED', failureKind: 'CONFIGURATION' })]}
-        isLoading={false}
-        error={null}
-      />,
-    )
+    const html = renderTable({
+      items: [makeItem({ outcome: 'MISCONFIGURED', failureKind: 'CONFIGURATION' })],
+    })
     expect(html).toContain('Błędna konfiguracja')
     expect(html).toContain('Konfiguracja')
   })
 
   it('renders canRetry=true as Dostepny', () => {
-    const html = render(
-      <NotificationFailureQueueTable
-        items={[makeItem({ canRetry: true, retryBlockedReasonCode: null })]}
-        isLoading={false}
-        error={null}
-      />,
-    )
+    const html = renderTable({ items: [makeItem({ canRetry: true, retryBlockedReasonCode: null })] })
     expect(html).toContain('Dostępny')
   })
 
+  it('renders retry button for canRetry=true', () => {
+    const html = renderTable({ items: [makeItem({ canRetry: true })] })
+
+    expect(html).toContain('Ponów')
+  })
+
+  it('does not render retry button for canRetry=false', () => {
+    const html = renderTable({
+      items: [makeItem({ canRetry: false, retryBlockedReasonCode: 'RETRY_LIMIT_REACHED' })],
+    })
+
+    expect(html).not.toContain('Ponów')
+  })
+
   it('renders RETRY_LIMIT_REACHED as Wyczerpany', () => {
-    const html = render(
-      <NotificationFailureQueueTable
-        items={[
-          makeItem({ canRetry: false, retryBlockedReasonCode: 'RETRY_LIMIT_REACHED', retryCount: 3 }),
-        ]}
-        isLoading={false}
-        error={null}
-      />,
-    )
+    const html = renderTable({
+      items: [
+        makeItem({ canRetry: false, retryBlockedReasonCode: 'RETRY_LIMIT_REACHED', retryCount: 3 }),
+      ],
+    })
     expect(html).toContain('Wyczerpany')
     expect(html).toContain('3 / 3')
   })
 
   it('renders link to RequestDetailPage', () => {
-    const html = render(
-      <NotificationFailureQueueTable
-        items={[makeItem({ requestId: 'request-abc-123' })]}
-        isLoading={false}
-        error={null}
-      />,
-    )
+    const html = renderTable({ items: [makeItem({ requestId: 'request-abc-123' })] })
     expect(html).toContain('/requests/request-abc-123')
   })
 
   it('renders eventLabel', () => {
-    const html = render(
-      <NotificationFailureQueueTable
-        items={[makeItem({ eventLabel: 'Zmiana statusu sprawy' })]}
-        isLoading={false}
-        error={null}
-      />,
-    )
+    const html = renderTable({ items: [makeItem({ eventLabel: 'Zmiana statusu sprawy' })] })
     expect(html).toContain('Zmiana statusu sprawy')
   })
 })

--- a/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx
+++ b/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx
@@ -6,6 +6,8 @@ interface NotificationFailureQueueTableProps {
   items: GlobalNotificationFailureQueueItemDto[]
   isLoading: boolean
   error: string | null
+  retryingAttemptIds: string[]
+  onRetryAttempt: (item: GlobalNotificationFailureQueueItemDto) => void
 }
 
 function getOutcomeClass(outcome: GlobalNotificationFailureQueueItemDto['outcome']): string {
@@ -57,6 +59,8 @@ export function NotificationFailureQueueTable({
   items,
   isLoading,
   error,
+  retryingAttemptIds,
+  onRetryAttempt,
 }: NotificationFailureQueueTableProps) {
   if (isLoading) {
     return (
@@ -94,40 +98,59 @@ export function NotificationFailureQueueTable({
             <th className="px-4 py-3">Ponowienia</th>
             <th className="px-4 py-3">Status retry</th>
             <th className="px-4 py-3">Czas</th>
+            <th className="px-4 py-3">Akcja</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-100">
-          {items.map((item) => (
-            <tr key={item.attemptId} className="bg-white hover:bg-gray-50">
-              <td className="px-4 py-3 font-mono text-xs">
-                <Link
-                  to={buildPath(ROUTES.REQUEST_DETAIL, item.requestId)}
-                  className="text-blue-600 hover:underline"
-                >
-                  {item.requestId.slice(0, 8)}...
-                </Link>
-              </td>
-              <td className="px-4 py-3 text-gray-900">{item.eventLabel}</td>
-              <td className="px-4 py-3">
-                <span
-                  className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getOutcomeClass(item.outcome)}`}
-                >
-                  {getOutcomeLabel(item.outcome)}
-                </span>
-              </td>
-              <td className="px-4 py-3 text-gray-600">{getFailureKindLabel(item.failureKind)}</td>
-              <td className="px-4 py-3 text-gray-600">{item.retryCount} / 3</td>
-              <td className="px-4 py-3">
-                <span
-                  className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${getRetryStatusClass(item)}`}
-                  title={item.retryBlockedReasonCode ?? undefined}
-                >
-                  {getRetryStatusLabel(item)}
-                </span>
-              </td>
-              <td className="px-4 py-3 text-gray-400">{formatRelativeTime(item.createdAt)}</td>
-            </tr>
-          ))}
+          {items.map((item) => {
+            const isRetrying = retryingAttemptIds.includes(item.attemptId)
+
+            return (
+              <tr key={item.attemptId} className="bg-white hover:bg-gray-50">
+                <td className="px-4 py-3 font-mono text-xs">
+                  <Link
+                    to={buildPath(ROUTES.REQUEST_DETAIL, item.requestId)}
+                    className="text-blue-600 hover:underline"
+                  >
+                    {item.requestId.slice(0, 8)}...
+                  </Link>
+                </td>
+                <td className="px-4 py-3 text-gray-900">{item.eventLabel}</td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getOutcomeClass(item.outcome)}`}
+                  >
+                    {getOutcomeLabel(item.outcome)}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-gray-600">
+                  {getFailureKindLabel(item.failureKind)}
+                </td>
+                <td className="px-4 py-3 text-gray-600">{item.retryCount} / 3</td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${getRetryStatusClass(item)}`}
+                    title={item.retryBlockedReasonCode ?? undefined}
+                  >
+                    {getRetryStatusLabel(item)}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-gray-400">{formatRelativeTime(item.createdAt)}</td>
+                <td className="px-4 py-3">
+                  {item.canRetry && (
+                    <button
+                      type="button"
+                      onClick={() => onRetryAttempt(item)}
+                      disabled={isRetrying}
+                      className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {isRetrying ? 'Ponawiam...' : 'Ponów'}
+                    </button>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.test.tsx
+++ b/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalNotificationFailureQueueItemDto } from '@np-manager/shared'
+import { NotificationFailureQueuePage } from './NotificationFailureQueuePage'
+
+const { getGlobalNotificationFailureQueueMock, retryInternalNotificationAttemptMock } =
+  vi.hoisted(() => ({
+    getGlobalNotificationFailureQueueMock: vi.fn(),
+    retryInternalNotificationAttemptMock: vi.fn(),
+  }))
+
+vi.mock('@/services/portingRequests.api', () => ({
+  getGlobalNotificationFailureQueue: (...args: unknown[]) =>
+    getGlobalNotificationFailureQueueMock(...args),
+  retryInternalNotificationAttempt: (...args: unknown[]) =>
+    retryInternalNotificationAttemptMock(...args),
+}))
+
+function makeItem(
+  overrides: Partial<GlobalNotificationFailureQueueItemDto> = {},
+): GlobalNotificationFailureQueueItemDto {
+  return {
+    attemptId: 'attempt-1',
+    requestId: 'request-1',
+    eventCode: 'STATUS_CHANGED',
+    eventLabel: 'Zmiana statusu sprawy',
+    attemptOrigin: 'PRIMARY',
+    channel: 'EMAIL',
+    recipient: 'bok@test.pl',
+    outcome: 'FAILED',
+    failureKind: 'DELIVERY',
+    retryCount: 0,
+    canRetry: true,
+    retryBlockedReasonCode: null,
+    createdAt: '2026-04-11T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <NotificationFailureQueuePage />
+    </MemoryRouter>,
+  )
+}
+
+describe('NotificationFailureQueuePage', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getGlobalNotificationFailureQueueMock.mockResolvedValue({
+      items: [makeItem()],
+      total: 1,
+    })
+    retryInternalNotificationAttemptMock.mockResolvedValue({})
+  })
+
+  it('calls retry endpoint after clicking retry', async () => {
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponów' }))
+
+    await waitFor(() => {
+      expect(retryInternalNotificationAttemptMock).toHaveBeenCalledWith('request-1', 'attempt-1')
+    })
+  })
+
+  it('shows loading state only for clicked row', async () => {
+    let resolveRetry: () => void = () => {}
+    retryInternalNotificationAttemptMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRetry = () => resolve({})
+      }),
+    )
+    getGlobalNotificationFailureQueueMock.mockResolvedValue({
+      items: [
+        makeItem({ attemptId: 'attempt-1', requestId: 'request-1' }),
+        makeItem({ attemptId: 'attempt-2', requestId: 'request-2' }),
+      ],
+      total: 2,
+    })
+
+    renderPage()
+
+    const buttons = await screen.findAllByRole('button', { name: 'Ponów' })
+    fireEvent.click(buttons[0]!)
+
+    expect(screen.getByRole('button', { name: 'Ponawiam...' }).hasAttribute('disabled')).toBe(true)
+    expect(screen.getByRole('button', { name: 'Ponów' }).hasAttribute('disabled')).toBe(false)
+
+    resolveRetry()
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Ponawiam...' })).toBeNull()
+    })
+  })
+
+  it('refreshes queue and shows success message after successful retry', async () => {
+    getGlobalNotificationFailureQueueMock
+      .mockResolvedValueOnce({ items: [makeItem()], total: 1 })
+      .mockResolvedValueOnce({ items: [], total: 0 })
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponów' }))
+
+    await waitFor(() => {
+      expect(getGlobalNotificationFailureQueueMock).toHaveBeenCalledTimes(2)
+    })
+    expect(screen.getByText('Ponowienie wykonane')).toBeTruthy()
+  })
+
+  it('shows business message for 409 retry blocked response', async () => {
+    retryInternalNotificationAttemptMock.mockRejectedValueOnce({
+      isAxiosError: true,
+      response: {
+        status: 409,
+        data: {
+          error: {
+            retryBlockedReasonCode: 'RETRY_LIMIT_REACHED',
+          },
+        },
+      },
+    })
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponów' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('Limit ponowień osiągnięty')).toBeTruthy()
+    })
+  })
+
+  it('keeps retry availability filter wired to queue refresh', async () => {
+    renderPage()
+
+    await screen.findByRole('button', { name: 'Ponów' })
+    fireEvent.click(screen.getByLabelText('Tylko z dostępnym retry'))
+
+    await waitFor(() => {
+      expect(getGlobalNotificationFailureQueueMock).toHaveBeenCalledWith(
+        expect.objectContaining({ canRetry: true, limit: 50, offset: 0 }),
+      )
+    })
+  })
+
+  it('keeps pagination wired to queue refresh', async () => {
+    getGlobalNotificationFailureQueueMock.mockResolvedValue({
+      items: [makeItem()],
+      total: 120,
+    })
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Następna' }))
+
+    await waitFor(() => {
+      expect(getGlobalNotificationFailureQueueMock).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 50, offset: 50 }),
+      )
+    })
+  })
+})

--- a/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx
+++ b/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx
@@ -1,26 +1,54 @@
-import { useEffect, useState } from 'react'
-import type { GlobalNotificationFailureQueueItemDto } from '@np-manager/shared'
+import { useCallback, useEffect, useState } from 'react'
+import axios from 'axios'
+import type {
+  GlobalNotificationFailureQueueItemDto,
+  InternalNotificationRetryBlockedReasonCodeDto,
+} from '@np-manager/shared'
 import {
   getGlobalNotificationFailureQueue,
+  retryInternalNotificationAttempt,
   type GetGlobalNotificationFailureQueueParams,
 } from '@/services/portingRequests.api'
 import { NotificationFailureQueueTable } from '@/components/NotificationFailureQueueTable/NotificationFailureQueueTable'
 
 const PAGE_SIZE = 50
 
+const RETRY_BLOCKED_MESSAGES: Record<InternalNotificationRetryBlockedReasonCodeDto, string> = {
+  RETRY_LIMIT_REACHED: 'Limit ponowień osiągnięty',
+  NOT_LATEST_IN_CHAIN: 'Dostępna jest już nowsza próba',
+  ORIGIN_NOT_RETRYABLE: 'Tego typu próby nie można ponowić',
+  OUTCOME_NOT_RETRYABLE: 'Ten wynik nie kwalifikuje się do ponowienia',
+}
+
+function getRetryErrorMessage(error: unknown): string {
+  if (!axios.isAxiosError(error)) {
+    return 'Nie udało się ponowić wysyłki'
+  }
+
+  const responseData = error.response?.data as
+    | { error?: { retryBlockedReasonCode?: InternalNotificationRetryBlockedReasonCodeDto } }
+    | undefined
+  const reasonCode = responseData?.error?.retryBlockedReasonCode
+
+  if (error.response?.status === 409 && reasonCode) {
+    return RETRY_BLOCKED_MESSAGES[reasonCode]
+  }
+
+  return 'Nie udało się ponowić wysyłki'
+}
+
 export function NotificationFailureQueuePage() {
   const [items, setItems] = useState<GlobalNotificationFailureQueueItemDto[]>([])
   const [total, setTotal] = useState(0)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [retrySuccessMessage, setRetrySuccessMessage] = useState<string | null>(null)
+  const [retryErrorMessage, setRetryErrorMessage] = useState<string | null>(null)
+  const [retryingAttemptIds, setRetryingAttemptIds] = useState<string[]>([])
   const [onlyRetryAvailable, setOnlyRetryAvailable] = useState(false)
   const [offset, setOffset] = useState(0)
 
-  useEffect(() => {
-    setOffset(0)
-  }, [onlyRetryAvailable])
-
-  useEffect(() => {
+  const loadQueue = useCallback(async () => {
     setIsLoading(true)
     setError(null)
 
@@ -32,18 +60,44 @@ export function NotificationFailureQueuePage() {
       params.canRetry = true
     }
 
-    getGlobalNotificationFailureQueue(params)
-      .then((result) => {
-        setItems(result.items)
-        setTotal(result.total)
-      })
-      .catch(() => {
-        setError('Nie udało się pobrać listy problematycznych notyfikacji.')
-      })
-      .finally(() => {
-        setIsLoading(false)
-      })
-  }, [onlyRetryAvailable, offset])
+    try {
+      const result = await getGlobalNotificationFailureQueue(params)
+      setItems(result.items)
+      setTotal(result.total)
+    } catch {
+      setError('Nie udało się pobrać listy problematycznych notyfikacji.')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [offset, onlyRetryAvailable])
+
+  useEffect(() => {
+    setOffset(0)
+  }, [onlyRetryAvailable])
+
+  useEffect(() => {
+    void loadQueue()
+  }, [loadQueue])
+
+  async function handleRetryAttempt(item: GlobalNotificationFailureQueueItemDto) {
+    if (retryingAttemptIds.includes(item.attemptId)) {
+      return
+    }
+
+    setRetryingAttemptIds((current) => [...current, item.attemptId])
+    setRetrySuccessMessage(null)
+    setRetryErrorMessage(null)
+
+    try {
+      await retryInternalNotificationAttempt(item.requestId, item.attemptId)
+      setRetrySuccessMessage('Ponowienie wykonane')
+      await loadQueue()
+    } catch (retryError) {
+      setRetryErrorMessage(getRetryErrorMessage(retryError))
+    } finally {
+      setRetryingAttemptIds((current) => current.filter((id) => id !== item.attemptId))
+    }
+  }
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
   const currentPage = Math.floor(offset / PAGE_SIZE) + 1
@@ -77,8 +131,26 @@ export function NotificationFailureQueuePage() {
         )}
       </div>
 
+      {retrySuccessMessage && (
+        <div className="mb-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+          {retrySuccessMessage}
+        </div>
+      )}
+
+      {retryErrorMessage && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {retryErrorMessage}
+        </div>
+      )}
+
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-        <NotificationFailureQueueTable items={items} isLoading={isLoading} error={error} />
+        <NotificationFailureQueueTable
+          items={items}
+          isLoading={isLoading}
+          error={error}
+          retryingAttemptIds={retryingAttemptIds}
+          onRetryAttempt={(item) => void handleRetryAttempt(item)}
+        />
       </div>
 
       {!isLoading && !error && total > PAGE_SIZE && (
@@ -98,7 +170,7 @@ export function NotificationFailureQueuePage() {
             disabled={!hasNext}
             className="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 hover:bg-gray-100 disabled:cursor-not-allowed"
           >
-            Nastepna
+            Następna
           </button>
         </div>
       )}

--- a/apps/frontend/src/services/portingRequests.api.test.ts
+++ b/apps/frontend/src/services/portingRequests.api.test.ts
@@ -23,6 +23,7 @@ import {
   getPortingRequestInternalNotifications,
   getPortingRequests,
   getPortingRequestsSummary,
+  retryInternalNotificationAttempt,
   updatePortingRequestAssignment,
 } from './portingRequests.api'
 
@@ -158,6 +159,17 @@ describe('portingRequests.api assignment flow', () => {
 
     expect(getMock).toHaveBeenCalledWith(
       '/porting-requests/request-1/internal-notification-attempts?limit=10',
+    )
+  })
+
+  it('calls internal notification attempt retry endpoint', async () => {
+    postMock.mockResolvedValueOnce({ data: { data: { retryAttempt: { id: 'attempt-retry-1' } } } })
+
+    await retryInternalNotificationAttempt('request-1', 'attempt-1')
+
+    expect(postMock).toHaveBeenCalledWith(
+      '/porting-requests/request-1/internal-notification-attempts/attempt-1/retry',
+      {},
     )
   })
 

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -31,6 +31,7 @@ import type {
   PortingRequestOperationalSummaryDto,
   PortingRequestSummaryQueryDto,
   PreparePortingCommunicationDraftDto,
+  RetryInternalNotificationAttemptResultDto,
   PortingTimelineResultDto,
   SendPortingCommunicationResultDto,
   UpdatePortingRequestStatusDto,
@@ -272,6 +273,18 @@ export async function getGlobalNotificationFailureQueue(
     success: true
     data: GlobalNotificationFailureQueueResultDto
   }>(suffix ? `/internal-notification-failures?${suffix}` : '/internal-notification-failures')
+
+  return response.data.data
+}
+
+export async function retryInternalNotificationAttempt(
+  id: string,
+  attemptId: string,
+): Promise<RetryInternalNotificationAttemptResultDto> {
+  const response = await apiClient.post<{
+    success: true
+    data: RetryInternalNotificationAttemptResultDto
+  }>(`/porting-requests/${id}/internal-notification-attempts/${attemptId}/retry`, {})
 
   return response.data.data
 }


### PR DESCRIPTION
## Problem

PR20A dodał globalną kolejkę błędów notyfikacji v1 jako widok read-only, ale operator nadal musiał przechodzić do `RequestDetailPage`, żeby ponowić próbę dla rekordu z `canRetry=true`.

## Zakres zmian

### Frontend
- dodano retry action bezpośrednio w global queue `/notifications/failures`
- rekordy z `canRetry=true` pokazują przycisk `Ponów`
- kliknięcie używa istniejącego endpointu:
  - `POST /api/porting-requests/:id/internal-notification-attempts/:attemptId/retry`
- loading jest lokalny dla klikniętego wiersza:
  - `Ponawiam...`
- po sukcesie wyświetlany jest komunikat:
  - `Ponowienie wykonane`
- po sukcesie odświeżana jest wyłącznie global queue
- dla `409` z `retryBlockedReasonCode` UI pokazuje komunikat biznesowy
- dla pozostałych błędów UI pokazuje:
  - `Nie udało się ponowić wysyłki`

## Zmienione pliki
- `apps/frontend/src/services/portingRequests.api.ts`
- `apps/frontend/src/services/portingRequests.api.test.ts`
- `apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx`
- `apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.test.tsx`
- `apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx`
- `apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.test.tsx`

## Ważne decyzje
- brak nowych endpointów
- brak zmian backendu
- brak bulk retry
- brak modala
- brak pola reason w UI
- brak zmian w `RequestDetailPage`
- retry pozostaje zgodne z semantyką z PR19B-1

## Walidacja
- frontend `npx tsc --noEmit` ✅
- frontend `npm run test` ✅
- frontend `npm run build` ✅

Backend i shared nie zostały zmienione.