### PR TITLE
feat(PR20D): add server-side manual intervention filter to global notification failure queue

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/global-notification-failure-queue.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/global-notification-failure-queue.service.test.ts
@@ -196,6 +196,92 @@ describe('getGlobalNotificationFailureQueue', () => {
     expect(callArg.skip).toBe(20)
   })
 
+  describe('operationalStatus=MANUAL_INTERVENTION_REQUIRED', () => {
+    it('returns only MISCONFIGURED outcome items', async () => {
+      mockAttemptFindMany.mockResolvedValue([])
+      mockAttemptCount.mockResolvedValue(0)
+
+      await getGlobalNotificationFailureQueue({ operationalStatus: 'MANUAL_INTERVENTION_REQUIRED' })
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const whereArg = mockAttemptFindMany.mock.calls[0]![0].where
+      expect(whereArg.OR).toContainEqual({ outcome: 'MISCONFIGURED' })
+    })
+
+    it('returns items with failureKind CONFIGURATION via OR clause', async () => {
+      mockAttemptFindMany.mockResolvedValue([])
+      mockAttemptCount.mockResolvedValue(0)
+
+      await getGlobalNotificationFailureQueue({ operationalStatus: 'MANUAL_INTERVENTION_REQUIRED' })
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const whereArg = mockAttemptFindMany.mock.calls[0]![0].where
+      expect(whereArg.OR).toContainEqual({ failureKind: { in: ['CONFIGURATION', 'POLICY'] } })
+    })
+
+    it('keeps isLatestForChain=true constraint', async () => {
+      mockAttemptFindMany.mockResolvedValue([])
+      mockAttemptCount.mockResolvedValue(0)
+
+      await getGlobalNotificationFailureQueue({ operationalStatus: 'MANUAL_INTERVENTION_REQUIRED' })
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const whereArg = mockAttemptFindMany.mock.calls[0]![0].where
+      expect(whereArg.isLatestForChain).toBe(true)
+    })
+
+    it('does not apply outcome IN filter when operationalStatus is set', async () => {
+      mockAttemptFindMany.mockResolvedValue([])
+      mockAttemptCount.mockResolvedValue(0)
+
+      await getGlobalNotificationFailureQueue({ operationalStatus: 'MANUAL_INTERVENTION_REQUIRED' })
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const whereArg = mockAttemptFindMany.mock.calls[0]![0].where
+      // outcome should not be a simple { in: [...] } filter — the OR clause handles it
+      expect(whereArg.outcome).toBeUndefined()
+    })
+
+    it('returns MISCONFIGURED items in the result', async () => {
+      const misconfiguredAttempt = buildAttempt({ outcome: 'MISCONFIGURED', failureKind: null })
+      mockAttemptFindMany.mockResolvedValue([misconfiguredAttempt])
+      mockAttemptCount.mockResolvedValue(1)
+
+      const result = await getGlobalNotificationFailureQueue({
+        operationalStatus: 'MANUAL_INTERVENTION_REQUIRED',
+      })
+
+      expect(result.total).toBe(1)
+      expect(result.items[0]?.outcome).toBe('MISCONFIGURED')
+    })
+
+    it('returns FAILED+CONFIGURATION items in the result', async () => {
+      const configAttempt = buildAttempt({ outcome: 'FAILED', failureKind: 'CONFIGURATION' })
+      mockAttemptFindMany.mockResolvedValue([configAttempt])
+      mockAttemptCount.mockResolvedValue(1)
+
+      const result = await getGlobalNotificationFailureQueue({
+        operationalStatus: 'MANUAL_INTERVENTION_REQUIRED',
+      })
+
+      expect(result.total).toBe(1)
+      expect(result.items[0]?.failureKind).toBe('CONFIGURATION')
+    })
+
+    it('returns FAILED+POLICY items in the result', async () => {
+      const policyAttempt = buildAttempt({ outcome: 'FAILED', failureKind: 'POLICY' })
+      mockAttemptFindMany.mockResolvedValue([policyAttempt])
+      mockAttemptCount.mockResolvedValue(1)
+
+      const result = await getGlobalNotificationFailureQueue({
+        operationalStatus: 'MANUAL_INTERVENTION_REQUIRED',
+      })
+
+      expect(result.total).toBe(1)
+      expect(result.items[0]?.failureKind).toBe('POLICY')
+    })
+  })
+
   it('caps limit at 100', async () => {
     mockAttemptFindMany.mockResolvedValue([])
     mockAttemptCount.mockResolvedValue(0)

--- a/apps/backend/src/modules/porting-requests/global-notification-failure-queue.service.ts
+++ b/apps/backend/src/modules/porting-requests/global-notification-failure-queue.service.ts
@@ -7,10 +7,12 @@ const MAX_LIMIT = 100
 
 export type GlobalFailureQueueOutcomeFilter = 'FAILED' | 'MISCONFIGURED'
 export type GlobalFailureQueueSort = 'newest' | 'retryAvailable'
+export type GlobalFailureQueueOperationalStatusFilter = 'MANUAL_INTERVENTION_REQUIRED'
 
 export interface GlobalNotificationFailureQueueParams {
   outcomes?: GlobalFailureQueueOutcomeFilter[]
   canRetry?: boolean
+  operationalStatus?: GlobalFailureQueueOperationalStatusFilter
   sort?: GlobalFailureQueueSort
   limit?: number
   offset?: number
@@ -39,7 +41,7 @@ export async function getGlobalNotificationFailureQueue(
   const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT)
   const offset = params.offset ?? 0
 
-  const baseWhere = buildWhereClause(outcomes, params.canRetry)
+  const baseWhere = buildWhereClause(outcomes, params.canRetry, params.operationalStatus)
   const dbSelect = {
     id: true,
     requestId: true,
@@ -97,7 +99,21 @@ export async function getGlobalNotificationFailureQueue(
 function buildWhereClause(
   outcomes: GlobalFailureQueueOutcomeFilter[],
   canRetry?: boolean,
+  operationalStatus?: GlobalFailureQueueOperationalStatusFilter,
 ) {
+  if (operationalStatus === 'MANUAL_INTERVENTION_REQUIRED') {
+    // Returns records matching the v1 operational heuristic for manual intervention:
+    // MISCONFIGURED outcome, or CONFIGURATION/POLICY failureKind.
+    // Combination with canRetry not supported in v1 (these items are non-retryable by definition).
+    return {
+      isLatestForChain: true,
+      OR: [
+        { outcome: 'MISCONFIGURED' as const },
+        { failureKind: { in: ['CONFIGURATION', 'POLICY'] as ('CONFIGURATION' | 'POLICY')[] } },
+      ],
+    }
+  }
+
   const base = {
     isLatestForChain: true,
     outcome: { in: outcomes as ('FAILED' | 'MISCONFIGURED')[] },

--- a/apps/backend/src/modules/porting-requests/internal-notification-failures.router.ts
+++ b/apps/backend/src/modules/porting-requests/internal-notification-failures.router.ts
@@ -5,6 +5,7 @@ import { authorize } from '../../shared/middleware/authorize'
 import type { UserRole } from '@np-manager/shared'
 import {
   getGlobalNotificationFailureQueue,
+  type GlobalFailureQueueOperationalStatusFilter,
   type GlobalFailureQueueOutcomeFilter,
   type GlobalFailureQueueSort,
 } from './global-notification-failure-queue.service'
@@ -29,6 +30,9 @@ const globalFailureQueueQuerySchema = z.object({
       if (val === 'false') return false
       return undefined
     }),
+  operationalStatus: z
+    .enum(['MANUAL_INTERVENTION_REQUIRED'])
+    .optional() as z.ZodType<GlobalFailureQueueOperationalStatusFilter | undefined>,
   sort: z.enum(['newest', 'retryAvailable']).default('newest') as z.ZodType<GlobalFailureQueueSort>,
   limit: z.coerce.number().int().min(1).max(100).default(50),
   offset: z.coerce.number().int().min(0).default(0),
@@ -43,6 +47,7 @@ export async function internalNotificationFailuresRouter(app: FastifyInstance) {
       const result = await getGlobalNotificationFailureQueue({
         outcomes: query.outcome,
         canRetry: query.canRetry,
+        operationalStatus: query.operationalStatus,
         sort: query.sort,
         limit: query.limit,
         offset: query.offset,

--- a/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.test.tsx
+++ b/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.test.tsx
@@ -137,34 +137,75 @@ describe('NotificationFailureQueuePage', () => {
     })
   })
 
-  it('manual intervention filter shows only MANUAL_INTERVENTION_REQUIRED items', async () => {
-    getGlobalNotificationFailureQueueMock.mockResolvedValue({
-      items: [
-        makeItem({
-          attemptId: 'attempt-delivery',
-          outcome: 'FAILED',
-          failureKind: 'DELIVERY',
-          canRetry: true,
-        }),
-        makeItem({
-          attemptId: 'attempt-manual',
-          eventLabel: 'Zdarzenie wymagające interwencji',
-          outcome: 'MISCONFIGURED',
-          failureKind: 'CONFIGURATION',
-          canRetry: false,
-        }),
-      ],
-      total: 2,
-    })
+  it('manual intervention filter sends operationalStatus param to backend', async () => {
+    getGlobalNotificationFailureQueueMock
+      .mockResolvedValueOnce({ items: [makeItem()], total: 1 })
+      .mockResolvedValueOnce({
+        items: [
+          makeItem({
+            attemptId: 'attempt-manual',
+            eventLabel: 'Zdarzenie wymagające interwencji',
+            outcome: 'MISCONFIGURED',
+            failureKind: 'CONFIGURATION',
+            canRetry: false,
+          }),
+        ],
+        total: 1,
+      })
 
     renderPage()
 
-    await screen.findByText('Zdarzenie wymagające interwencji')
+    await screen.findByRole('button', { name: 'Ponów' })
     fireEvent.click(screen.getByLabelText('Tylko wymagające interwencji'))
 
-    expect(screen.queryByText('Zmiana statusu sprawy')).toBeNull()
+    await waitFor(() => {
+      expect(getGlobalNotificationFailureQueueMock).toHaveBeenCalledWith(
+        expect.objectContaining({ operationalStatus: 'MANUAL_INTERVENTION_REQUIRED' }),
+      )
+    })
+  })
+
+  it('manual intervention filter renders items returned by backend', async () => {
+    getGlobalNotificationFailureQueueMock
+      .mockResolvedValueOnce({ items: [makeItem()], total: 1 })
+      .mockResolvedValueOnce({
+        items: [
+          makeItem({
+            attemptId: 'attempt-manual',
+            eventLabel: 'Zdarzenie wymagające interwencji',
+            outcome: 'MISCONFIGURED',
+            failureKind: 'CONFIGURATION',
+            canRetry: false,
+          }),
+        ],
+        total: 1,
+      })
+
+    renderPage()
+
+    await screen.findByText('Zmiana statusu sprawy')
+    fireEvent.click(screen.getByLabelText('Tylko wymagające interwencji'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Zmiana statusu sprawy')).toBeNull()
+    })
     expect(screen.getByText('Zdarzenie wymagające interwencji')).toBeTruthy()
-    expect(screen.getByText('Wyniki przefiltrowane na bieżącej stronie')).toBeTruthy()
+  })
+
+  it('manual intervention filter does not show client-side page note', async () => {
+    getGlobalNotificationFailureQueueMock
+      .mockResolvedValueOnce({ items: [makeItem()], total: 1 })
+      .mockResolvedValueOnce({ items: [], total: 0 })
+
+    renderPage()
+
+    await screen.findByRole('button', { name: 'Ponów' })
+    fireEvent.click(screen.getByLabelText('Tylko wymagające interwencji'))
+
+    await waitFor(() => {
+      expect(getGlobalNotificationFailureQueueMock).toHaveBeenCalledTimes(2)
+    })
+    expect(screen.queryByText('Wyniki przefiltrowane na bieżącej stronie')).toBeNull()
   })
 
   it('keeps retry availability filter wired to queue refresh', async () => {

--- a/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx
+++ b/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx
@@ -10,7 +10,6 @@ import {
   type GetGlobalNotificationFailureQueueParams,
 } from '@/services/portingRequests.api'
 import { NotificationFailureQueueTable } from '@/components/NotificationFailureQueueTable/NotificationFailureQueueTable'
-import { deriveOperationalStatus } from '@/lib/notificationFailureQueueOperationalStatus'
 
 const PAGE_SIZE = 50
 
@@ -61,6 +60,9 @@ export function NotificationFailureQueuePage() {
     if (onlyRetryAvailable) {
       params.canRetry = true
     }
+    if (onlyManualIntervention) {
+      params.operationalStatus = 'MANUAL_INTERVENTION_REQUIRED'
+    }
 
     try {
       const result = await getGlobalNotificationFailureQueue(params)
@@ -71,11 +73,15 @@ export function NotificationFailureQueuePage() {
     } finally {
       setIsLoading(false)
     }
-  }, [offset, onlyRetryAvailable])
+  }, [offset, onlyRetryAvailable, onlyManualIntervention])
 
   useEffect(() => {
     setOffset(0)
   }, [onlyRetryAvailable])
+
+  useEffect(() => {
+    setOffset(0)
+  }, [onlyManualIntervention])
 
   useEffect(() => {
     void loadQueue()
@@ -100,10 +106,6 @@ export function NotificationFailureQueuePage() {
       setRetryingAttemptIds((current) => current.filter((id) => id !== item.attemptId))
     }
   }
-
-  const displayedItems = onlyManualIntervention
-    ? items.filter((item) => deriveOperationalStatus(item) === 'MANUAL_INTERVENTION_REQUIRED')
-    : items
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
   const currentPage = Math.floor(offset / PAGE_SIZE) + 1
@@ -161,13 +163,8 @@ export function NotificationFailureQueuePage() {
       )}
 
       <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
-        {onlyManualIntervention && !isLoading && !error && (
-          <p className="px-4 pt-3 text-xs text-gray-400">
-            Wyniki przefiltrowane na bieżącej stronie
-          </p>
-        )}
         <NotificationFailureQueueTable
-          items={displayedItems}
+          items={items}
           isLoading={isLoading}
           error={error}
           retryingAttemptIds={retryingAttemptIds}

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -249,6 +249,7 @@ export async function getPortingRequestInternalNotificationAttempts(
 export interface GetGlobalNotificationFailureQueueParams {
   outcomes?: ('FAILED' | 'MISCONFIGURED')[]
   canRetry?: boolean
+  operationalStatus?: 'MANUAL_INTERVENTION_REQUIRED'
   sort?: 'newest' | 'retryAvailable'
   limit?: number
   offset?: number
@@ -263,6 +264,9 @@ export async function getGlobalNotificationFailureQueue(
   }
   if (params.canRetry !== undefined) {
     query.set('canRetry', String(params.canRetry))
+  }
+  if (params.operationalStatus) {
+    query.set('operationalStatus', params.operationalStatus)
   }
   if (params.sort) query.set('sort', params.sort)
   if (params.limit) query.set('limit', String(params.limit))


### PR DESCRIPTION
## Summary

Extends the global notification failure queue endpoint with server-side filtering for manual intervention required items. Moves filtering logic from client-side (page-only) to backend, enabling operators to reliably see all items requiring intervention across paginated results.

## Changes

### Backend
- **Service**: Added `operationalStatus?: 'MANUAL_INTERVENTION_REQUIRED'` param to `GlobalNotificationFailureQueueParams`. Extended `buildWhereClause()` to filter by outcome=MISCONFIGURED or failureKind IN (CONFIGURATION, POLICY).
- **Router**: Added `operationalStatus` query param to Zod schema.
- **Tests**: 7 new tests covering MANUAL_INTERVENTION_REQUIRED filtering logic.

### Frontend
- **API**: Added `operationalStatus` param to `GetGlobalNotificationFailureQueueParams` and wire to URLSearchParams.
- **Page**: Removed client-side filter logic. When checkbox active, sends `operationalStatus=MANUAL_INTERVENTION_REQUIRED` to backend. Removed "Wyniki przefiltrowane na bieżącej stronie" note. Added offset reset on filter change.
- **Tests**: 3 new tests verifying server-side behavior (param sent, items rendered, note removed).

## Implementation Notes

- Existing endpoint extended, not replaced.
- Combination of `operationalStatus` with `canRetry` not supported in v1 (these items are non-retryable by definition).
- Backend heuristic: manual intervention required = MISCONFIGURED outcome OR CONFIGURATION/POLICY failureKind.

## Test Results

✓ Backend tsc, 21 tests, build
✓ Frontend tsc, 9 tests, build

## Ready for Review