### PR TITLE
feat(PR20C): add operational status layer to global notification failure queue

### DIFF
--- a/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.test.tsx
+++ b/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.test.tsx
@@ -72,9 +72,9 @@ describe('NotificationFailureQueueTable', () => {
     expect(html).toContain('Konfiguracja')
   })
 
-  it('renders canRetry=true as Dostepny', () => {
+  it('renders canRetry=true as Gotowy do ponowienia', () => {
     const html = renderTable({ items: [makeItem({ canRetry: true, retryBlockedReasonCode: null })] })
-    expect(html).toContain('Dostępny')
+    expect(html).toContain('Gotowy do ponowienia')
   })
 
   it('renders retry button for canRetry=true', () => {
@@ -91,14 +91,41 @@ describe('NotificationFailureQueueTable', () => {
     expect(html).not.toContain('Ponów')
   })
 
-  it('renders RETRY_LIMIT_REACHED as Wyczerpany', () => {
+  it('renders RETRY_LIMIT_REACHED as Limit wyczerpany', () => {
     const html = renderTable({
       items: [
         makeItem({ canRetry: false, retryBlockedReasonCode: 'RETRY_LIMIT_REACHED', retryCount: 3 }),
       ],
     })
-    expect(html).toContain('Wyczerpany')
+    expect(html).toContain('Limit wyczerpany')
     expect(html).toContain('3 / 3')
+  })
+
+  it('renders MISCONFIGURED as Wymaga interwencji', () => {
+    const html = renderTable({
+      items: [makeItem({ outcome: 'MISCONFIGURED', failureKind: 'CONFIGURATION', canRetry: false })],
+    })
+    expect(html).toContain('Wymaga interwencji')
+  })
+
+  it('renders RETRY_BLOCKED_OTHER (NOT_LATEST_IN_CHAIN) as Zablokowany', () => {
+    const html = renderTable({
+      items: [
+        makeItem({
+          canRetry: false,
+          retryBlockedReasonCode: 'NOT_LATEST_IN_CHAIN',
+          failureKind: 'DELIVERY',
+        }),
+      ],
+    })
+    expect(html).toContain('Zablokowany')
+  })
+
+  it('MANUAL_INTERVENTION_REQUIRED row has orange accent class', () => {
+    const html = renderTable({
+      items: [makeItem({ outcome: 'MISCONFIGURED', failureKind: 'CONFIGURATION', canRetry: false })],
+    })
+    expect(html).toContain('border-l-orange-400')
   })
 
   it('renders link to RequestDetailPage', () => {

--- a/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx
+++ b/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx
@@ -1,6 +1,10 @@
 import { Link } from 'react-router-dom'
 import type { GlobalNotificationFailureQueueItemDto } from '@np-manager/shared'
 import { buildPath, ROUTES } from '@/constants/routes'
+import {
+  deriveOperationalStatus,
+  OPERATIONAL_STATUS_CONFIG,
+} from '@/lib/notificationFailureQueueOperationalStatus'
 
 interface NotificationFailureQueueTableProps {
   items: GlobalNotificationFailureQueueItemDto[]
@@ -31,18 +35,6 @@ function getFailureKindLabel(
   return '—'
 }
 
-function getRetryStatusLabel(item: GlobalNotificationFailureQueueItemDto): string {
-  if (item.canRetry) return 'Dostępny'
-  if (item.retryBlockedReasonCode === 'RETRY_LIMIT_REACHED') return 'Wyczerpany'
-  if (item.retryBlockedReasonCode === 'ORIGIN_NOT_RETRYABLE') return 'Niedostępny (fallback)'
-  return 'Niedostępny'
-}
-
-function getRetryStatusClass(item: GlobalNotificationFailureQueueItemDto): string {
-  if (item.canRetry) return 'bg-emerald-100 text-emerald-700'
-  if (item.retryBlockedReasonCode === 'RETRY_LIMIT_REACHED') return 'bg-red-100 text-red-700'
-  return 'bg-gray-100 text-gray-600'
-}
 
 function formatRelativeTime(isoString: string): string {
   const diff = Date.now() - new Date(isoString).getTime()
@@ -96,7 +88,7 @@ export function NotificationFailureQueueTable({
             <th className="px-4 py-3">Wynik</th>
             <th className="px-4 py-3">Rodzaj błędu</th>
             <th className="px-4 py-3">Ponowienia</th>
-            <th className="px-4 py-3">Status retry</th>
+            <th className="px-4 py-3">Status operacyjny</th>
             <th className="px-4 py-3">Czas</th>
             <th className="px-4 py-3">Akcja</th>
           </tr>
@@ -104,9 +96,11 @@ export function NotificationFailureQueueTable({
         <tbody className="divide-y divide-gray-100">
           {items.map((item) => {
             const isRetrying = retryingAttemptIds.includes(item.attemptId)
+            const opStatus = deriveOperationalStatus(item)
+            const opConfig = OPERATIONAL_STATUS_CONFIG[opStatus]
 
             return (
-              <tr key={item.attemptId} className="bg-white hover:bg-gray-50">
+              <tr key={item.attemptId} className={`bg-white hover:bg-gray-50 ${opConfig.rowAccentClass}`}>
                 <td className="px-4 py-3 font-mono text-xs">
                   <Link
                     to={buildPath(ROUTES.REQUEST_DETAIL, item.requestId)}
@@ -129,10 +123,9 @@ export function NotificationFailureQueueTable({
                 <td className="px-4 py-3 text-gray-600">{item.retryCount} / 3</td>
                 <td className="px-4 py-3">
                   <span
-                    className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${getRetryStatusClass(item)}`}
-                    title={item.retryBlockedReasonCode ?? undefined}
+                    className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${opConfig.badgeClass}`}
                   >
-                    {getRetryStatusLabel(item)}
+                    {opConfig.label}
                   </span>
                 </td>
                 <td className="px-4 py-3 text-gray-400">{formatRelativeTime(item.createdAt)}</td>

--- a/apps/frontend/src/lib/notificationFailureQueueOperationalStatus.test.ts
+++ b/apps/frontend/src/lib/notificationFailureQueueOperationalStatus.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import { deriveOperationalStatus } from './notificationFailureQueueOperationalStatus'
+
+function makeInput(
+  overrides: Partial<Parameters<typeof deriveOperationalStatus>[0]> = {},
+): Parameters<typeof deriveOperationalStatus>[0] {
+  return {
+    outcome: 'FAILED',
+    failureKind: 'DELIVERY',
+    canRetry: true,
+    retryBlockedReasonCode: null,
+    ...overrides,
+  }
+}
+
+describe('deriveOperationalStatus', () => {
+  it('MISCONFIGURED outcome → MANUAL_INTERVENTION_REQUIRED', () => {
+    expect(deriveOperationalStatus(makeInput({ outcome: 'MISCONFIGURED', failureKind: null }))).toBe(
+      'MANUAL_INTERVENTION_REQUIRED',
+    )
+  })
+
+  it('FAILED + CONFIGURATION failureKind → MANUAL_INTERVENTION_REQUIRED', () => {
+    expect(
+      deriveOperationalStatus(makeInput({ outcome: 'FAILED', failureKind: 'CONFIGURATION' })),
+    ).toBe('MANUAL_INTERVENTION_REQUIRED')
+  })
+
+  it('FAILED + POLICY failureKind → MANUAL_INTERVENTION_REQUIRED', () => {
+    expect(
+      deriveOperationalStatus(makeInput({ outcome: 'FAILED', failureKind: 'POLICY' })),
+    ).toBe('MANUAL_INTERVENTION_REQUIRED')
+  })
+
+  it('FAILED + DELIVERY + canRetry=true → RETRY_AVAILABLE', () => {
+    expect(
+      deriveOperationalStatus(
+        makeInput({ outcome: 'FAILED', failureKind: 'DELIVERY', canRetry: true }),
+      ),
+    ).toBe('RETRY_AVAILABLE')
+  })
+
+  it('FAILED + DELIVERY + RETRY_LIMIT_REACHED → RETRY_BLOCKED_EXHAUSTED', () => {
+    expect(
+      deriveOperationalStatus(
+        makeInput({
+          outcome: 'FAILED',
+          failureKind: 'DELIVERY',
+          canRetry: false,
+          retryBlockedReasonCode: 'RETRY_LIMIT_REACHED',
+        }),
+      ),
+    ).toBe('RETRY_BLOCKED_EXHAUSTED')
+  })
+
+  it('FAILED + DELIVERY + NOT_LATEST_IN_CHAIN → RETRY_BLOCKED_OTHER', () => {
+    expect(
+      deriveOperationalStatus(
+        makeInput({
+          outcome: 'FAILED',
+          failureKind: 'DELIVERY',
+          canRetry: false,
+          retryBlockedReasonCode: 'NOT_LATEST_IN_CHAIN',
+        }),
+      ),
+    ).toBe('RETRY_BLOCKED_OTHER')
+  })
+
+  it('FAILED + DELIVERY + ORIGIN_NOT_RETRYABLE → RETRY_BLOCKED_OTHER', () => {
+    expect(
+      deriveOperationalStatus(
+        makeInput({
+          outcome: 'FAILED',
+          failureKind: 'DELIVERY',
+          canRetry: false,
+          retryBlockedReasonCode: 'ORIGIN_NOT_RETRYABLE',
+        }),
+      ),
+    ).toBe('RETRY_BLOCKED_OTHER')
+  })
+
+  it('FAILED + null failureKind + canRetry=true → RETRY_AVAILABLE', () => {
+    expect(
+      deriveOperationalStatus(
+        makeInput({ outcome: 'FAILED', failureKind: null, canRetry: true }),
+      ),
+    ).toBe('RETRY_AVAILABLE')
+  })
+
+  it('edge case: MISCONFIGURED + canRetry=true → still MANUAL_INTERVENTION_REQUIRED', () => {
+    expect(
+      deriveOperationalStatus(
+        makeInput({ outcome: 'MISCONFIGURED', canRetry: true, retryBlockedReasonCode: null }),
+      ),
+    ).toBe('MANUAL_INTERVENTION_REQUIRED')
+  })
+
+  it('FAILED + null failureKind + RETRY_LIMIT_REACHED → RETRY_BLOCKED_EXHAUSTED', () => {
+    expect(
+      deriveOperationalStatus(
+        makeInput({
+          outcome: 'FAILED',
+          failureKind: null,
+          canRetry: false,
+          retryBlockedReasonCode: 'RETRY_LIMIT_REACHED',
+        }),
+      ),
+    ).toBe('RETRY_BLOCKED_EXHAUSTED')
+  })
+
+  it('FAILED + CONFIGURATION + canRetry=true → MANUAL_INTERVENTION_REQUIRED (config takes priority)', () => {
+    expect(
+      deriveOperationalStatus(
+        makeInput({ outcome: 'FAILED', failureKind: 'CONFIGURATION', canRetry: true }),
+      ),
+    ).toBe('MANUAL_INTERVENTION_REQUIRED')
+  })
+})

--- a/apps/frontend/src/lib/notificationFailureQueueOperationalStatus.ts
+++ b/apps/frontend/src/lib/notificationFailureQueueOperationalStatus.ts
@@ -1,0 +1,56 @@
+import type { GlobalNotificationFailureQueueItemDto } from '@np-manager/shared'
+
+export type OperationalStatus =
+  | 'RETRY_AVAILABLE'
+  | 'RETRY_BLOCKED_EXHAUSTED'
+  | 'RETRY_BLOCKED_OTHER'
+  | 'MANUAL_INTERVENTION_REQUIRED'
+
+type StatusInput = Pick<
+  GlobalNotificationFailureQueueItemDto,
+  'outcome' | 'failureKind' | 'canRetry' | 'retryBlockedReasonCode'
+>
+
+export function deriveOperationalStatus(item: StatusInput): OperationalStatus {
+  // MISCONFIGURED outcome or configuration/policy failure kind signals that retrying
+  // alone won't help — the operator needs to fix a config or policy first.
+  // Note: failureKind=POLICY is an operational heuristic for v1. Policy failures
+  // often require human decisions (e.g. operator rule changes), not just a retry.
+  if (
+    item.outcome === 'MISCONFIGURED' ||
+    item.failureKind === 'CONFIGURATION' ||
+    item.failureKind === 'POLICY'
+  ) {
+    return 'MANUAL_INTERVENTION_REQUIRED'
+  }
+
+  if (item.canRetry) return 'RETRY_AVAILABLE'
+  if (item.retryBlockedReasonCode === 'RETRY_LIMIT_REACHED') return 'RETRY_BLOCKED_EXHAUSTED'
+  return 'RETRY_BLOCKED_OTHER'
+}
+
+export const OPERATIONAL_STATUS_CONFIG: Record<
+  OperationalStatus,
+  { label: string; badgeClass: string; rowAccentClass: string }
+> = {
+  RETRY_AVAILABLE: {
+    label: 'Gotowy do ponowienia',
+    badgeClass: 'bg-emerald-100 text-emerald-700',
+    rowAccentClass: 'border-l-4 border-l-emerald-400',
+  },
+  RETRY_BLOCKED_EXHAUSTED: {
+    label: 'Limit wyczerpany',
+    badgeClass: 'bg-red-100 text-red-700',
+    rowAccentClass: 'border-l-4 border-l-red-400',
+  },
+  RETRY_BLOCKED_OTHER: {
+    label: 'Zablokowany',
+    badgeClass: 'bg-gray-100 text-gray-600',
+    rowAccentClass: '',
+  },
+  MANUAL_INTERVENTION_REQUIRED: {
+    label: 'Wymaga interwencji',
+    badgeClass: 'bg-orange-100 text-orange-700',
+    rowAccentClass: 'border-l-4 border-l-orange-400',
+  },
+}

--- a/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.test.tsx
+++ b/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.test.tsx
@@ -137,6 +137,36 @@ describe('NotificationFailureQueuePage', () => {
     })
   })
 
+  it('manual intervention filter shows only MANUAL_INTERVENTION_REQUIRED items', async () => {
+    getGlobalNotificationFailureQueueMock.mockResolvedValue({
+      items: [
+        makeItem({
+          attemptId: 'attempt-delivery',
+          outcome: 'FAILED',
+          failureKind: 'DELIVERY',
+          canRetry: true,
+        }),
+        makeItem({
+          attemptId: 'attempt-manual',
+          eventLabel: 'Zdarzenie wymagające interwencji',
+          outcome: 'MISCONFIGURED',
+          failureKind: 'CONFIGURATION',
+          canRetry: false,
+        }),
+      ],
+      total: 2,
+    })
+
+    renderPage()
+
+    await screen.findByText('Zdarzenie wymagające interwencji')
+    fireEvent.click(screen.getByLabelText('Tylko wymagające interwencji'))
+
+    expect(screen.queryByText('Zmiana statusu sprawy')).toBeNull()
+    expect(screen.getByText('Zdarzenie wymagające interwencji')).toBeTruthy()
+    expect(screen.getByText('Wyniki przefiltrowane na bieżącej stronie')).toBeTruthy()
+  })
+
   it('keeps retry availability filter wired to queue refresh', async () => {
     renderPage()
 

--- a/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx
+++ b/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx
@@ -10,6 +10,7 @@ import {
   type GetGlobalNotificationFailureQueueParams,
 } from '@/services/portingRequests.api'
 import { NotificationFailureQueueTable } from '@/components/NotificationFailureQueueTable/NotificationFailureQueueTable'
+import { deriveOperationalStatus } from '@/lib/notificationFailureQueueOperationalStatus'
 
 const PAGE_SIZE = 50
 
@@ -46,6 +47,7 @@ export function NotificationFailureQueuePage() {
   const [retryErrorMessage, setRetryErrorMessage] = useState<string | null>(null)
   const [retryingAttemptIds, setRetryingAttemptIds] = useState<string[]>([])
   const [onlyRetryAvailable, setOnlyRetryAvailable] = useState(false)
+  const [onlyManualIntervention, setOnlyManualIntervention] = useState(false)
   const [offset, setOffset] = useState(0)
 
   const loadQueue = useCallback(async () => {
@@ -99,6 +101,10 @@ export function NotificationFailureQueuePage() {
     }
   }
 
+  const displayedItems = onlyManualIntervention
+    ? items.filter((item) => deriveOperationalStatus(item) === 'MANUAL_INTERVENTION_REQUIRED')
+    : items
+
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
   const currentPage = Math.floor(offset / PAGE_SIZE) + 1
   const hasPrev = offset > 0
@@ -114,15 +120,26 @@ export function NotificationFailureQueuePage() {
       </div>
 
       <div className="mb-4 flex items-center justify-between">
-        <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
-          <input
-            type="checkbox"
-            checked={onlyRetryAvailable}
-            onChange={(e) => setOnlyRetryAvailable(e.target.checked)}
-            className="h-4 w-4 rounded border-gray-300 text-blue-600"
-          />
-          Tylko z dostępnym retry
-        </label>
+        <div className="flex items-center gap-4">
+          <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={onlyRetryAvailable}
+              onChange={(e) => setOnlyRetryAvailable(e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-blue-600"
+            />
+            Tylko z dostępnym retry
+          </label>
+          <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-700">
+            <input
+              type="checkbox"
+              checked={onlyManualIntervention}
+              onChange={(e) => setOnlyManualIntervention(e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300 text-orange-600"
+            />
+            Tylko wymagające interwencji
+          </label>
+        </div>
 
         {!isLoading && !error && (
           <span className="text-xs text-gray-400">
@@ -144,8 +161,13 @@ export function NotificationFailureQueuePage() {
       )}
 
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        {onlyManualIntervention && !isLoading && !error && (
+          <p className="px-4 pt-3 text-xs text-gray-400">
+            Wyniki przefiltrowane na bieżącej stronie
+          </p>
+        )}
         <NotificationFailureQueueTable
-          items={items}
+          items={displayedItems}
           isLoading={isLoading}
           error={error}
           retryingAttemptIds={retryingAttemptIds}


### PR DESCRIPTION
## Kontekst

PR20C to lekka warstwa operacyjnej czytelności w global notification failure queue — kolejny krok po PR20A (read-only queue) i PR20B (retry action w queue).

Problem przed tym PR: operator musiał samodzielnie łączyć `outcome` + `failureKind` + `canRetry` + `retryBlockedReasonCode`, żeby ocenić co wymaga uwagi.

## Zmiany

**Nowe pliki:**
- `apps/frontend/src/lib/notificationFailureQueueOperationalStatus.ts` — helper `deriveOperationalStatus()` + `OPERATIONAL_STATUS_CONFIG`
- `apps/frontend/src/lib/notificationFailureQueueOperationalStatus.test.ts` — 10 unit testów helpera

**Zmodyfikowane:**
- `NotificationFailureQueueTable.tsx` — kolumna „Status retry" zastąpiona kolumną „Status operacyjny" z 4 badge'ami + kolorowy pasek boczny na wierszu
- `NotificationFailureQueueTable.test.tsx` — zaktualizowane testy kolumny statusu
- `NotificationFailureQueuePage.tsx` — dodany checkbox „Tylko wymagające interwencji" (filtr client-side)
- `NotificationFailureQueuePage.test.tsx` — nowy test filtru

## Logika `deriveOperationalStatus`

| outcome | failureKind | canRetry | retryBlockedReasonCode | → status |
|---|---|---|---|---|
| MISCONFIGURED | any | any | any | `MANUAL_INTERVENTION_REQUIRED` |
| FAILED | CONFIGURATION | any | any | `MANUAL_INTERVENTION_REQUIRED` |
| FAILED | POLICY | any | any | `MANUAL_INTERVENTION_REQUIRED` |
| FAILED | any | true | null | `RETRY_AVAILABLE` |
| FAILED | any | false | RETRY_LIMIT_REACHED | `RETRY_BLOCKED_EXHAUSTED` |
| FAILED | any | false | inne | `RETRY_BLOCKED_OTHER` |

## Badge'e UI

- `Gotowy do ponowienia` — zielony
- `Limit wyczerpany` — czerwony
- `Zablokowany` — szary
- `Wymaga interwencji` — pomarańczowy

## Zakres

- Frontend-only — zero zmian w backendzie i shared DTO
- Brak nowych endpointów
- Retry button zachowany bez zmian

## Testy

149/149 passed, tsc clean, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)