### PR TITLE
feat(frontend): domknij redesign operacyjny 2A

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@ Przed zmianami przeczytaj:
 2. `CLAUDE.md`
 3. `docs/PROJECT_CONTINUITY.md`
 
+### Role dokumentow
+
+- `AGENTS.md` - stale zasady pracy, walidacji, bezpieczenstwa i konwencji repo.
+- `docs/PROJECT_CONTINUITY.md` - biezaca ciaglosc projektu, aktualny stan i decyzje architektoniczne.
+- `CLAUDE.md` - lekki entrypoint dla Claude Code, bez duplikowania pelnej dokumentacji.
+
 ---
 
 ## Struktura projektu

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Claude Code entrypoint - NP-Manager
+
+Ten plik jest lekkim punktem startowym dla Claude Code.
+
+Przed praca przeczytaj:
+1. `AGENTS.md` - stale zasady pracy, komendy walidacyjne, konwencje repo.
+2. `docs/PROJECT_CONTINUITY.md` - aktualny stan projektu, decyzje i roadmapa.
+
+Zasada nadrzedna: stan repozytorium jest zrodlem prawdy. Nie duplikuj tutaj duzych fragmentow dokumentacji; aktualizuj `AGENTS.md` dla zasad stalych i `docs/PROJECT_CONTINUITY.md` dla biezacego stanu projektu.

--- a/apps/frontend/src/components/PliCbdIntegrationHistory/PliCbdIntegrationHistory.tsx
+++ b/apps/frontend/src/components/PliCbdIntegrationHistory/PliCbdIntegrationHistory.tsx
@@ -36,9 +36,18 @@ function DiagnosticPanel({ label, data }: { label: string; data: unknown }) {
   if (!data) return null
 
   return (
-    <details className="mt-2">
-      <summary className="cursor-pointer text-xs text-gray-500 hover:text-gray-700 select-none">
-        {label}
+    <details className="group mt-2">
+      <summary
+        onClick={(event) => event.currentTarget.focus()}
+        className="flex w-full cursor-pointer list-none items-center gap-2 text-xs text-gray-500 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 [&::-webkit-details-marker]:hidden"
+      >
+        <span
+          aria-hidden="true"
+          className="inline-flex h-5 w-5 items-center justify-center rounded border border-gray-200 bg-white text-[10px] font-semibold transition-transform group-open:rotate-180"
+        >
+          v
+        </span>
+        <span>{label}</span>
       </summary>
       <pre className="mt-1 overflow-x-auto rounded bg-gray-50 border border-gray-200 p-2 text-xs text-gray-700 whitespace-pre-wrap break-all">
         {JSON.stringify(data, null, 2)}
@@ -84,7 +93,7 @@ function IntegrationEventItem({ item }: { item: PliCbdIntegrationEventDto }) {
           <p className="text-sm text-gray-600">
             {item.errorMessage ??
               item.actionName ??
-              'Operacja foundation PLI CBD zostala zapisana.'}
+              'Operacja PLI CBD zostala zapisana.'}
           </p>
 
           {hasTransportMeta && (

--- a/apps/frontend/src/components/PliCbdTechnicalPayloadPreview/PliCbdTechnicalPayloadPreview.tsx
+++ b/apps/frontend/src/components/PliCbdTechnicalPayloadPreview/PliCbdTechnicalPayloadPreview.tsx
@@ -18,7 +18,7 @@ export function PliCbdTechnicalPayloadPreview({
           Payload techniczny {messageType}
         </h2>
         <p className="text-sm text-gray-500">
-          Read-only preview ustandaryzowanego payloadu pod przyszly serializer XML / SOAP.
+          Podglad danych technicznych przygotowanych dla komunikatu {messageType}.
         </p>
       </div>
 

--- a/apps/frontend/src/components/PliCbdXmlPreview/PliCbdXmlPreview.tsx
+++ b/apps/frontend/src/components/PliCbdXmlPreview/PliCbdXmlPreview.tsx
@@ -14,7 +14,7 @@ export function PliCbdXmlPreview({ messageType, result, isLoading }: PliCbdXmlPr
           XML preview {messageType}
         </h2>
         <p className="text-sm text-gray-500">
-          Internal read-only serializer preview nad technical payload, bez SOAP i bez transportu.
+          Podglad XML dla komunikatu {messageType}, tylko do weryfikacji administracyjnej.
         </p>
       </div>
 

--- a/apps/frontend/src/components/PortingCaseHistory/PortingCaseHistory.tsx
+++ b/apps/frontend/src/components/PortingCaseHistory/PortingCaseHistory.tsx
@@ -79,16 +79,25 @@ function HistoryItem({ item }: { item: PortingRequestCaseHistoryItemDto }) {
 interface PortingCaseHistoryProps {
   items: PortingRequestCaseHistoryItemDto[]
   isLoading: boolean
+  showHeader?: boolean
 }
 
-export function PortingCaseHistory({ items, isLoading }: PortingCaseHistoryProps) {
+function HistoryHeader() {
+  return (
+    <>
+      <h2 className="mb-1 text-sm font-semibold uppercase tracking-wide text-gray-700">
+        Historia sprawy
+      </h2>
+      <p className="mb-4 text-sm text-gray-500">Biznesowy audit trail zmian statusu sprawy.</p>
+    </>
+  )
+}
+
+export function PortingCaseHistory({ items, isLoading, showHeader = true }: PortingCaseHistoryProps) {
   if (isLoading) {
     return (
-      <div className="card p-5">
-        <h2 className="mb-1 text-sm font-semibold uppercase tracking-wide text-gray-700">
-          Historia sprawy
-        </h2>
-        <p className="mb-4 text-sm text-gray-500">Biznesowy audit trail zmian statusu sprawy.</p>
+      <div className={showHeader ? 'card p-5' : ''}>
+        {showHeader && <HistoryHeader />}
         <div className="flex items-center justify-center py-8 text-sm text-gray-400">
           Ladowanie historii...
         </div>
@@ -98,24 +107,18 @@ export function PortingCaseHistory({ items, isLoading }: PortingCaseHistoryProps
 
   if (items.length === 0) {
     return (
-      <div className="card p-5">
-        <h2 className="mb-1 text-sm font-semibold uppercase tracking-wide text-gray-700">
-          Historia sprawy
-        </h2>
-        <p className="mb-4 text-sm text-gray-500">Biznesowy audit trail zmian statusu sprawy.</p>
-        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-5 text-center text-sm text-gray-500">
-          Brak wpisow w historii sprawy.
+      <div className={showHeader ? 'card p-5' : ''}>
+        {showHeader && <HistoryHeader />}
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-5 text-center text-sm leading-6 text-gray-600">
+          Brak wpisow w historii statusu tej sprawy. Komunikacja, powiadomienia i operacje PLI CBD sa pokazane w osobnych sekcjach.
         </div>
       </div>
     )
   }
 
   return (
-    <div className="card p-5">
-      <h2 className="mb-1 text-sm font-semibold uppercase tracking-wide text-gray-700">
-        Historia sprawy
-      </h2>
-      <p className="mb-4 text-sm text-gray-500">Biznesowy audit trail zmian statusu sprawy.</p>
+    <div className={showHeader ? 'card p-5' : ''}>
+      {showHeader && <HistoryHeader />}
       <div>
         {items.map((item) => (
           <HistoryItem key={item.id} item={item} />

--- a/apps/frontend/src/components/PortingCommunicationPanel/PortingCommunicationPanel.test.tsx
+++ b/apps/frontend/src/components/PortingCommunicationPanel/PortingCommunicationPanel.test.tsx
@@ -127,6 +127,49 @@ describe('PortingCommunicationPanel', () => {
     expect(html).toContain('Brak komunikacji zapisanych dla tej sprawy.')
   })
 
+  it('renders status-blocked draft action as disabled secondary UI with operational reason', () => {
+    const html = renderToStaticMarkup(
+      <PortingCommunicationPanel
+        actions={[
+          {
+            type: 'COMPLETION_NOTICE',
+            label: 'Informacja o zakonczeniu portowania',
+            description: 'Finalna komunikacja po zakonczeniu przeniesienia numeru.',
+            canPreview: false,
+            canCreateDraft: false,
+            canMarkSent: false,
+            disabled: true,
+            disabledReason:
+              'Akcja jest dostepna dopiero dla spraw w statusie zgodnym z polityka komunikacji.',
+            existingDraftId: null,
+            existingDraftInfo: null,
+            allowsMultipleDrafts: false,
+          },
+        ]}
+        summary={EMPTY_SUMMARY}
+        items={[]}
+        isLoadingHistory={false}
+        preview={null}
+        feedbackError={null}
+        feedbackSuccess={null}
+        previewingActionType={null}
+        creatingDraftActionType={null}
+        markingSentId={null}
+        currentStatus="SUBMITTED"
+        onPreviewDraft={vi.fn()}
+        onCreateDraft={vi.fn()}
+        onMarkAsSent={vi.fn()}
+        {...NEW_DELIVERY_PROPS}
+      />,
+    )
+
+    expect(html).toContain('Niedostepne teraz')
+    expect(html).toContain('Akcja bedzie dostepna dla statusow:')
+    expect(html).toContain('Aktualny status:')
+    expect(html).toContain('bg-ink-50 text-ink-400')
+    expect(html).not.toContain('bg-brand-600')
+  })
+
   it('does not keep a stale success message when the panel is rendered again without feedback', () => {
     const successHtml = renderToStaticMarkup(
       <PortingCommunicationPanel

--- a/apps/frontend/src/components/PortingCommunicationPanel/PortingCommunicationPanel.tsx
+++ b/apps/frontend/src/components/PortingCommunicationPanel/PortingCommunicationPanel.tsx
@@ -1,5 +1,6 @@
 import {
   COMMUNICATION_DELIVERY_OUTCOME_LABELS,
+  PORTING_CASE_STATUS_LABELS,
   PORTING_COMMUNICATION_STATUS_LABELS,
   PORTING_REQUEST_COMMUNICATION_ACTION_TYPE_LABELS,
   type CommunicationDeliveryAttemptDto,
@@ -7,9 +8,11 @@ import {
   type PortingCommunicationDto,
   type PortingCommunicationPreviewDto,
   type PortingCommunicationSummaryDto,
+  type PortingCaseStatus,
   type PortingRequestCommunicationActionDto,
   type PortingRequestCommunicationActionType,
 } from '@np-manager/shared'
+import { Badge, Button, cx } from '@/components/ui'
 
 function formatDateTime(iso: string): string {
   return new Date(iso).toLocaleString('pl-PL', {
@@ -59,6 +62,40 @@ function getActionTypeLabel(type: PortingRequestCommunicationActionType): string
   return PORTING_REQUEST_COMMUNICATION_ACTION_TYPE_LABELS[type]
 }
 
+const actionAvailabilityByType: Record<PortingRequestCommunicationActionType, PortingCaseStatus[]> = {
+  MISSING_DOCUMENTS: ['DRAFT', 'SUBMITTED', 'PENDING_DONOR'],
+  CLIENT_CONFIRMATION: ['DRAFT', 'SUBMITTED', 'PENDING_DONOR', 'CONFIRMED'],
+  REJECTION_NOTICE: ['REJECTED'],
+  COMPLETION_NOTICE: ['PORTED'],
+  INTERNAL_NOTE_EMAIL: ['DRAFT', 'SUBMITTED', 'PENDING_DONOR', 'CONFIRMED', 'ERROR'],
+}
+
+function formatStatusList(statuses: PortingCaseStatus[]): string {
+  return statuses.map((status) => PORTING_CASE_STATUS_LABELS[status]).join(', ')
+}
+
+function buildBlockedReason(
+  action: PortingRequestCommunicationActionDto,
+  currentStatus: PortingCaseStatus | null,
+): string | null {
+  if (!action.disabledReason) {
+    return null
+  }
+
+  if (action.existingDraftInfo) {
+    return 'Akcja jest wstrzymana, bo istnieje aktywny draft tego typu. Oznacz go jako wyslany albo anuluj przed utworzeniem kolejnego.'
+  }
+
+  const availableStatuses = actionAvailabilityByType[action.type]
+
+  if (availableStatuses.length > 0) {
+    const currentStatusLabel = currentStatus ? PORTING_CASE_STATUS_LABELS[currentStatus] : 'nieznany'
+    return `Akcja bedzie dostepna dla statusow: ${formatStatusList(availableStatuses)}. Aktualny status: ${currentStatusLabel}.`
+  }
+
+  return action.disabledReason
+}
+
 function canSend(status: PortingCommunicationDto['status']): boolean {
   return status === 'DRAFT' || status === 'READY_TO_SEND'
 }
@@ -87,6 +124,7 @@ interface PortingCommunicationPanelProps {
   cancellingId: string | null
   deliveryAttemptsByCommId: Record<string, CommunicationDeliveryAttemptsResultDto>
   loadingDeliveryAttemptsId: string | null
+  currentStatus?: PortingCaseStatus | null
   onPreviewDraft: (actionType: PortingRequestCommunicationActionType) => void
   onCreateDraft: (actionType: PortingRequestCommunicationActionType) => void
   onMarkAsSent: (communicationId: string) => void
@@ -112,6 +150,7 @@ export function PortingCommunicationPanel({
   cancellingId,
   deliveryAttemptsByCommId,
   loadingDeliveryAttemptsId,
+  currentStatus = null,
   onPreviewDraft,
   onCreateDraft,
   onMarkAsSent,
@@ -121,38 +160,37 @@ export function PortingCommunicationPanel({
   onLoadDeliveryAttempts,
 }: PortingCommunicationPanelProps) {
   return (
-    <div className="card p-5">
+    <div className="panel p-5">
       <div className="mb-4">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        <h2 className="text-sm font-semibold text-ink-900">
           Komunikacja operacyjna
         </h2>
-        <p className="mt-1 text-sm text-gray-500">
-          Backend steruje dostepnymi akcjami, blokadami i duplikatami draftow. UI tylko pokazuje
-          aktualna polityke i historie.
+        <p className="mt-1 text-sm leading-6 text-ink-500">
+          Drafty i wysylki do klienta zgodne z aktualnym statusem sprawy oraz polityka uprawnien.
         </p>
       </div>
 
       <div className="mb-5 grid gap-3 md:grid-cols-3">
-        <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
-          <p className="text-xs uppercase tracking-wide text-gray-500">Drafty</p>
-          <p className="mt-1 text-lg font-semibold text-gray-900">{summary.draftCount}</p>
-          <p className="text-xs text-gray-500">Lacznie komunikacji: {summary.totalCount}</p>
+        <div className="rounded-lg border border-line bg-ink-50 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-ink-400">Drafty</p>
+          <p className="mt-1 text-lg font-semibold text-ink-900">{summary.draftCount}</p>
+          <p className="text-xs text-ink-500">Lacznie komunikacji: {summary.totalCount}</p>
         </div>
 
-        <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
-          <p className="text-xs uppercase tracking-wide text-gray-500">Wyslane</p>
-          <p className="mt-1 text-lg font-semibold text-gray-900">{summary.sentCount}</p>
-          <p className="text-xs text-gray-500">Bledy: {summary.errorCount}</p>
+        <div className="rounded-lg border border-line bg-ink-50 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-ink-400">Wyslane</p>
+          <p className="mt-1 text-lg font-semibold text-ink-900">{summary.sentCount}</p>
+          <p className="text-xs text-ink-500">Bledy: {summary.errorCount}</p>
         </div>
 
-        <div className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3">
-          <p className="text-xs uppercase tracking-wide text-gray-500">Ostatnia komunikacja</p>
-          <p className="mt-1 text-sm font-semibold text-gray-900">
+        <div className="rounded-lg border border-line bg-ink-50 px-4 py-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-ink-400">Ostatnia komunikacja</p>
+          <p className="mt-1 text-sm font-semibold text-ink-900">
             {summary.lastCommunicationType
               ? getActionTypeLabel(summary.lastCommunicationType)
               : 'Brak komunikacji'}
           </p>
-          <p className="text-xs text-gray-500">
+          <p className="text-xs text-ink-500">
             {summary.lastCommunicationAt ? formatDateTime(summary.lastCommunicationAt) : '-'}
           </p>
         </div>
@@ -175,46 +213,61 @@ export function PortingCommunicationPanel({
           actions.map((action) => {
             const isPreviewLoading = previewingActionType === action.type
             const isCreateLoading = creatingDraftActionType === action.type
+            const isActionBusy = isPreviewLoading || isCreateLoading
+            const blockedReason = buildBlockedReason(action, currentStatus)
             const previewForAction = preview?.actionType === action.type ? preview : null
+            const disabledActionClass =
+              'border-line bg-ink-50 text-ink-400 shadow-none hover:border-line hover:bg-ink-50'
 
             return (
-              <div key={action.type} className="rounded-lg border border-gray-200 bg-white p-4">
+              <div
+                key={action.type}
+                className={cx(
+                  'rounded-lg border p-4',
+                  action.disabled || !action.canCreateDraft
+                    ? 'border-line bg-ink-50/80'
+                    : 'border-line bg-surface',
+                )}
+              >
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="max-w-3xl">
                     <div className="flex flex-wrap items-center gap-2">
-                      <h3 className="text-sm font-semibold text-gray-900">{action.label}</h3>
+                      <h3 className="text-sm font-semibold text-ink-900">{action.label}</h3>
                       {action.existingDraftInfo && (
-                        <span className="inline-flex items-center rounded bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
-                          Aktywny draft
-                        </span>
+                        <Badge tone="amber">Aktywny draft</Badge>
+                      )}
+                      {action.disabled && (
+                        <Badge tone="neutral" className="bg-ink-100 text-ink-500">
+                          Niedostepne teraz
+                        </Badge>
                       )}
                     </div>
-                    <p className="mt-1 text-sm text-gray-500">{action.description}</p>
+                    <p className="mt-1 text-sm leading-6 text-ink-500">{action.description}</p>
                   </div>
 
                   <div className="flex flex-wrap gap-2">
-                    <button
-                      type="button"
+                    <Button
                       onClick={() => onPreviewDraft(action.type)}
-                      className="btn-secondary"
+                      variant="secondary"
+                      className={!action.canPreview ? disabledActionClass : undefined}
                       disabled={!action.canPreview || isPreviewLoading || isCreateLoading}
                     >
-                      {isPreviewLoading ? 'Ladowanie...' : 'Podglad'}
-                    </button>
-                    <button
-                      type="button"
+                      {isPreviewLoading ? 'Przygotowuje podglad' : 'Podglad'}
+                    </Button>
+                    <Button
                       onClick={() => onCreateDraft(action.type)}
-                      className="btn-primary"
+                      variant={action.canCreateDraft ? 'primary' : 'secondary'}
+                      className={!action.canCreateDraft ? disabledActionClass : undefined}
                       disabled={!action.canCreateDraft || isCreateLoading || isPreviewLoading}
                     >
-                      {isCreateLoading ? 'Tworzenie...' : 'Utworz draft'}
-                    </button>
-                    <button
-                      type="button"
+                      {isCreateLoading ? 'Tworze draft' : 'Utworz draft'}
+                    </Button>
+                    <Button
                       onClick={() =>
                         action.existingDraftId ? onMarkAsSent(action.existingDraftId) : undefined
                       }
-                      className="btn-secondary"
+                      variant="secondary"
+                      className={!action.canMarkSent ? disabledActionClass : undefined}
                       disabled={
                         !action.canMarkSent ||
                         !action.existingDraftId ||
@@ -222,22 +275,28 @@ export function PortingCommunicationPanel({
                       }
                     >
                       {markingSentId === action.existingDraftId
-                        ? 'Zapisywanie...'
+                        ? 'Zapis statusu'
                         : 'Oznacz jako wyslane'}
-                    </button>
+                    </Button>
                   </div>
                 </div>
 
-                {action.disabledReason && (
-                  <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
-                    {action.disabledReason}
+                {isActionBusy && (
+                  <p role="status" className="mt-3 text-xs font-medium text-ink-500">
+                    Trwa jednorazowa operacja. Po zakonczeniu panel odswiezy historie komunikacji.
+                  </p>
+                )}
+
+                {blockedReason && (
+                  <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm leading-6 text-amber-900">
+                    {blockedReason}
                   </div>
                 )}
 
                 {action.existingDraftInfo && (
-                  <div className="mt-3 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">
+                  <div className="mt-3 rounded-md border border-line bg-surface px-3 py-2 text-sm text-ink-700">
                     <p className="font-medium">Istnieje juz aktywny draft tego typu.</p>
-                    <p className="mt-1 text-xs text-gray-500">
+                    <p className="mt-1 text-xs text-ink-500">
                       {action.existingDraftInfo.subject}
                       {' · '}
                       {action.existingDraftInfo.recipient}
@@ -251,13 +310,13 @@ export function PortingCommunicationPanel({
                 )}
 
                 {previewForAction && (
-                  <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
-                    <p className="text-xs uppercase tracking-wide text-gray-500">Podglad draftu</p>
-                    <p className="mt-1 text-sm text-gray-700">Do: {previewForAction.recipient}</p>
-                    <p className="mt-2 text-sm font-semibold text-gray-900">
+                  <div className="mt-3 rounded-lg border border-line bg-ink-50 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-ink-400">Podglad draftu</p>
+                    <p className="mt-1 text-sm text-ink-700">Do: {previewForAction.recipient}</p>
+                    <p className="mt-2 text-sm font-semibold text-ink-900">
                       {previewForAction.subject}
                     </p>
-                    <pre className="mt-2 whitespace-pre-wrap text-sm text-gray-700">
+                    <pre className="mt-2 whitespace-pre-wrap text-sm text-ink-700">
                       {previewForAction.body}
                     </pre>
                   </div>
@@ -320,7 +379,7 @@ export function PortingCommunicationPanel({
                           className="btn-secondary"
                           disabled={markingSentId === item.id || isSending || isRetrying || isCancelling}
                         >
-                          {markingSentId === item.id ? 'Zapisywanie...' : 'Oznacz jako wyslane'}
+                          {markingSentId === item.id ? 'Zapis statusu' : 'Oznacz jako wyslane'}
                         </button>
                       )}
 

--- a/apps/frontend/src/components/PortingExternalActionsPanel/PortingExternalActionsPanel.tsx
+++ b/apps/frontend/src/components/PortingExternalActionsPanel/PortingExternalActionsPanel.tsx
@@ -42,7 +42,7 @@ export function PortingExternalActionsPanel({
       <div>
         <h3 className="text-sm font-semibold text-gray-800">Etapy zewnetrzne</h3>
         <p className="mt-1 text-sm text-gray-500">
-          Reczne akcje foundation pod Adescom/PLI CBD. Dzialaja bez realnej integracji API.
+          Reczne operacje zwiazane z etapami PLI CBD i komunikacja do klienta.
         </p>
       </div>
 
@@ -128,7 +128,7 @@ export function PortingExternalActionsPanel({
               className="btn-primary"
               disabled={isSubmitting}
             >
-              {isSubmitting ? 'Zapisywanie...' : selectedAction.label}
+              {isSubmitting ? 'Zapis operacji' : selectedAction.label}
             </button>
             <button type="button" onClick={onReset} className="btn-secondary" disabled={isSubmitting}>
               Wyczysc

--- a/apps/frontend/src/components/layout/AppLayout.tsx
+++ b/apps/frontend/src/components/layout/AppLayout.tsx
@@ -1,11 +1,13 @@
-import { useState } from 'react'
-import { NavLink, Outlet, useNavigate } from 'react-router-dom'
-import { useAuthStore } from '@/stores/auth.store'
+import { useMemo, useState } from 'react'
+import { NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { ROUTES } from '@/constants/routes'
+import { useAuthStore } from '@/stores/auth.store'
 import { USER_ROLE_LABELS } from '@np-manager/shared'
+import { Button, cx } from '@/components/ui'
 
 interface NavItem {
   label: string
+  description: string
   path: string
   icon: string
   roles?: string[]
@@ -13,26 +15,27 @@ interface NavItem {
 }
 
 const primaryNavItems: NavItem[] = [
-  { label: 'Dashboard', path: ROUTES.DASHBOARD, icon: 'D', exact: true },
-  { label: 'Sprawy', path: ROUTES.REQUESTS, icon: 'S' },
-  { label: 'Klienci', path: ROUTES.CLIENTS, icon: 'K' },
-  { label: 'Zadania', path: ROUTES.TASKS, icon: 'Z' },
-  { label: 'Raporty', path: ROUTES.REPORTS, icon: 'R', roles: ['ADMIN', 'MANAGER', 'AUDITOR'] },
+  { label: 'Dashboard', description: 'Pulpit operacyjny', path: ROUTES.DASHBOARD, icon: 'D', exact: true },
+  { label: 'Sprawy', description: 'Portowanie numerow', path: ROUTES.REQUESTS, icon: 'S' },
+  { label: 'Klienci', description: 'Kartoteka klientow', path: ROUTES.CLIENTS, icon: 'K' },
+  { label: 'Zadania', description: 'Praca zespolu', path: ROUTES.TASKS, icon: 'Z' },
+  { label: 'Raporty', description: 'Kontrola i wyniki', path: ROUTES.REPORTS, icon: 'R', roles: ['ADMIN', 'MANAGER', 'AUDITOR'] },
   {
-    label: 'Błędy notyfikacji',
+    label: 'Bledy notyfikacji',
+    description: 'Kolejka interwencji',
     path: ROUTES.NOTIFICATION_FAILURES,
     icon: '!',
     roles: ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER'],
   },
-  { label: 'Operatorzy', path: ROUTES.OPERATORS, icon: 'O' },
+  { label: 'Operatorzy', description: 'Slownik operatorow', path: ROUTES.OPERATORS, icon: 'O' },
 ]
 
 const adminNavItems: NavItem[] = [
-  { label: 'Uzytkownicy', path: ROUTES.ADMIN_USERS, icon: 'U' },
-  { label: 'Operatorzy', path: ROUTES.ADMIN_OPERATORS, icon: 'O' },
-  { label: 'Szablony komunikatow', path: ROUTES.ADMIN_COMMUNICATION_TEMPLATES, icon: 'T' },
-  { label: 'Powiadomienia portingu', path: ROUTES.ADMIN_PORTING_NOTIFICATION_SETTINGS, icon: 'P' },
-  { label: 'Fallback notyfikacji', path: ROUTES.ADMIN_NOTIFICATION_FALLBACK_SETTINGS, icon: 'F' },
+  { label: 'Uzytkownicy', description: 'Role i dostep', path: ROUTES.ADMIN_USERS, icon: 'U' },
+  { label: 'Operatorzy', description: 'Administracja slownika', path: ROUTES.ADMIN_OPERATORS, icon: 'O' },
+  { label: 'Szablony komunikatow', description: 'Tresci klienta', path: ROUTES.ADMIN_COMMUNICATION_TEMPLATES, icon: 'T' },
+  { label: 'Powiadomienia portingu', description: 'Routing zespolowy', path: ROUTES.ADMIN_PORTING_NOTIFICATION_SETTINGS, icon: 'P' },
+  { label: 'Fallback notyfikacji', description: 'Obsluga bledow', path: ROUTES.ADMIN_NOTIFICATION_FALLBACK_SETTINGS, icon: 'F' },
 ]
 
 function SidebarLink({ item, sidebarCollapsed }: { item: NavItem; sidebarCollapsed: boolean }) {
@@ -41,23 +44,60 @@ function SidebarLink({ item, sidebarCollapsed }: { item: NavItem; sidebarCollaps
       to={item.path}
       end={item.exact ?? false}
       className={({ isActive }) =>
-        `flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-150 ${
-          isActive ? 'bg-blue-600 text-white' : 'text-gray-300 hover:bg-gray-700 hover:text-white'
-        }`
+        cx(
+          'group flex min-h-11 items-center gap-3 rounded-ui px-3 py-2 text-sm font-semibold transition-colors',
+          isActive
+            ? 'bg-brand-600 text-white shadow-soft'
+            : 'text-ink-600 hover:bg-ink-100 hover:text-ink-900',
+        )
       }
+      title={sidebarCollapsed ? item.label : undefined}
     >
-      <span className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-md bg-gray-800 text-xs font-semibold text-gray-200">
-        {item.icon}
-      </span>
-      {!sidebarCollapsed && <span className="truncate">{item.label}</span>}
+      {({ isActive }) => (
+        <>
+          <span
+            className={cx(
+              'flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-ui text-xs font-bold',
+              isActive ? 'bg-white/18 text-white' : 'bg-ink-100 text-ink-650 group-hover:bg-white',
+            )}
+          >
+            {item.icon}
+          </span>
+          {!sidebarCollapsed && (
+            <span className="min-w-0">
+              <span className="block truncate">{item.label}</span>
+              <span
+                className={cx(
+                  'block truncate text-[11px] font-medium',
+                  isActive ? 'text-brand-100' : 'text-ink-400',
+                )}
+              >
+                {item.description}
+              </span>
+            </span>
+          )}
+        </>
+      )}
     </NavLink>
   )
+}
+
+function getSectionLabel(pathname: string): string {
+  if (pathname.startsWith('/requests')) return 'Sprawy portowania'
+  if (pathname.startsWith('/clients')) return 'Klienci'
+  if (pathname.startsWith('/notifications')) return 'Notyfikacje'
+  if (pathname.startsWith('/admin')) return 'Administracja'
+  if (pathname.startsWith('/operators')) return 'Operatorzy'
+  if (pathname.startsWith('/reports')) return 'Raporty'
+  if (pathname.startsWith('/tasks')) return 'Zadania'
+  return 'Pulpit'
 }
 
 export function AppLayout() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const { user, clearAuth } = useAuthStore()
   const navigate = useNavigate()
+  const location = useLocation()
   const isAdmin = user?.role === 'ADMIN'
 
   const handleLogout = () => {
@@ -65,35 +105,40 @@ export function AppLayout() {
     void navigate(ROUTES.LOGIN)
   }
 
-  const visiblePrimaryItems = primaryNavItems.filter((item) => {
-    if (item.path === ROUTES.OPERATORS && isAdmin) {
-      return false
-    }
+  const visiblePrimaryItems = useMemo(
+    () =>
+      primaryNavItems.filter((item) => {
+        if (item.path === ROUTES.OPERATORS && isAdmin) {
+          return false
+        }
 
-    if (!item.roles) return true
-    return user ? item.roles.includes(user.role) : false
-  })
+        if (!item.roles) return true
+        return user ? item.roles.includes(user.role) : false
+      }),
+    [isAdmin, user],
+  )
 
   return (
-    <div className="flex h-screen overflow-hidden bg-gray-50">
+    <div className="flex h-screen overflow-hidden bg-canvas">
       <aside
-        className={`flex flex-shrink-0 flex-col bg-gray-900 text-white transition-all duration-200 ${
-          sidebarCollapsed ? 'w-16' : 'w-64'
-        }`}
+        className={cx(
+          'flex flex-shrink-0 flex-col border-r border-line bg-surface transition-all duration-200',
+          sidebarCollapsed ? 'w-20' : 'w-72',
+        )}
       >
-        <div className="flex h-16 items-center gap-3 border-b border-gray-700 px-4 py-4">
-          <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-blue-600 text-sm font-bold text-white">
+        <div className="flex h-20 items-center gap-3 border-b border-line px-4">
+          <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-ui bg-ink-900 text-sm font-bold text-white">
             NP
           </div>
           {!sidebarCollapsed && (
-            <div className="overflow-hidden">
-              <div className="truncate text-sm font-semibold">NP-Manager</div>
-              <div className="truncate text-xs text-gray-400">Portabilnosc numerow</div>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold text-ink-900">NP-Manager</div>
+              <div className="truncate text-xs font-medium text-ink-500">Operacje portingu</div>
             </div>
           )}
         </div>
 
-        <nav className="flex-1 overflow-y-auto px-2 py-4">
+        <nav className="flex-1 overflow-y-auto px-3 py-5">
           <div className="space-y-1">
             {visiblePrimaryItems.map((item) => (
               <SidebarLink key={item.path} item={item} sidebarCollapsed={sidebarCollapsed} />
@@ -101,9 +146,9 @@ export function AppLayout() {
           </div>
 
           {isAdmin && (
-            <div className="mt-6">
+            <div className="mt-7">
               {!sidebarCollapsed && (
-                <div className="px-3 pb-2 text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">
+                <div className="px-3 pb-2 text-xs font-semibold uppercase tracking-[0.18em] text-ink-400">
                   Administracja
                 </div>
               )}
@@ -116,62 +161,67 @@ export function AppLayout() {
           )}
         </nav>
 
-        <div className="border-t border-gray-700 p-3">
+        <div className="border-t border-line p-3">
           {user && (
-            <div className={`flex items-center gap-3 ${sidebarCollapsed ? 'justify-center' : ''}`}>
-              <div className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-gray-600 text-sm font-medium">
-                {user.firstName[0]}
-                {user.lastName[0]}
-              </div>
-              {!sidebarCollapsed && (
-                <div className="flex-1 overflow-hidden">
-                  <div className="truncate text-sm font-medium">
-                    {user.firstName} {user.lastName}
-                  </div>
-                  <div className="truncate text-xs text-gray-400">
-                    {USER_ROLE_LABELS[user.role]}
-                  </div>
-                </div>
+            <div
+              className={cx(
+                'rounded-panel border border-line bg-ink-50 p-3',
+                sidebarCollapsed && 'flex justify-center px-2',
               )}
+            >
+              <div className="flex items-center gap-3">
+                <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-ui bg-brand-600 text-sm font-bold text-white">
+                  {user.firstName[0]}
+                  {user.lastName[0]}
+                </div>
+                {!sidebarCollapsed && (
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-sm font-semibold text-ink-900">
+                      {user.firstName} {user.lastName}
+                    </div>
+                    <div className="truncate text-xs text-ink-500">{USER_ROLE_LABELS[user.role]}</div>
+                  </div>
+                )}
+              </div>
             </div>
           )}
         </div>
 
         <button
           onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
-          className="flex h-10 items-center justify-center border-t border-gray-700 text-gray-400 transition-colors hover:bg-gray-700 hover:text-white"
+          className="flex h-11 items-center justify-center border-t border-line text-sm font-semibold text-ink-500 transition-colors hover:bg-ink-100 hover:text-ink-900"
           title={sidebarCollapsed ? 'Rozwin menu' : 'Zwin menu'}
+          type="button"
         >
-          <span className="text-sm">{sidebarCollapsed ? '>' : '<'}</span>
+          {sidebarCollapsed ? '>' : '<'}
         </button>
       </aside>
 
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <header className="flex h-16 flex-shrink-0 items-center justify-between border-b border-gray-200 bg-white px-6">
-          <div className="flex items-center gap-4">
-            <span className="text-sm text-gray-500">System zarzadzania portabilnoscia</span>
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <header className="flex h-20 flex-shrink-0 items-center justify-between border-b border-line bg-surface/95 px-6 backdrop-blur">
+          <div className="min-w-0">
+            <div className="text-xs font-semibold uppercase tracking-[0.18em] text-ink-400">
+              NP-Manager
+            </div>
+            <div className="mt-1 truncate text-sm font-semibold text-ink-800">
+              {getSectionLabel(location.pathname)}
+            </div>
           </div>
 
           <div className="flex items-center gap-3">
-            <button
-              className="relative rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
-              title="Powiadomienia"
-            >
-              <span className="text-lg">!</span>
-            </button>
-
-            <button
-              onClick={handleLogout}
-              className="flex items-center gap-2 rounded-lg px-3 py-2 text-sm text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900"
-            >
-              <span>{'<'}</span>
-              <span>Wyloguj</span>
-            </button>
+            <div className="hidden rounded-ui border border-line bg-ink-50 px-3 py-2 text-xs font-medium text-ink-500 md:block">
+              Portabilnosc numerow
+            </div>
+            <Button onClick={handleLogout} variant="ghost" size="sm">
+              Wyloguj
+            </Button>
           </div>
         </header>
 
         <main className="flex-1 overflow-y-auto">
-          <Outlet />
+          <div className="mx-auto w-full max-w-[1600px] px-5 py-6 md:px-8">
+            <Outlet />
+          </div>
         </main>
       </div>
     </div>

--- a/apps/frontend/src/components/ui/Badge.tsx
+++ b/apps/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,31 @@
+import type { HTMLAttributes } from 'react'
+import { cx } from './styles'
+
+export type BadgeTone = 'neutral' | 'brand' | 'green' | 'emerald' | 'amber' | 'red' | 'orange'
+
+const toneClasses: Record<BadgeTone, string> = {
+  neutral: 'bg-ink-100 text-ink-650 ring-line',
+  brand: 'bg-brand-50 text-brand-700 ring-brand-200',
+  green: 'bg-green-50 text-green-700 ring-green-200',
+  emerald: 'bg-emerald-50 text-emerald-700 ring-emerald-200',
+  amber: 'bg-amber-50 text-amber-800 ring-amber-200',
+  red: 'bg-red-50 text-red-700 ring-red-200',
+  orange: 'bg-orange-50 text-orange-700 ring-orange-200',
+}
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: BadgeTone
+}
+
+export function Badge({ className, tone = 'neutral', ...props }: BadgeProps) {
+  return (
+    <span
+      className={cx(
+        'inline-flex min-h-6 items-center rounded-ui px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset',
+        toneClasses[tone],
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/apps/frontend/src/components/ui/Button.tsx
+++ b/apps/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,66 @@
+import type { ButtonHTMLAttributes, AnchorHTMLAttributes } from 'react'
+import { Link, type LinkProps } from 'react-router-dom'
+import { cx } from './styles'
+
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
+type ButtonSize = 'sm' | 'md'
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    'bg-brand-600 text-white shadow-soft hover:bg-brand-700 focus-visible:ring-brand-500',
+  secondary:
+    'border border-line-strong bg-surface text-ink-700 hover:border-brand-300 hover:bg-brand-50 focus-visible:ring-brand-500',
+  ghost: 'text-ink-600 hover:bg-ink-100 hover:text-ink-900 focus-visible:ring-brand-500',
+  danger:
+    'border border-red-200 bg-red-50 text-red-700 hover:bg-red-100 focus-visible:ring-red-500',
+}
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'h-8 px-3 text-xs',
+  md: 'h-10 px-4 text-sm',
+}
+
+const baseClasses =
+  'inline-flex items-center justify-center gap-2 rounded-ui font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+}
+
+export function Button({
+  className,
+  variant = 'secondary',
+  size = 'md',
+  type = 'button',
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cx(baseClasses, variantClasses[variant], sizeClasses[size], className)}
+      {...props}
+    />
+  )
+}
+
+export interface ButtonLinkProps
+  extends LinkProps,
+    Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof LinkProps> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+}
+
+export function ButtonLink({
+  className,
+  variant = 'secondary',
+  size = 'md',
+  ...props
+}: ButtonLinkProps) {
+  return (
+    <Link
+      className={cx(baseClasses, variantClasses[variant], sizeClasses[size], className)}
+      {...props}
+    />
+  )
+}

--- a/apps/frontend/src/components/ui/FilterChip.tsx
+++ b/apps/frontend/src/components/ui/FilterChip.tsx
@@ -1,0 +1,22 @@
+import type { ButtonHTMLAttributes } from 'react'
+import { cx } from './styles'
+
+interface FilterChipProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  active?: boolean
+}
+
+export function FilterChip({ active = false, className, type = 'button', ...props }: FilterChipProps) {
+  return (
+    <button
+      type={type}
+      className={cx(
+        'inline-flex h-8 items-center justify-center rounded-ui border px-3 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2',
+        active
+          ? 'border-brand-600 bg-brand-600 text-white shadow-soft'
+          : 'border-line-strong bg-surface text-ink-650 hover:border-brand-300 hover:bg-brand-50 hover:text-brand-700',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/apps/frontend/src/components/ui/MetricCard.tsx
+++ b/apps/frontend/src/components/ui/MetricCard.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from 'react'
+import { cx } from './styles'
+
+interface MetricCardProps {
+  title: string
+  value: number | string
+  detail?: ReactNode
+  active?: boolean
+  onClick?: () => void
+}
+
+export function MetricCard({ title, value, detail, active = false, onClick }: MetricCardProps) {
+  const content = (
+    <>
+      <span className="text-xs font-semibold uppercase tracking-[0.12em] text-ink-500">
+        {title}
+      </span>
+      <span className="mt-3 block text-3xl font-semibold tracking-tight text-ink-900">
+        {value}
+      </span>
+      {detail && <span className="mt-2 block text-xs leading-5 text-ink-500">{detail}</span>}
+    </>
+  )
+
+  const className = cx(
+    'rounded-panel border p-4 text-left transition-colors',
+    active
+      ? 'border-brand-500 bg-brand-50 shadow-soft'
+      : 'border-line bg-surface hover:border-brand-200 hover:bg-brand-50/60',
+  )
+
+  if (!onClick) {
+    return <div className={className}>{content}</div>
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cx(
+        className,
+        'w-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2',
+      )}
+    >
+      {content}
+    </button>
+  )
+}

--- a/apps/frontend/src/components/ui/PageHeader.tsx
+++ b/apps/frontend/src/components/ui/PageHeader.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+interface PageHeaderProps {
+  eyebrow?: string
+  title: string
+  description?: ReactNode
+  actions?: ReactNode
+}
+
+export function PageHeader({ eyebrow, title, description, actions }: PageHeaderProps) {
+  return (
+    <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+      <div className="min-w-0">
+        {eyebrow && (
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-brand-700">
+            {eyebrow}
+          </p>
+        )}
+        <h1 className="mt-1 text-3xl font-semibold tracking-tight text-ink-900">{title}</h1>
+        {description && <div className="mt-2 text-sm leading-6 text-ink-500">{description}</div>}
+      </div>
+      {actions && <div className="flex flex-wrap items-center gap-2">{actions}</div>}
+    </div>
+  )
+}

--- a/apps/frontend/src/components/ui/index.ts
+++ b/apps/frontend/src/components/ui/index.ts
@@ -1,0 +1,6 @@
+export { Badge, type BadgeProps, type BadgeTone } from './Badge'
+export { Button, ButtonLink, type ButtonLinkProps, type ButtonProps } from './Button'
+export { FilterChip } from './FilterChip'
+export { MetricCard } from './MetricCard'
+export { PageHeader } from './PageHeader'
+export { cx } from './styles'

--- a/apps/frontend/src/components/ui/styles.ts
+++ b/apps/frontend/src/components/ui/styles.ts
@@ -1,0 +1,3 @@
+export function cx(...classes: Array<string | false | null | undefined>): string {
+  return classes.filter(Boolean).join(' ')
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -14,70 +14,66 @@
   }
 
   body {
-    @apply bg-gray-50 text-gray-900;
+    @apply bg-canvas text-ink-900;
     margin: 0;
     padding: 0;
   }
 
-  /* Scrollbar styling */
+  button,
+  input,
+  select,
+  textarea {
+    font: inherit;
+  }
+
   ::-webkit-scrollbar {
     width: 6px;
     height: 6px;
   }
 
   ::-webkit-scrollbar-track {
-    @apply bg-gray-100;
+    @apply bg-ink-100;
   }
 
   ::-webkit-scrollbar-thumb {
-    @apply bg-gray-300 rounded-full;
+    @apply rounded-full bg-ink-300;
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    @apply bg-gray-400;
+    @apply bg-ink-400;
   }
 }
 
 @layer components {
-  /* Klasy pomocnicze wielokrotnie używane */
   .btn-primary {
-    @apply inline-flex items-center justify-center gap-2 px-4 py-2
-           bg-blue-600 text-white text-sm font-medium rounded-lg
-           hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
-           disabled:opacity-50 disabled:cursor-not-allowed
-           transition-colors duration-150;
+    @apply inline-flex items-center justify-center gap-2 rounded-ui bg-brand-600 px-4 py-2 text-sm font-semibold text-white shadow-soft transition-colors duration-150 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50;
   }
 
   .btn-secondary {
-    @apply inline-flex items-center justify-center gap-2 px-4 py-2
-           bg-white text-gray-700 text-sm font-medium rounded-lg border border-gray-300
-           hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2
-           disabled:opacity-50 disabled:cursor-not-allowed
-           transition-colors duration-150;
+    @apply inline-flex items-center justify-center gap-2 rounded-ui border border-line-strong bg-surface px-4 py-2 text-sm font-semibold text-ink-700 transition-colors duration-150 hover:border-brand-300 hover:bg-brand-50 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50;
   }
 
   .input-field {
-    @apply block w-full px-3 py-2
-           bg-white border border-gray-300 rounded-lg text-sm
-           placeholder-gray-400
-           focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500
-           disabled:bg-gray-50 disabled:text-gray-500
-           transition-colors duration-150;
+    @apply block w-full rounded-ui border border-line-strong bg-surface px-3 py-2 text-sm text-ink-800 transition-colors duration-150 placeholder-ink-400 focus:border-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500 disabled:bg-ink-50 disabled:text-ink-500;
   }
 
   .input-error {
-    @apply border-red-500 focus:ring-red-500 focus:border-red-500;
+    @apply border-red-500 focus:border-red-500 focus:ring-red-500;
   }
 
   .label {
-    @apply block text-sm font-medium text-gray-700 mb-1;
+    @apply mb-1 block text-sm font-semibold text-ink-700;
   }
 
   .error-message {
-    @apply text-xs text-red-600 mt-1;
+    @apply mt-1 text-xs text-red-600;
   }
 
   .card {
-    @apply bg-white rounded-xl border border-gray-200 shadow-sm;
+    @apply rounded-panel border border-line bg-surface shadow-sm;
+  }
+
+  .panel {
+    @apply rounded-panel border border-line bg-surface shadow-panel;
   }
 }

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -3,6 +3,7 @@ import axios from 'axios'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ROUTES } from '@/constants/routes'
 import { useAuthStore } from '@/stores/auth.store'
+import { Badge, Button, ButtonLink, type BadgeTone, cx } from '@/components/ui'
 import {
   assignPortingRequestToMe,
   cancelPortingCommunication,
@@ -212,43 +213,58 @@ function getAssignmentActionErrorMessage(error: unknown, fallback: string): stri
 }
 
 function SectionCard({
+  id,
   title,
   description,
   children,
+  compact = false,
 }: {
+  id?: string
   title: string
   description?: string
   children: React.ReactNode
+  compact?: boolean
 }) {
   return (
-    <div className="card p-5">
-      <div className="mb-4">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">{title}</h2>
-        {description && <p className="mt-1 text-sm text-gray-500">{description}</p>}
+    <section id={id} className={cx('panel scroll-mt-6', compact ? 'p-4' : 'p-5')}>
+      <div className={compact ? 'mb-3' : 'mb-4'}>
+        <h2 className="text-sm font-semibold text-ink-900">{title}</h2>
+        {description && <p className="mt-1 text-sm leading-6 text-ink-500">{description}</p>}
       </div>
       {children}
-    </div>
+    </section>
   )
 }
 
 function DisclosureCard({
+  id,
   title,
   description,
   children,
 }: {
+  id?: string
   title: string
   description: string
   children: React.ReactNode
 }) {
   return (
-    <details className="card overflow-hidden">
-      <summary className="cursor-pointer list-none px-5 py-4">
-        <div className="pr-8">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">{title}</h2>
-          <p className="mt-1 text-sm text-gray-500">{description}</p>
+    <details id={id} className="panel group scroll-mt-6 overflow-hidden">
+      <summary
+        onClick={(event) => event.currentTarget.focus()}
+        className="flex w-full cursor-pointer list-none items-start justify-between gap-4 px-5 py-4 transition-colors hover:bg-ink-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-inset group-open:bg-ink-50/50 [&::-webkit-details-marker]:hidden"
+      >
+        <div className="min-w-0 pr-4">
+          <h2 className="text-sm font-semibold text-ink-900">{title}</h2>
+          <p className="mt-1 text-sm leading-6 text-ink-500">{description}</p>
         </div>
+        <span
+          aria-hidden="true"
+          className="mt-1 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-ui border border-line bg-surface text-sm font-semibold text-ink-500 transition-transform group-open:rotate-180"
+        >
+          v
+        </span>
       </summary>
-      <div className="border-t border-gray-100 px-5 py-5">{children}</div>
+      <div className="border-t border-line px-5 py-5">{children}</div>
     </details>
   )
 }
@@ -264,9 +280,9 @@ function Field({
 }) {
   return (
     <div>
-      <dt className="mb-0.5 text-xs text-gray-500">{label}</dt>
-      <dd className={`text-sm text-gray-900 ${mono ? 'font-mono' : ''}`}>
-        {value ?? <span className="text-gray-400">-</span>}
+      <dt className="mb-1 text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">{label}</dt>
+      <dd className={cx('text-sm font-medium text-ink-800', mono && 'font-mono')}>
+        {value ?? <span className="font-normal text-ink-400">-</span>}
       </dd>
     </div>
   )
@@ -275,12 +291,61 @@ function Field({
 function WideField({ label, value }: { label: string; value: string | null | undefined }) {
   return (
     <div className="sm:col-span-2">
-      <dt className="mb-0.5 text-xs text-gray-500">{label}</dt>
-      <dd className="whitespace-pre-wrap text-sm text-gray-900">
-        {value ?? <span className="text-gray-400">-</span>}
+      <dt className="mb-1 text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">{label}</dt>
+      <dd className="whitespace-pre-wrap text-sm font-medium leading-6 text-ink-800">
+        {value ?? <span className="font-normal text-ink-400">-</span>}
       </dd>
     </div>
   )
+}
+
+function DetailMetric({
+  label,
+  value,
+  tone = 'neutral',
+  actionLabel,
+  onAction,
+}: {
+  label: string
+  value: string
+  tone?: BadgeTone
+  actionLabel?: string
+  onAction?: () => void
+}) {
+  return (
+    <div className="rounded-panel border border-line bg-surface px-4 py-3">
+      <div className="text-xs font-semibold uppercase tracking-[0.1em] text-ink-400">{label}</div>
+      <div className="mt-2 flex flex-wrap items-center gap-3">
+        <Badge tone={tone}>{value}</Badge>
+        {actionLabel && onAction && (
+          <button
+            type="button"
+            onClick={onAction}
+            className="rounded-ui bg-brand-50/70 px-2 py-1 text-xs font-semibold text-brand-800 underline-offset-4 transition-colors hover:bg-brand-100 hover:text-brand-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+          >
+            {actionLabel} {'>'}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function scrollToSection(sectionId: string) {
+  document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+function getStatusTone(status: ReturnType<typeof getPortingStatusMeta>['tone']): BadgeTone {
+  const toneByStatus: Record<ReturnType<typeof getPortingStatusMeta>['tone'], BadgeTone> = {
+    gray: 'neutral',
+    blue: 'brand',
+    amber: 'amber',
+    green: 'green',
+    red: 'red',
+    emerald: 'emerald',
+  }
+
+  return toneByStatus[status]
 }
 
 function formatDateTime(iso: string): string {
@@ -310,7 +375,7 @@ function buildAdminTransportBanner(result: PliCbdManualExportResultDto) {
     outcome === 'ACCEPTED'
       ? 'Zaakceptowany przez PLI CBD.'
       : outcome === 'STUBBED'
-        ? 'Stub: brak realnego transportu, artefakty zapisane lokalnie.'
+        ? 'Operacja zapisana w trybie testowym.'
         : outcome === 'REJECTED'
           ? `Odrzucony przez PLI CBD: ${transportResult?.rejectionReason ?? 'brak powodu'}`
           : outcome === 'TRANSPORT_ERROR'
@@ -325,57 +390,55 @@ function buildAdminTransportBanner(result: PliCbdManualExportResultDto) {
 function NotificationHealthPanel({ health }: { health: NotificationHealthDiagnosticsDto }) {
   const statusConfig: Record<
     NotificationHealthDiagnosticsDto['status'],
-    { label: string; badgeClass: string; panelClass: string }
+    { label: string; tone: BadgeTone; panelClass: string }
   > = {
     OK: {
       label: 'OK — brak bledow notyfikacji',
-      badgeClass: 'bg-emerald-100 text-emerald-700',
-      panelClass: 'border-emerald-200 bg-emerald-50',
+      tone: 'emerald',
+      panelClass: 'border-emerald-200 bg-emerald-50/70',
     },
     FAILED: {
       label: 'Blad wysylki',
-      badgeClass: 'bg-red-100 text-red-700',
-      panelClass: 'border-red-200 bg-red-50',
+      tone: 'red',
+      panelClass: 'border-red-200 bg-red-50/80',
     },
     MISCONFIGURED: {
       label: 'Blad konfiguracji',
-      badgeClass: 'bg-amber-100 text-amber-700',
-      panelClass: 'border-amber-200 bg-amber-50',
+      tone: 'amber',
+      panelClass: 'border-amber-200 bg-amber-50/80',
     },
     MIXED: {
       label: 'Bledy mieszane',
-      badgeClass: 'bg-orange-100 text-orange-700',
-      panelClass: 'border-orange-200 bg-orange-50',
+      tone: 'orange',
+      panelClass: 'border-orange-200 bg-orange-50/80',
     },
   }
 
   const config = statusConfig[health.status]
 
   return (
-    <div className={`rounded-lg border p-4 ${config.panelClass}`}>
-      <div className="flex items-center justify-between mb-2">
-        <h3 className="text-sm font-semibold text-gray-700">Diagnostyka powiadomien wewnetrznych</h3>
-        <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${config.badgeClass}`}>
-          {config.label}
-        </span>
+    <div className={`rounded-panel border p-4 ${config.panelClass}`}>
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-ink-800">Zdrowie powiadomien wewnetrznych</h3>
+        <Badge tone={config.tone}>{config.label}</Badge>
       </div>
       {health.status !== 'OK' && (
         <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs sm:grid-cols-4">
           <div>
-            <dt className="text-gray-500">Wszystkich bledow</dt>
-            <dd className="font-medium text-gray-800">{health.failureCount}</dd>
+            <dt className="text-ink-500">Wszystkich bledow</dt>
+            <dd className="font-semibold text-ink-800">{health.failureCount}</dd>
           </div>
           <div>
-            <dt className="text-gray-500">Blad wysylki</dt>
-            <dd className="font-medium text-gray-800">{health.failedCount}</dd>
+            <dt className="text-ink-500">Blad wysylki</dt>
+            <dd className="font-semibold text-ink-800">{health.failedCount}</dd>
           </div>
           <div>
-            <dt className="text-gray-500">Blad konfiguracji</dt>
-            <dd className="font-medium text-gray-800">{health.misconfiguredCount}</dd>
+            <dt className="text-ink-500">Blad konfiguracji</dt>
+            <dd className="font-semibold text-ink-800">{health.misconfiguredCount}</dd>
           </div>
           <div>
-            <dt className="text-gray-500">Ostatni blad</dt>
-            <dd className="font-medium text-gray-800">
+            <dt className="text-ink-500">Ostatni blad</dt>
+            <dd className="font-semibold text-ink-800">
               {health.lastFailureAt
                 ? new Date(health.lastFailureAt).toLocaleDateString('pl-PL', {
                     day: '2-digit',
@@ -1456,58 +1519,156 @@ export function RequestDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-24 text-sm text-gray-400">Ladowanie...</div>
+      <div className="flex items-center justify-center py-24 text-sm font-medium text-ink-500">
+        Ladowanie szczegolow sprawy...
+      </div>
     )
   }
 
   if (error || !request) {
     return (
-      <div className="p-6">
-        <div className="card p-8 text-center">
-          <p className="mb-4 text-sm text-red-500">{error ?? 'Sprawa nie zostala znaleziona.'}</p>
-          <button onClick={() => void navigate(ROUTES.REQUESTS)} className="btn-secondary">
-            Wroc do listy
-          </button>
-        </div>
+      <div className="panel p-8 text-center">
+        <p className="mb-4 text-sm font-medium text-red-600">
+          {error ?? 'Sprawa nie zostala znaleziona.'}
+        </p>
+        <Button onClick={() => void navigate(ROUTES.REQUESTS)} variant="secondary">
+          Wroc do listy
+        </Button>
       </div>
     )
   }
 
   const statusMeta = getPortingStatusMeta(request.statusInternal)
+  const assignedUserLabel = request.assignedUser
+    ? `${request.assignedUser.displayName} (${request.assignedUser.email})`
+    : 'Nieprzypisana'
+  const commercialOwnerLabel = request.commercialOwner
+    ? `${request.commercialOwner.displayName} (${request.commercialOwner.email})`
+    : 'Brak opiekuna'
+  const quickStatusActions = canManageStatus ? availableStatusActions.slice(0, 3) : []
+  const hasQuickActions =
+    quickStatusActions.length > 0 || canManageAssignment || availableCommunicationActions.length > 0
 
   return (
-    <div className="max-w-6xl space-y-4 p-6">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <button
-            onClick={() => void navigate(ROUTES.REQUESTS)}
-            className="mb-2 flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700"
-          >
-            {'<-'} Sprawy portowania
-          </button>
-          <h1 className="text-2xl font-bold text-gray-900">{request.caseNumber}</h1>
-          <div className="mt-2 flex flex-wrap items-center gap-3">
-            <span
-              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${statusMeta.className}`}
-            >
-              {statusMeta.label}
-            </span>
-            <span className="inline-flex items-center rounded bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600">
-              {PORTING_MODE_LABELS[request.portingMode]}
-            </span>
-            <span className="text-sm text-gray-500">{request.client.displayName}</span>
-            <span className="text-sm text-gray-500">{request.numberDisplay}</span>
+    <div className="space-y-6">
+      <section className="panel overflow-hidden">
+        <div className="border-b border-line px-5 py-5">
+          <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
+            <div className="min-w-0">
+              <Button
+                onClick={() => void navigate(ROUTES.REQUESTS)}
+                variant="ghost"
+                size="sm"
+                className="mb-3 -ml-2"
+              >
+                {'<-'} Sprawy portowania
+              </Button>
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge tone="neutral">{request.caseNumber}</Badge>
+                <Badge tone={getStatusTone(statusMeta.tone)}>{statusMeta.label}</Badge>
+                <Badge tone="brand">{PORTING_MODE_LABELS[request.portingMode]}</Badge>
+              </div>
+              <h1 className="mt-3 text-3xl font-semibold tracking-tight text-ink-900">
+                {request.client.displayName}
+              </h1>
+              <p className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm font-medium text-ink-500">
+                <span className="font-mono text-ink-700">{request.numberDisplay}</span>
+                <span>{request.subscriberDisplayName}</span>
+                <span>
+                  {request.donorOperator.name} {'->'} {request.recipientOperator.name}
+                </span>
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <ButtonLink to={ROUTES.REQUEST_NEW} variant="secondary">
+                + Nowa sprawa
+              </ButtonLink>
+            </div>
           </div>
         </div>
 
-        <button onClick={() => void navigate(ROUTES.REQUEST_NEW)} className="btn-secondary">
-          + Nowa sprawa
-        </button>
-      </div>
+        <div className="grid gap-3 bg-ink-50/70 px-5 py-4 md:grid-cols-2 xl:grid-cols-4">
+          <DetailMetric
+            label="Status"
+            value={statusMeta.label}
+            tone={getStatusTone(statusMeta.tone)}
+            actionLabel={canManageStatus ? 'Akcje' : undefined}
+            onAction={canManageStatus ? () => scrollToSection('workflow-actions') : undefined}
+          />
+          <DetailMetric
+            label="Przypisanie BOK"
+            value={request.assignedUser ? request.assignedUser.displayName : 'Nieprzypisana'}
+            tone={request.assignedUser ? 'brand' : 'amber'}
+            actionLabel={canManageAssignment ? 'Zmien' : 'Szczegoly'}
+            onAction={() => scrollToSection('assignment-panel')}
+          />
+          <DetailMetric
+            label="Opiekun handlowy"
+            value={request.commercialOwner ? request.commercialOwner.displayName : 'Brak opiekuna'}
+            tone={request.commercialOwner ? 'emerald' : 'amber'}
+            actionLabel={canManageCommercialOwner ? 'Zmien' : 'Szczegoly'}
+            onAction={() => scrollToSection('commercial-owner-panel')}
+          />
+          <DetailMetric
+            label="Notyfikacje"
+            value={request.notificationHealth.status === 'OK' ? 'OK' : `${request.notificationHealth.failureCount} bledow`}
+            tone={request.notificationHealth.status === 'OK' ? 'emerald' : 'red'}
+            actionLabel={request.notificationHealth.failureCount > 0 ? 'Sprawdz' : 'Historia'}
+            onAction={() => scrollToSection('notification-panel')}
+          />
+        </div>
+      </section>
 
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,2fr)_minmax(320px,1fr)]">
-        <div className="space-y-4">
-          <SectionCard title="Przeglad" description="Najwazniejsze dane operacyjne sprawy.">
+      {hasQuickActions && (
+        <section className="panel p-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <h2 className="text-sm font-semibold text-ink-900">Szybkie akcje</h2>
+              <p className="mt-1 text-sm text-ink-500">
+                Najczestsze przejscia operacyjne bez szukania panelu w prawej kolumnie.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {quickStatusActions.map((action) => (
+                <Button
+                  key={`${action.actionId}-${action.targetStatus}`}
+                  onClick={() => {
+                    handleSelectStatusAction(action)
+                    scrollToSection('workflow-actions')
+                  }}
+                  variant="primary"
+                  size="sm"
+                >
+                  {action.label}
+                </Button>
+              ))}
+              {canManageAssignment && (
+                <Button
+                  onClick={() => scrollToSection('assignment-panel')}
+                  variant="secondary"
+                  size="sm"
+                >
+                  Przypisanie BOK
+                </Button>
+              )}
+              {availableCommunicationActions.length > 0 && (
+                <Button
+                  onClick={() => scrollToSection('communication-panel')}
+                  variant="secondary"
+                  size="sm"
+                >
+                  Komunikacja
+                </Button>
+              )}
+            </div>
+          </div>
+        </section>
+      )}
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.6fr)_minmax(340px,0.9fr)]">
+        <div className="space-y-5">
+          <SectionCard title="Najwazniejsze informacje" description="Dane potrzebne od razu po wejsciu w sprawe.">
             <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <Field label="Klient" value={request.client.displayName} />
               <Field label="Abonent" value={request.subscriberDisplayName} />
@@ -1522,7 +1683,7 @@ export function RequestDetailPage() {
             </dl>
           </SectionCard>
 
-          <SectionCard title="Terminy" description="Terminy istotne z perspektywy codziennej obslugi.">
+          <SectionCard title="Porting i terminy" description="Daty oraz parametry potrzebne do operacyjnej obslugi portowania.">
             <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <Field label="Wnioskowany dzien przeniesienia" value={request.requestedPortDate} mono />
               <Field label="Najwczesniejsza akceptowalna data" value={request.earliestAcceptablePortDate} mono />
@@ -1533,7 +1694,7 @@ export function RequestDetailPage() {
             </dl>
           </SectionCard>
 
-          <SectionCard title="Dane sprawy" description="Tozsamosc abonenta, kontakt i notatki operacyjne.">
+          <SectionCard title="Dane klienta i kontakt" description="Tozsamosc abonenta, kontakt i notatki operacyjne.">
             <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <Field label="Typ identyfikatora" value={SUBSCRIBER_IDENTITY_TYPE_LABELS[request.identityType]} />
               <Field label="Wartosc identyfikatora" value={request.identityValue} mono />
@@ -1544,61 +1705,79 @@ export function RequestDetailPage() {
             </dl>
           </SectionCard>
 
-          <PortingCommunicationPanel
-            actions={availableCommunicationActions}
-            summary={communicationSummary}
-            items={communicationItems}
-            isLoadingHistory={isCommunicationLoading}
-            preview={communicationPreview}
-            feedbackError={communicationFeedbackError}
-            feedbackSuccess={communicationFeedbackSuccess}
-            previewingActionType={previewingCommunicationActionType}
-            creatingDraftActionType={creatingCommunicationActionType}
-            markingSentId={markingCommunicationId}
-            sendingId={sendingCommunicationId}
-            retryingId={retryingCommunicationId}
-            cancellingId={cancellingCommunicationId}
-            deliveryAttemptsByCommId={deliveryAttemptsByCommId}
-            loadingDeliveryAttemptsId={loadingDeliveryAttemptsId}
-            onCreateDraft={(actionType) => void handleCreateCommunicationDraft(actionType)}
-            onPreviewDraft={(actionType) => void handlePreviewCommunicationDraft(actionType)}
-            onMarkAsSent={(communicationId) => void handleMarkCommunicationAsSent(communicationId)}
-            onSend={(communicationId) => void handleSendCommunication(communicationId)}
-            onRetry={(communicationId) => void handleRetryCommunication(communicationId)}
-            onCancel={(communicationId) => void handleCancelCommunication(communicationId)}
-            onLoadDeliveryAttempts={(communicationId) => void handleLoadDeliveryAttempts(communicationId)}
-          />
+          <SectionCard
+            id="notification-panel"
+            title="Stan notyfikacji"
+            description="Widok problemow transportu i historii wewnetrznych powiadomien."
+          >
+            <div className="space-y-4">
+              <NotificationHealthPanel health={request.notificationHealth} />
 
-          <PortingCaseHistory items={caseHistoryItems} isLoading={isCaseHistoryLoading} />
+              {(request.notificationHealth.failureCount > 0 ||
+                isNotificationFailuresLoading ||
+                notificationFailuresError) && (
+                <NotificationFailureHistoryPanel
+                  items={notificationFailureItems}
+                  isLoading={isNotificationFailuresLoading}
+                  error={notificationFailuresError}
+                />
+              )}
 
-          <NotificationHealthPanel health={request.notificationHealth} />
+              <PortingInternalNotificationsPanel
+                items={internalNotificationItems}
+                isLoading={isInternalNotificationLoading}
+                error={internalNotificationError}
+              />
 
-          {(request.notificationHealth.failureCount > 0 ||
-            isNotificationFailuresLoading ||
-            notificationFailuresError) && (
-            <NotificationFailureHistoryPanel
-              items={notificationFailureItems}
-              isLoading={isNotificationFailuresLoading}
-              error={notificationFailuresError}
+              <InternalNotificationAttemptsPanel
+                items={internalNotificationAttemptItems}
+                isLoading={isInternalNotificationAttemptsLoading}
+                error={internalNotificationAttemptsError}
+              />
+            </div>
+          </SectionCard>
+
+          <div id="communication-panel" className="scroll-mt-6">
+            <PortingCommunicationPanel
+              actions={availableCommunicationActions}
+              summary={communicationSummary}
+              items={communicationItems}
+              isLoadingHistory={isCommunicationLoading}
+              preview={communicationPreview}
+              feedbackError={communicationFeedbackError}
+              feedbackSuccess={communicationFeedbackSuccess}
+              previewingActionType={previewingCommunicationActionType}
+              creatingDraftActionType={creatingCommunicationActionType}
+              markingSentId={markingCommunicationId}
+              sendingId={sendingCommunicationId}
+              retryingId={retryingCommunicationId}
+              cancellingId={cancellingCommunicationId}
+              deliveryAttemptsByCommId={deliveryAttemptsByCommId}
+              loadingDeliveryAttemptsId={loadingDeliveryAttemptsId}
+              currentStatus={request.statusInternal}
+              onCreateDraft={(actionType) => void handleCreateCommunicationDraft(actionType)}
+              onPreviewDraft={(actionType) => void handlePreviewCommunicationDraft(actionType)}
+              onMarkAsSent={(communicationId) => void handleMarkCommunicationAsSent(communicationId)}
+              onSend={(communicationId) => void handleSendCommunication(communicationId)}
+              onRetry={(communicationId) => void handleRetryCommunication(communicationId)}
+              onCancel={(communicationId) => void handleCancelCommunication(communicationId)}
+              onLoadDeliveryAttempts={(communicationId) => void handleLoadDeliveryAttempts(communicationId)}
             />
-          )}
+          </div>
 
-          <PortingInternalNotificationsPanel
-            items={internalNotificationItems}
-            isLoading={isInternalNotificationLoading}
-            error={internalNotificationError}
-          />
-
-          <InternalNotificationAttemptsPanel
-            items={internalNotificationAttemptItems}
-            isLoading={isInternalNotificationAttemptsLoading}
-            error={internalNotificationAttemptsError}
-          />
+          <SectionCard title="Historia operacyjna" description="Chronologia zmian statusu i zdarzen sprawy.">
+            <PortingCaseHistory
+              items={caseHistoryItems}
+              isLoading={isCaseHistoryLoading}
+              showHeader={false}
+            />
+          </SectionCard>
 
           {isAdmin && (
             <DisclosureCard
+              id="pli-cbd-panel"
               title="PLI CBD"
-              description="Sekcja administracyjna z operacjami foundation i statusem procesu PLI CBD."
+              description="Sekcja administracyjna z eksportem, synchronizacja i statusem procesu PLI CBD."
             >
               <div className="space-y-4">
                 <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4">
@@ -1645,10 +1824,6 @@ export function RequestDetailPage() {
                   </div>
                 )}
 
-                <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-                  Manualne akcje sa foundation pod przyszla integracje. Nadal nie ma realnego klienta SOAP do PLI CBD.
-                </div>
-
                 <PliCbdProcessSnapshot snapshot={processSnapshot} isLoading={isProcessSnapshotLoading} />
               </div>
             </DisclosureCard>
@@ -1656,19 +1831,20 @@ export function RequestDetailPage() {
 
           {isAdmin && (
             <DisclosureCard
+              id="diagnostics-panel"
               title="Diagnostyka"
-              description="Drafty, payloady techniczne, XML preview i historia integracji. Schowane domyslnie."
+              description="Podglady techniczne, XML i historia integracji. Schowane domyslnie."
             >
               <div className="space-y-4">
                 <div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-                  Diagnostyka jest widoczna tylko dla administratora. Nie sugeruje jeszcze realnego transportu SOAP.
+                  Diagnostyka jest widoczna tylko dla administratora i sluzy do weryfikacji danych technicznych przed operacjami PLI CBD.
                 </div>
 
                 <div className="space-y-3">
                   <div>
                     <h3 className="text-sm font-semibold text-gray-800">Manualny eksport komunikatow PLI CBD</h3>
                     <p className="mt-1 text-sm text-gray-500">
-                      Buduje draft, payload i XML, zapisuje historie integracji, ale nadal nie wysyla do realnego PLI CBD.
+                      Przygotowuje dane komunikatu, zapisuje historie integracji i pokazuje wynik operacji.
                     </p>
                   </div>
 
@@ -1729,9 +1905,18 @@ export function RequestDetailPage() {
                               )}
 
                               {result.technicalWarnings.length > 0 && (
-                                <details className="mt-1">
-                                  <summary className="cursor-pointer text-xs opacity-75 hover:underline">
-                                    Ostrzezenia techniczne ({result.technicalWarnings.length})
+                                <details className="group mt-1">
+                                  <summary
+                                    onClick={(event) => event.currentTarget.focus()}
+                                    className="flex cursor-pointer list-none items-center gap-2 text-xs opacity-75 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 [&::-webkit-details-marker]:hidden"
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      className="inline-flex h-5 w-5 items-center justify-center rounded border border-current text-[10px] font-semibold transition-transform group-open:rotate-180"
+                                    >
+                                      v
+                                    </span>
+                                    <span>Ostrzezenia techniczne ({result.technicalWarnings.length})</span>
                                   </summary>
                                   <ul className="mt-1 list-inside list-disc space-y-0.5 text-xs">
                                     {result.technicalWarnings.map((warning, index) => (
@@ -1780,44 +1965,50 @@ export function RequestDetailPage() {
         </div>
 
         <div className="space-y-4">
-          <PortingAssignmentPanel
-            assignedUser={request.assignedUser}
-            assignedAt={request.assignedAt}
-            assignedByDisplayName={assignedByDisplayName}
-            historyItems={assignmentHistoryItems}
-            isHistoryLoading={isAssignmentHistoryLoading}
-            canManageAssignment={canManageAssignment}
-            canSelectAssignee={canSelectAssignee}
-            isLoadingAssigneeOptions={isAssignableUsersLoading}
-            assigneeOptions={assigneeOptions}
-            selectedAssigneeId={assigneeDraft}
-            currentUserId={user?.id ?? null}
-            isAssigningToMe={isAssigningToMe}
-            isUpdatingAssignment={isUpdatingAssignment}
-            isUnassigning={isUnassigning}
-            feedbackError={assignmentFeedbackError}
-            feedbackSuccess={assignmentFeedbackSuccess}
-            onSelectedAssigneeIdChange={setAssigneeDraft}
-            onAssignToMe={() => void handleAssignToMe()}
-            onUpdateAssignment={() => void handleUpdateAssignment()}
-            onUnassign={() => void handleUnassign()}
-          />
+          <div id="assignment-panel" className="scroll-mt-6">
+            <PortingAssignmentPanel
+              assignedUser={request.assignedUser}
+              assignedAt={request.assignedAt}
+              assignedByDisplayName={assignedByDisplayName}
+              historyItems={assignmentHistoryItems}
+              isHistoryLoading={isAssignmentHistoryLoading}
+              canManageAssignment={canManageAssignment}
+              canSelectAssignee={canSelectAssignee}
+              isLoadingAssigneeOptions={isAssignableUsersLoading}
+              assigneeOptions={assigneeOptions}
+              selectedAssigneeId={assigneeDraft}
+              currentUserId={user?.id ?? null}
+              isAssigningToMe={isAssigningToMe}
+              isUpdatingAssignment={isUpdatingAssignment}
+              isUnassigning={isUnassigning}
+              feedbackError={assignmentFeedbackError}
+              feedbackSuccess={assignmentFeedbackSuccess}
+              onSelectedAssigneeIdChange={setAssigneeDraft}
+              onAssignToMe={() => void handleAssignToMe()}
+              onUpdateAssignment={() => void handleUpdateAssignment()}
+              onUnassign={() => void handleUnassign()}
+            />
+          </div>
 
           <SectionCard
+            id="commercial-owner-panel"
             title="Opiekun handlowy"
             description="Opcjonalny opiekun handlowy odpowiedzialny za relacje z klientem."
+            compact
           >
             <div className="space-y-3">
               <div>
-                <span className="block text-xs font-medium text-gray-500">Aktualny opiekun</span>
-                {request.commercialOwner ? (
-                  <span className="mt-0.5 block text-sm font-medium text-gray-900">
-                    {request.commercialOwner.displayName}{' '}
-                    <span className="font-normal text-gray-500">({request.commercialOwner.email})</span>
-                  </span>
-                ) : (
-                  <span className="mt-0.5 block text-sm text-gray-400">Brak przypisanego opiekuna</span>
-                )}
+                <span className="block text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">
+                  Aktualny opiekun
+                </span>
+                <span
+                  className={cx(
+                    'mt-1 block text-sm font-semibold',
+                    request.commercialOwner ? 'text-ink-900' : 'text-amber-800',
+                  )}
+                >
+                  {commercialOwnerLabel}
+                </span>
               </div>
 
               {canManageCommercialOwner && (
@@ -1830,7 +2021,7 @@ export function RequestDetailPage() {
                       value={commercialOwnerDraft}
                       onChange={(e) => setCommercialOwnerDraft(e.target.value)}
                       disabled={isUpdatingCommercialOwner || isCommercialOwnerCandidatesLoading}
-                      className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-100 disabled:bg-gray-50 disabled:text-gray-400"
+                      className="input-field"
                     >
                       <option value="">— brak —</option>
                       {commercialOwnerCandidates.map((candidate) => (
@@ -1848,7 +2039,7 @@ export function RequestDetailPage() {
                       disabled={isUpdatingCommercialOwner || isCommercialOwnerCandidatesLoading}
                       className="btn-primary"
                     >
-                      {isUpdatingCommercialOwner ? 'Zapisywanie...' : 'Zapisz'}
+                      {isUpdatingCommercialOwner ? 'Zapis opiekuna' : 'Zapisz'}
                     </button>
                     {request.commercialOwner && (
                       <button
@@ -1878,8 +2069,10 @@ export function RequestDetailPage() {
           </SectionCard>
 
           <SectionCard
-            title="Akcje"
-            description="Frontend tylko pokazuje dozwolone akcje. Backend pozostaje zrodlem prawdy dla workflow."
+            id="workflow-actions"
+            title="Akcje workflow"
+            description="Dostepne przejscia wynikaja z aktualnego statusu sprawy i uprawnien operatora."
+            compact
           >
             {canManageStatus ? (
               <div className="space-y-4">
@@ -1924,7 +2117,7 @@ export function RequestDetailPage() {
                           type="text"
                           value={statusReason}
                           onChange={(event) => setStatusReason(event.target.value)}
-                          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+                          className="input-field"
                           placeholder={selectedStatusAction.reasonLabel ?? 'Podaj powod'}
                         />
                       </label>
@@ -1939,7 +2132,7 @@ export function RequestDetailPage() {
                         value={statusComment}
                         onChange={(event) => setStatusComment(event.target.value)}
                         rows={selectedStatusAction.requiresComment ? 4 : 3}
-                        className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 outline-none transition focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+                        className="input-field"
                         placeholder={
                           selectedStatusAction.requiresComment
                             ? 'Dodaj wymagany komentarz'
@@ -1955,7 +2148,7 @@ export function RequestDetailPage() {
                         className="btn-primary"
                         disabled={isUpdatingStatus || isExporting || isSyncing}
                       >
-                        {isUpdatingStatus ? 'Zapisywanie...' : selectedStatusAction.label}
+                        {isUpdatingStatus ? 'Zapis statusu' : selectedStatusAction.label}
                       </button>
                       <button
                         type="button"
@@ -2011,8 +2204,9 @@ export function RequestDetailPage() {
             )}
           </SectionCard>
 
-          <SectionCard title="Meta" description="Informacje pomocnicze dla obslugi sprawy.">
+          <SectionCard title="Meta" description="Informacje pomocnicze dla obslugi sprawy." compact>
             <dl className="grid grid-cols-1 gap-4">
+              <Field label="Przypisanie BOK" value={assignedUserLabel} />
               <Field label="Utworzono" value={formatDateTime(request.createdAt)} />
               <Field label="Ostatnia zmiana" value={formatDateTime(request.updatedAt)} />
               <Field

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -1,5 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import { Badge, Button, ButtonLink, FilterChip, MetricCard, PageHeader, cx } from '@/components/ui'
 import { buildPath, ROUTES } from '@/constants/routes'
 import { useOperators } from '@/hooks/useOperators'
 import {
@@ -17,13 +18,15 @@ import {
   PORTING_MODE_LABELS,
 } from '@np-manager/shared'
 import type {
+  CommercialOwnerFilter,
+  NotificationHealthFilter,
   NotificationHealthStatus,
   PortingCaseStatus,
   PortingMode,
+  PortingRequestAssigneeSummaryDto,
   PortingRequestListItemDto,
   PortingRequestListResultDto,
   PortingRequestOperationalSummaryDto,
-  PortingRequestAssigneeSummaryDto,
 } from '@np-manager/shared'
 import {
   applyQueryParamUpdates,
@@ -37,6 +40,25 @@ import {
 
 const PAGE_SIZE = 20
 const PORTING_MODES: PortingMode[] = ['DAY', 'END', 'EOP']
+
+const ownershipOptions: Array<{ id: OwnershipFilter; label: string }> = [
+  { id: 'ALL', label: 'Wszystkie' },
+  { id: 'MINE', label: 'Moje sprawy' },
+  { id: 'UNASSIGNED', label: 'Nieprzypisane' },
+]
+
+const commercialOwnerOptions: Array<{ id: CommercialOwnerFilter; label: string }> = [
+  { id: 'ALL', label: 'Wszystkie' },
+  { id: 'WITH_OWNER', label: 'Z opiekunem' },
+  { id: 'WITHOUT_OWNER', label: 'Bez opiekuna' },
+  { id: 'MINE', label: 'Moje handlowe' },
+]
+
+const notificationHealthOptions: Array<{ id: NotificationHealthFilter; label: string }> = [
+  { id: 'ALL', label: 'Wszystkie' },
+  { id: 'HAS_FAILURES', label: 'Bledy notyfikacji' },
+  { id: 'NO_FAILURES', label: 'Bez bledow' },
+]
 
 function parseStatus(value: string | null): PortingCaseStatus | null {
   const valid = Object.values(PORTING_CASE_STATUSES) as PortingCaseStatus[]
@@ -60,45 +82,58 @@ function formatCommercialOwnerLabel(assignee: PortingRequestAssigneeSummaryDto |
   return `${assignee.displayName} (${assignee.email})`
 }
 
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('pl-PL', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  })
+}
+
+function pluralizeRequests(total: number): string {
+  return total === 1 ? 'sprawa' : total < 5 ? 'sprawy' : 'spraw'
+}
+
 function StatusBadge({ status }: { status: PortingCaseStatus }) {
   const meta = getPortingStatusMeta(status)
-  return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${meta.className}`}>
-      {meta.label}
-    </span>
-  )
+  const toneByStatus = {
+    gray: 'neutral',
+    blue: 'brand',
+    amber: 'amber',
+    green: 'green',
+    red: 'red',
+    emerald: 'emerald',
+  } as const
+  const tone = toneByStatus[meta.tone]
+
+  return <Badge tone={tone}>{meta.label}</Badge>
 }
 
 function NotificationHealthBadge({ request }: { request: PortingRequestListItemDto }) {
   const { notificationHealthStatus, notificationFailureCount, notificationLastFailureAt } = request
 
-  const statusConfig: Record<NotificationHealthStatus, { label: string; className: string }> = {
-    OK: { label: 'OK', className: 'bg-emerald-100 text-emerald-700' },
-    FAILED: { label: 'Blad wysylki', className: 'bg-red-100 text-red-700' },
-    MISCONFIGURED: { label: 'Blad konfiguracji', className: 'bg-amber-100 text-amber-700' },
-    MIXED: { label: 'Bledy mieszane', className: 'bg-orange-100 text-orange-700' },
+  const statusConfig: Record<
+    NotificationHealthStatus,
+    { label: string; tone: 'emerald' | 'red' | 'amber' | 'orange' }
+  > = {
+    OK: { label: 'OK', tone: 'emerald' },
+    FAILED: { label: 'Blad wysylki', tone: 'red' },
+    MISCONFIGURED: { label: 'Blad konfiguracji', tone: 'amber' },
+    MIXED: { label: 'Bledy mieszane', tone: 'orange' },
   }
 
   const config = statusConfig[notificationHealthStatus]
 
   if (notificationHealthStatus === 'OK') {
-    return (
-      <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${config.className}`}>
-        OK
-      </span>
-    )
+    return <Badge tone={config.tone}>OK</Badge>
   }
 
-  const lastFailureDate = notificationLastFailureAt
-    ? new Date(notificationLastFailureAt).toLocaleDateString('pl-PL', { day: '2-digit', month: '2-digit', year: 'numeric' })
-    : null
+  const lastFailureDate = notificationLastFailureAt ? formatDate(notificationLastFailureAt) : null
 
   return (
-    <div className="flex flex-col gap-0.5">
-      <span className={`inline-flex items-center rounded px-2 py-0.5 text-xs font-medium ${config.className}`}>
-        {config.label}
-      </span>
-      <span className="text-xs text-gray-400">
+    <div className="flex flex-col gap-1">
+      <Badge tone={config.tone}>{config.label}</Badge>
+      <span className="text-xs leading-5 text-ink-500">
         {notificationFailureCount} {notificationFailureCount === 1 ? 'blad' : 'bledow'}
         {lastFailureDate ? `, ost. ${lastFailureDate}` : ''}
       </span>
@@ -106,35 +141,79 @@ function NotificationHealthBadge({ request }: { request: PortingRequestListItemD
   )
 }
 
+function FilterGroup({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-xs font-semibold uppercase tracking-[0.12em] text-ink-400">
+        {label}
+      </span>
+      <div className="flex flex-wrap gap-2">{children}</div>
+    </div>
+  )
+}
+
 export function RequestRow({
   request,
   onClick,
-  formatDate,
+  formatDate: formatDateValue,
 }: {
   request: PortingRequestListItemDto
   onClick: () => void
   formatDate: (value: string) => string
 }) {
+  const ownerLabel = formatCommercialOwnerLabel(request.commercialOwnerSummary)
+  const assigneeLabel = formatAssigneeLabel(request.assignedUserSummary)
+
   return (
-    <tr onClick={onClick} className="hover:bg-blue-50 cursor-pointer transition-colors">
-      <td className="px-4 py-3 font-mono text-xs text-gray-700 whitespace-nowrap">{request.caseNumber}</td>
-      <td className="px-4 py-3 font-medium text-gray-900 max-w-[200px] truncate">{request.clientDisplayName}</td>
-      <td className="px-4 py-3 text-gray-600 font-mono text-xs whitespace-nowrap">{request.numberDisplay}</td>
-      <td className="px-4 py-3 text-gray-600 max-w-[160px] truncate">{request.donorOperatorName}</td>
-      <td className="px-4 py-3 text-gray-600 whitespace-nowrap">{PORTING_MODE_LABELS[request.portingMode]}</td>
-      <td className="px-4 py-3 whitespace-nowrap">
+    <tr
+      onClick={onClick}
+      className="cursor-pointer border-b border-line transition-colors last:border-b-0 hover:bg-brand-50/70"
+    >
+      <td className="px-5 py-4 align-top">
+        <div className="font-mono text-xs font-semibold text-ink-700">{request.caseNumber}</div>
+        <div className="mt-1 text-xs text-ink-400">{formatDateValue(request.createdAt)}</div>
+      </td>
+      <td className="px-5 py-4 align-top">
+        <div className="max-w-[240px] truncate text-sm font-semibold text-ink-900">
+          {request.clientDisplayName}
+        </div>
+        <div className="mt-1 font-mono text-xs text-ink-500">{request.numberDisplay}</div>
+      </td>
+      <td className="px-5 py-4 align-top">
+        <div className="max-w-[180px] truncate text-sm text-ink-650">{request.donorOperatorName}</div>
+        <div className="mt-1 text-xs font-semibold text-ink-400">
+          {PORTING_MODE_LABELS[request.portingMode]}
+        </div>
+      </td>
+      <td className="px-5 py-4 align-top">
         <StatusBadge status={request.statusInternal} />
       </td>
-      <td className="px-4 py-3 text-gray-600 max-w-[220px] truncate">
-        {formatAssigneeLabel(request.assignedUserSummary)}
+      <td className="px-5 py-4 align-top">
+        <div className="max-w-[220px] truncate text-sm font-medium text-ink-700">
+          {assigneeLabel}
+        </div>
+        <div className="mt-1 text-xs text-ink-400">BOK</div>
       </td>
-      <td className="px-4 py-3 text-gray-600 max-w-[220px] truncate">
-        {formatCommercialOwnerLabel(request.commercialOwnerSummary)}
+      <td className="px-5 py-4 align-top">
+        <div
+          className={cx(
+            'max-w-[260px] truncate text-sm font-semibold',
+            request.commercialOwnerSummary ? 'text-ink-800' : 'text-amber-800',
+          )}
+        >
+          {ownerLabel}
+        </div>
+        <div className="mt-1 text-xs text-ink-400">Opiekun handlowy</div>
       </td>
-      <td className="px-4 py-3 whitespace-nowrap">
+      <td className="px-5 py-4 align-top">
         <NotificationHealthBadge request={request} />
       </td>
-      <td className="px-4 py-3 text-gray-400 text-xs whitespace-nowrap">{formatDate(request.createdAt)}</td>
     </tr>
   )
 }
@@ -244,292 +323,223 @@ export function RequestsPage() {
     void loadData()
   }, [loadData])
 
-  const formatDate = (iso: string) =>
-    new Date(iso).toLocaleDateString('pl-PL', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    })
-
   const { items = [], pagination } = result ?? {}
   const summaryCards = summary ? buildRequestsSummaryCards(summary, filters) : []
 
   return (
-    <div className="p-6 space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">Sprawy portowania</h1>
-          {pagination && (
-            <p className="text-sm text-gray-500 mt-0.5">
-              {pagination.total}{' '}
-              {pagination.total === 1 ? 'sprawa' : pagination.total < 5 ? 'sprawy' : 'spraw'}
-            </p>
-          )}
-        </div>
-        <Link to={ROUTES.REQUEST_NEW} className="btn-primary">
-          + Nowa sprawa
-        </Link>
-      </div>
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="Operacje"
+        title="Sprawy portowania"
+        description={
+          pagination ? (
+            <>
+              {pagination.total} {pluralizeRequests(pagination.total)} w aktualnym widoku.
+            </>
+          ) : (
+            'Lista operacyjna spraw z filtrami ownership, statusu i zdrowia notyfikacji.'
+          )
+        }
+        actions={
+          <ButtonLink to={ROUTES.REQUEST_NEW} variant="primary">
+            + Nowa sprawa
+          </ButtonLink>
+        }
+      />
 
       {summary && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-5 gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-5">
           {summaryCards.map((card) => (
-            <button
+            <MetricCard
               key={card.id}
-              type="button"
+              title={card.title}
+              value={card.value}
+              active={card.isActive}
+              detail={card.id === 'HAS_FAILURES' ? 'Wymaga kontroli operacyjnej' : 'Szybki filtr listy'}
               onClick={() => setParam(card.filterUpdates)}
-              className={`rounded-xl border px-4 py-3 text-left transition-colors ${
-                card.isActive
-                  ? 'border-blue-600 bg-blue-50'
-                  : 'border-gray-200 bg-white hover:border-blue-300 hover:bg-blue-50/40'
-              }`}
-            >
-              <p className="text-xs text-gray-500">{card.title}</p>
-              <p className="mt-1 text-2xl font-semibold text-gray-900">{card.value}</p>
-            </button>
+            />
           ))}
         </div>
       )}
 
-      <div className="card p-4 space-y-3">
-        <div className="grid grid-cols-1 lg:grid-cols-[1fr_220px] gap-3">
-          <input
-            type="search"
-            value={localSearch}
-            onChange={(event) => handleSearchChange(event.target.value)}
-            className="input-field"
-            placeholder="Szukaj po numerze sprawy, numerze telefonu lub nazwie klienta..."
-          />
-          <select
-            value={donorOperatorId}
-            onChange={(event) => {
-              setParam({ donorOperatorId: event.target.value || null, page: null })
-            }}
-            className="input-field"
-          >
-            <option value="">Wszyscy dawcy</option>
-            {operators.map((operator) => (
-              <option key={operator.id} value={operator.id}>
-                {operator.name}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div className="flex flex-wrap gap-2">
-          <button
-            onClick={() => setParam({ status: null, page: null })}
-            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-              !statusFilter
-                ? 'bg-blue-600 text-white'
-                : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
-            }`}
-          >
-            Wszystkie statusy
-          </button>
-          {(Object.values(PORTING_CASE_STATUSES) as PortingCaseStatus[]).map((status) => {
-            const meta = getPortingStatusMeta(status)
-            const isActive = statusFilter === status
-            return (
-              <button
-                key={status}
-                onClick={() => setParam({ status: isActive ? null : status, page: null })}
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? `${meta.className} ring-2 ring-offset-1 ring-current`
-                    : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
-                }`}
-              >
-                {meta.label}
-              </button>
-            )
-          })}
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs text-gray-500 mr-1">Tryb:</span>
-          <button
-            onClick={() => setParam({ portingMode: null, page: null })}
-            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-              !portingModeFilter
-                ? 'bg-blue-600 text-white'
-                : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
-            }`}
-          >
-            Wszystkie
-          </button>
-          {PORTING_MODES.map((mode) => {
-            const isActive = portingModeFilter === mode
-            return (
-              <button
-                key={mode}
-                onClick={() => setParam({ portingMode: isActive ? null : mode, page: null })}
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
-                }`}
-              >
-                {PORTING_MODE_LABELS[mode]}
-              </button>
-            )
-          })}
-
-          {hasActiveFilters && (
-            <button
-              onClick={clearFilters}
-              className="ml-auto px-3 py-1.5 rounded-lg text-sm text-gray-500 hover:text-gray-700 hover:bg-gray-100 transition-colors"
+      <section className="panel overflow-hidden">
+        <div className="border-b border-line px-5 py-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+            <div className="relative flex-1">
+              <input
+                type="search"
+                value={localSearch}
+                onChange={(event) => handleSearchChange(event.target.value)}
+                className="input-field h-11 pl-10"
+                placeholder="Szukaj po numerze sprawy, telefonie lub kliencie..."
+              />
+              <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm font-semibold text-ink-400">
+                S
+              </span>
+            </div>
+            <select
+              value={donorOperatorId}
+              onChange={(event) => {
+                setParam({ donorOperatorId: event.target.value || null, page: null })
+              }}
+              className="input-field h-11 lg:max-w-[260px]"
             >
-              Wyczysc filtry
-            </button>
-          )}
+              <option value="">Wszyscy dawcy</option>
+              {operators.map((operator) => (
+                <option key={operator.id} value={operator.id}>
+                  {operator.name}
+                </option>
+              ))}
+            </select>
+            {hasActiveFilters && (
+              <Button onClick={clearFilters} variant="ghost" className="h-11">
+                Wyczysc filtry
+              </Button>
+            )}
+          </div>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs text-gray-500 mr-1">Przypisanie:</span>
-          {(['ALL', 'MINE', 'UNASSIGNED'] as OwnershipFilter[]).map((filter) => {
-            const isActive = ownershipFilter === filter
-            const label =
-              filter === 'ALL' ? 'Wszystkie' : filter === 'MINE' ? 'Moje sprawy' : 'Nieprzypisane'
+        <div className="grid gap-5 px-5 py-5 xl:grid-cols-[1.15fr_0.85fr]">
+          <FilterGroup label="Status">
+            <FilterChip active={!statusFilter} onClick={() => setParam({ status: null, page: null })}>
+              Wszystkie
+            </FilterChip>
+            {(Object.values(PORTING_CASE_STATUSES) as PortingCaseStatus[]).map((status) => {
+              const meta = getPortingStatusMeta(status)
+              const isActive = statusFilter === status
+              return (
+                <FilterChip
+                  key={status}
+                  active={isActive}
+                  onClick={() => setParam({ status: isActive ? null : status, page: null })}
+                >
+                  {meta.label}
+                </FilterChip>
+              )
+            })}
+          </FilterGroup>
 
-            return (
-              <button
-                key={filter}
-                onClick={() => setParam({ ownership: filter === 'ALL' ? null : filter, page: null })}
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
-                }`}
-              >
-                {label}
-              </button>
-            )
-          })}
-        </div>
+          <FilterGroup label="Tryb portowania">
+            <FilterChip
+              active={!portingModeFilter}
+              onClick={() => setParam({ portingMode: null, page: null })}
+            >
+              Wszystkie
+            </FilterChip>
+            {PORTING_MODES.map((mode) => {
+              const isActive = portingModeFilter === mode
+              return (
+                <FilterChip
+                  key={mode}
+                  active={isActive}
+                  onClick={() => setParam({ portingMode: isActive ? null : mode, page: null })}
+                >
+                  {PORTING_MODE_LABELS[mode]}
+                </FilterChip>
+              )
+            })}
+          </FilterGroup>
 
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs text-gray-500 mr-1">Opiekun handlowy:</span>
-          {(
-            [
-              { id: 'ALL', label: 'Wszystkie' },
-              { id: 'WITH_OWNER', label: 'Z opiekunem' },
-              { id: 'WITHOUT_OWNER', label: 'Bez opiekuna' },
-              { id: 'MINE', label: 'Moje handlowe' },
-            ] as const
-          ).map((filter) => {
-            const isActive = commercialOwnerFilter === filter.id
-
-            return (
-              <button
+          <FilterGroup label="Przypisanie BOK">
+            {ownershipOptions.map((filter) => (
+              <FilterChip
                 key={filter.id}
+                active={ownershipFilter === filter.id}
+                onClick={() => setParam({ ownership: filter.id === 'ALL' ? null : filter.id, page: null })}
+              >
+                {filter.label}
+              </FilterChip>
+            ))}
+          </FilterGroup>
+
+          <FilterGroup label="Opiekun i notyfikacje">
+            {commercialOwnerOptions.map((filter) => (
+              <FilterChip
+                key={filter.id}
+                active={commercialOwnerFilter === filter.id}
                 onClick={() =>
                   setParam({
                     commercialOwnerFilter: filter.id === 'ALL' ? null : filter.id,
                     page: null,
                   })
                 }
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
-                }`}
               >
                 {filter.label}
-              </button>
-            )
-          })}
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-xs text-gray-500 mr-1">Notyfikacje:</span>
-          {(
-            [
-              { id: 'ALL', label: 'Wszystkie' },
-              { id: 'HAS_FAILURES', label: 'Bledy notyfikacji' },
-              { id: 'NO_FAILURES', label: 'Bez bledow' },
-            ] as const
-          ).map((filter) => {
-            const isActive = notificationHealthFilter === filter.id
-
-            return (
-              <button
+              </FilterChip>
+            ))}
+            {notificationHealthOptions.map((filter) => (
+              <FilterChip
                 key={filter.id}
+                active={notificationHealthFilter === filter.id}
                 onClick={() =>
                   setParam({
                     notificationHealthFilter: filter.id === 'ALL' ? null : filter.id,
                     page: null,
                   })
                 }
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-blue-600 text-white'
-                    : 'bg-white text-gray-700 border border-gray-300 hover:bg-gray-50'
-                }`}
               >
                 {filter.label}
-              </button>
-            )
-          })}
+              </FilterChip>
+            ))}
+          </FilterGroup>
         </div>
-      </div>
+      </section>
 
-      <div className="card overflow-hidden">
+      <section className="panel overflow-hidden">
+        <div className="flex items-center justify-between border-b border-line px-5 py-4">
+          <div>
+            <h2 className="text-sm font-semibold text-ink-900">Lista spraw</h2>
+            <p className="mt-1 text-xs text-ink-500">
+              Status, opiekun i health notyfikacji sa widoczne bez wchodzenia w szczegoly.
+            </p>
+          </div>
+          {pagination && (
+            <Badge tone="neutral">
+              {pagination.total} {pluralizeRequests(pagination.total)}
+            </Badge>
+          )}
+        </div>
+
         {isLoading ? (
-          <div className="flex items-center justify-center py-16 text-gray-400 text-sm">Ladowanie...</div>
+          <div className="flex items-center justify-center py-16 text-sm font-medium text-ink-500">
+            Ladowanie listy...
+          </div>
         ) : error ? (
-          <div className="flex flex-col items-center justify-center py-16 gap-3">
-            <p className="text-red-500 text-sm">{error}</p>
-            <button onClick={() => void loadData()} className="btn-secondary text-xs">
+          <div className="flex flex-col items-center justify-center gap-3 py-16">
+            <p className="text-sm font-medium text-red-600">{error}</p>
+            <Button onClick={() => void loadData()} variant="secondary" size="sm">
               Sprobuj ponownie
-            </button>
+            </Button>
           </div>
         ) : items.length === 0 ? (
-          <div className="flex flex-col items-center justify-center py-16 text-gray-400 gap-2">
-            <p className="text-sm font-medium text-gray-600">Brak spraw portowania</p>
-            <p className="text-xs">
+          <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
+            <p className="text-sm font-semibold text-ink-800">Brak spraw portowania</p>
+            <p className="max-w-md text-sm leading-6 text-ink-500">
               {hasActiveFilters
                 ? 'Zadna sprawa nie pasuje do podanych kryteriow.'
                 : 'Utworz pierwsza sprawe przyciskiem powyzej.'}
             </p>
             {hasActiveFilters && (
-              <button onClick={clearFilters} className="btn-secondary text-xs mt-1">
+              <Button onClick={clearFilters} variant="secondary" size="sm">
                 Wyczysc filtry
-              </button>
+              </Button>
             )}
           </div>
         ) : (
           <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead className="bg-gray-50 border-b border-gray-200">
+            <table className="w-full min-w-[1100px] text-sm">
+              <thead className="bg-ink-50 text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
                 <tr>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600 whitespace-nowrap">
-                    Numer sprawy
-                  </th>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600">Klient</th>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600 whitespace-nowrap">
-                    Numer / zakres
-                  </th>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600 whitespace-nowrap">
-                    Operator oddajacy
-                  </th>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600">Tryb</th>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600">Status</th>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600 whitespace-nowrap">
-                    Przypisanie
-                  </th>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600 whitespace-nowrap">
-                    Opiekun handlowy
-                  </th>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600 whitespace-nowrap">
-                    Notyfikacje
-                  </th>
-                  <th className="text-left px-4 py-3 font-medium text-gray-600 whitespace-nowrap">
-                    Utworzono
-                  </th>
+                  <th className="px-5 py-3 text-left">Sprawa</th>
+                  <th className="px-5 py-3 text-left">Klient i numer</th>
+                  <th className="px-5 py-3 text-left">Operator / tryb</th>
+                  <th className="px-5 py-3 text-left">Status</th>
+                  <th className="px-5 py-3 text-left">Przypisanie</th>
+                  <th className="px-5 py-3 text-left">Owner</th>
+                  <th className="min-w-[130px] whitespace-nowrap px-5 py-3 text-left">Notyfikacje</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-100">
+              <tbody>
                 {items.map((request) => (
                   <RequestRow
                     key={request.id}
@@ -542,30 +552,32 @@ export function RequestsPage() {
             </table>
           </div>
         )}
-      </div>
+      </section>
 
       {pagination && pagination.totalPages > 1 && (
-        <div className="flex items-center justify-between">
-          <p className="text-sm text-gray-500">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-ink-500">
             Strona {pagination.page} z {pagination.totalPages}
             {' | '}
             {pagination.total} rekordow
           </p>
           <div className="flex gap-2">
-            <button
+            <Button
               disabled={page <= 1}
               onClick={() => setParam({ page: String(page - 1) })}
-              className="btn-secondary px-3 py-1.5 text-xs disabled:opacity-40"
+              variant="secondary"
+              size="sm"
             >
               Poprzednia
-            </button>
-            <button
+            </Button>
+            <Button
               disabled={page >= pagination.totalPages}
               onClick={() => setParam({ page: String(page + 1) })}
-              className="btn-secondary px-3 py-1.5 text-xs disabled:opacity-40"
+              variant="secondary"
+              size="sm"
             >
               Nastepna
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -5,18 +5,45 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        // Kolory brandowe NP-Manager
         brand: {
+          25: '#f8fbff',
           50: '#eff6ff',
           100: '#dbeafe',
+          200: '#bfdbfe',
+          300: '#93c5fd',
           500: '#3b82f6',
           600: '#2563eb',
           700: '#1d4ed8',
           900: '#1e3a8a',
         },
+        ink: {
+          50: '#f8fafc',
+          100: '#f1f5f9',
+          200: '#e5e7eb',
+          300: '#d1d5db',
+          400: '#9ca3af',
+          500: '#6b7280',
+          600: '#4b5563',
+          650: '#374151',
+          700: '#1f2937',
+          800: '#111827',
+          900: '#0b1220',
+        },
+        surface: '#ffffff',
+        canvas: '#f6f8fb',
+        line: '#e5e7eb',
+        'line-strong': '#d1d5db',
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+      },
+      borderRadius: {
+        ui: '8px',
+        panel: '14px',
+      },
+      boxShadow: {
+        soft: '0 10px 30px rgba(15, 23, 42, 0.08)',
+        panel: '0 18px 50px rgba(15, 23, 42, 0.08)',
       },
     },
   },

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -4,9 +4,9 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 
 ---
 
-## Aktualny stan projektu (2026-04-12)
+## Aktualny stan projektu (2026-04-14)
 
-### Zrealizowane PR-y
+### Stan prac / etapy
 
 | PR    | Opis                                                                 | Status |
 |-------|----------------------------------------------------------------------|--------|
@@ -25,6 +25,10 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR19A-2 | Request-level read layer dla internal notification attempts        | DONE   |
 | PR19B-1 | Backend retry eligibility + request-scoped retry endpoint          | DONE   |
 | PR20E | Full server-side operational status filters for global queue       | DONE   |
+| Etap 2A.1 | Frontend redesign foundation + app shell + RequestsPage          | DONE   |
+| Etap 2A.2 | Frontend redesign RequestDetailPage                              | DONE   |
+| Etap 2A.3 | Operacyjny UX polish po review                                  | DONE   |
+| Etap 2A.4 | Final micro-polish przed zamknieciem 2A                         | DONE   |
 
 ---
 
@@ -217,6 +221,52 @@ Dispatch jest non-blocking (`.catch(() => {})`) i nie blokuje glownego flow API.
   - bez przebudowy historii PR14,
   - bez zmian w customer communication module.
 
+### Etap 2A - redesign frontendowy UI/UX
+
+Zakres pozostaje wylacznie frontendowy: bez zmian backendu, DTO, endpointow, workflow i logiki domenowej.
+
+Etap 2A.1:
+- Dodano lekka foundation UI w `apps/frontend/src/components/ui/`:
+  - `Button`, `ButtonLink`, `Badge`, `FilterChip`, `MetricCard`, `PageHeader`, `cx`.
+- Rozszerzono tokeny Tailwind o spokojny system `brand`, `ink`, `surface`, `canvas`, `line`, radiusy `ui/panel` i cienie `soft/panel`.
+- Przebudowano `AppLayout` na jasniejszy SaaS shell: sidebar, topbar, wrapper tresci.
+- Przeprojektowano `RequestsPage`:
+  - naglowek operacyjny,
+  - summary cards jako szybkie filtry,
+  - pogrupowany panel filtrow,
+  - tabela z mocniej widocznym statusem, ownerem i health notyfikacji.
+- Zachowano istniejace hooki, API calls, URL params i zachowanie biznesowe.
+
+Etap 2A.2:
+- Przeprojektowano `RequestDetailPage` w tym samym kierunku wizualnym:
+  - header sprawy z numerem, klientem, statusem, trybem i szybka akcja,
+  - metryki decyzyjne u gory: status, przypisanie BOK, opiekun handlowy, notyfikacje,
+  - sekcje operacyjne przed historia i diagnostyka,
+  - PLI CBD oraz diagnostyka pozostaja dostepne nizej w sekcjach rozwijanych dla admina.
+- Nie usunieto istniejacych funkcji detail page; zmieniono hierarchie, grupowanie i styling.
+
+Etap 2A.3:
+- Wdrozono frontend-only polish po review bez zmian backendu, DTO, endpointow i workflow.
+- Poprawiono disabled CTA w komunikacji operacyjnej:
+  - zablokowane akcje nie wygladaja jak aktywne primary CTA,
+  - operator widzi powody blokady oraz statusy, w ktorych akcja bedzie dostepna.
+- Dodano lekkie `Szybkie akcje` i shortcuty z kart detail do workflow, przypisania, opiekuna i notyfikacji.
+- Dopracowano empty state historii sprawy oraz usunieto z UI techniczne copy typu foundation/SOAP.
+- Dodano affordance disclosure dla PLI CBD/Diagnostyki.
+
+Etap 2A.4:
+- Wdrozono finalny frontend-only micro-polish przed zamknieciem 2A.
+- Uspojniono disclosure/focus:
+  - caly naglowek sekcji jest klikalny,
+  - focus po toggle pozostaje logicznie na headerze sekcji.
+- Skrocono naglowek kolumny notyfikacji na liscie do `Notyfikacje`.
+- Lekko wzmocniono mikro-linki w gornych kartach detail (`Akcje`, `Zmien`, `Historia`) bez robienia z nich duzych CTA.
+- Routing po `requestNumber` pozostaje osobnym follow-upem poza zakresem 2A.
+
+Otwarte:
+- Po pozytywnym smoke tescie w przegladarce Etap 2A moze zostac zamkniety.
+- Etap 2A nie oznacza jeszcze redesignu wszystkich ekranow; kolejne widoki powinny korzystac z `components/ui`.
+
 #### Konfiguracja transportu email
 
 ```env
@@ -297,6 +347,8 @@ packages/shared/src/
   dto/porting-internal-notifications.dto.ts # historia + DTO attempts (PR19A-2)
 
 apps/frontend/src/
+  components/ui/                 # Etap 2A frontend foundation
+  components/layout/AppLayout.tsx # Etap 2A app shell
   components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx
   components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.tsx
   pages/Requests/RequestDetailPage.tsx


### PR DESCRIPTION
## 1. Cel

Domkniecie etapu 2A redesignu frontendowego NP-Managera: foundation UI, RequestsPage, RequestDetailPage oraz finalny operacyjny UX polish po review.

## 2. Zakres zmian

- Dodano lekka warstwe UI foundation (`Button`, `Badge`, `FilterChip`, `MetricCard`, `PageHeader`) oraz tokeny Tailwind dla nowego shellu.
- Przebudowano `AppLayout` na jasniejszy operacyjny SaaS shell.
- Odświezono `RequestsPage`: naglowek, summary cards, filtry i tabela z czytelniejszym statusem/opiekunem/notyfikacjami.
- Odświezono `RequestDetailPage`: header sprawy, metryki, szybkie akcje, sekcje operacyjne, komunikacja, notyfikacje, historia i disclosure admin.
- Poprawiono UX komunikacji: zablokowane akcje sa wizualnie disabled i maja bardziej operacyjne powody blokady.
- Dopracowano disclosure/focus, empty states, copy administracyjne oraz kolumne notyfikacji.
- Zaktualizowano dokumentacje ciaglosci projektu.

## 3. Zmienione pliki / obszary

- `apps/frontend/src/components/ui/`
- `apps/frontend/src/components/layout/AppLayout.tsx`
- `apps/frontend/src/pages/Requests/RequestsPage.tsx`
- `apps/frontend/src/pages/Requests/RequestDetailPage.tsx`
- `apps/frontend/src/components/PortingCommunicationPanel/`
- `apps/frontend/src/components/PortingCaseHistory/`
- `apps/frontend/src/components/PliCbd*/`
- `apps/frontend/src/index.css`
- `apps/frontend/tailwind.config.ts`
- `AGENTS.md`
- `CLAUDE.md`
- `docs/PROJECT_CONTINUITY.md`

## 4. Testy i walidacja

- `npx tsc --noEmit` w `apps/frontend` - PASS
- `npm run test` w `apps/frontend` - PASS, 29 plikow, 157 testow
- `npm run build` w `apps/frontend` - PASS
- `npm run build -w packages/shared` - PASS
- `npx tsc --noEmit` w `apps/backend` - PASS
- `git diff --check` dla zmienianych plikow - PASS
- Smoke HTTP dev servera na `http://127.0.0.1:5175/` - PASS

Uwagi walidacyjne:
- Vitest emituje istniejace ostrzezenia React Router/useLayoutEffect SSR.
- Vite emituje istniejacy warning o chunku >500 kB.
- Git lokalnie ostrzega o konwersji LF -> CRLF.

## 5. Ryzyka / otwarte punkty

- Wymagany finalny manualny visual QA na danych podobnych do produkcyjnych przed zamknieciem 2A.
- Routing po `requestNumber` pozostaje osobnym taskiem poza zakresem tego PR.
- Nie zmieniano backendu, DTO, endpointow, workflow ani logiki domenowej.

## 6. Checklist przed merge

- [ ] Manualnie przeklikac RequestsPage.
- [ ] Manualnie przeklikac RequestDetailPage, w tym komunikacje i disclosure PLI CBD/Diagnostyka.
- [ ] Potwierdzic, ze 2A moze zostac zamkniete po smoke tescie.
