### PR TITLE
Codex/zdefiniuj filozofi produktu

### DIFF
--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -23,6 +23,7 @@ import {
   getPortingRequestAssignmentHistory,
   getPortingRequestIntegrationEvents,
   getPortingRequest,
+  getPortingRequestByCaseNumber,
   listAssignablePortingRequestUsers,
   listCommercialOwnerCandidates,
   listPortingRequests,
@@ -386,6 +387,18 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
         request.headers['user-agent'],
       )
 
+      return reply.status(200).send({ success: true, data: { request: portingRequest } })
+    },
+  )
+
+  app.get<{ Params: { caseNumber: string } }>(
+    '/by-case-number/:caseNumber',
+    { preHandler: [authenticate, authorize(readRoles)] },
+    async (request, reply) => {
+      const portingRequest = await getPortingRequestByCaseNumber(
+        request.params.caseNumber,
+        request.user.role as UserRole,
+      )
       return reply.status(200).send({ success: true, data: { request: portingRequest } })
     },
   )

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -1069,6 +1069,22 @@ export async function getPortingRequest(
   return toDetailDto(request, actorRole, communicationHistory)
 }
 
+export async function getPortingRequestByCaseNumber(
+  caseNumber: string,
+  actorRole: UserRole,
+): Promise<PortingRequestDetailDto> {
+  const requestStub = await prisma.portingRequest.findUnique({
+    where: { caseNumber },
+    select: { id: true },
+  })
+
+  if (!requestStub) {
+    throw AppError.notFound('Sprawa portowania nie zostala znaleziona.')
+  }
+
+  return getPortingRequest(requestStub.id, actorRole)
+}
+
 export async function updatePortingRequestAssignment(
   requestId: string,
   body: UpdatePortingRequestAssignmentBody,

--- a/apps/frontend/src/constants/routes.ts
+++ b/apps/frontend/src/constants/routes.ts
@@ -13,7 +13,7 @@ export const ROUTES = {
   // Sprawy portabilności
   REQUESTS: '/requests',
   REQUEST_NEW: '/requests/new',
-  REQUEST_DETAIL: '/requests/:id',
+  REQUEST_DETAIL: '/requests/:caseNumber',
 
   // Klienci
   CLIENTS: '/clients',
@@ -52,9 +52,9 @@ export const ROUTES = {
 export type AppRoute = (typeof ROUTES)[keyof typeof ROUTES]
 
 /**
- * Generuje ścieżkę ze wstawionym parametrem ID.
- * Przykład: buildPath(ROUTES.REQUEST_DETAIL, '123') → '/requests/123'
+ * Generuje ścieżkę ze wstawionym parametrem.
+ * Przykład: buildPath(ROUTES.REQUEST_DETAIL, 'NP/2024/001') → '/requests/NP/2024/001'
  */
-export function buildPath(route: string, id: string): string {
-  return route.replace(':id', id)
+export function buildPath(route: string, param: string): string {
+  return route.replace(/:[^/]+/, param)
 }

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import axios from 'axios'
-import { useNavigate, useParams } from 'react-router-dom'
-import { ROUTES } from '@/constants/routes'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
+import { buildPath, ROUTES } from '@/constants/routes'
 import { useAuthStore } from '@/stores/auth.store'
 import { Badge, Button, ButtonLink, type BadgeTone, cx } from '@/components/ui'
 import {
@@ -13,6 +13,7 @@ import {
   getPortingRequestAssignmentHistory,
   getPortingCommunicationDeliveryAttempts,
   getPortingRequestById,
+  getPortingRequestByCaseNumber,
   getPortingRequestCaseHistory,
   getPortingRequestCommunicationHistory,
   getPortingRequestInternalNotificationAttempts,
@@ -455,13 +456,23 @@ function NotificationHealthPanel({ health }: { health: NotificationHealthDiagnos
   )
 }
 
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 export function RequestDetailPage() {
-  const { id } = useParams<{ id: string }>()
+  const { caseNumber } = useParams<{ caseNumber: string }>()
   const navigate = useNavigate()
+  const location = useLocation()
   const { user } = useAuthStore()
+
+  // UUID of the loaded request — used by all secondary API calls and mutations.
+  // Populated by loadRequest after the first successful fetch.
+  const [internalId, setInternalId] = useState<string>('')
+  // Alias so all existing mutations and secondary callbacks keep working unchanged.
+  const id = internalId
 
   const [request, setRequest] = useState<PortingRequestDetailDto | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const [caseHistoryItems, setCaseHistoryItems] = useState<PortingRequestCaseHistoryItemDto[]>([])
@@ -664,13 +675,25 @@ export function RequestDetailPage() {
   }, [])
 
   const loadRequest = useCallback(async () => {
-    if (!id) return
+    if (!caseNumber) return
 
     setIsLoading(true)
     setError(null)
+    setNotFound(false)
 
     try {
-      const nextRequest = await getPortingRequestById(id)
+      let nextRequest: PortingRequestDetailDto
+
+      if (UUID_REGEX.test(caseNumber)) {
+        // Legacy UUID in URL — fetch by ID, then redirect to canonical caseNumber URL.
+        nextRequest = await getPortingRequestById(caseNumber)
+        navigate(buildPath(ROUTES.REQUEST_DETAIL, nextRequest.caseNumber), { replace: true })
+        return
+      } else {
+        nextRequest = await getPortingRequestByCaseNumber(caseNumber)
+      }
+
+      setInternalId(nextRequest.id)
       setRequest(nextRequest)
       setAssigneeDraft(nextRequest.assignedUser?.id ?? '')
       setCommercialOwnerDraft(nextRequest.commercialOwner?.id ?? '')
@@ -690,18 +713,19 @@ export function RequestDetailPage() {
           : null,
       )
     } catch (err) {
-      const detail =
-        axios.isAxiosError(err) && err.response
-          ? ` (HTTP ${err.response.status})`
-          : ''
-      setError(`Nie udalo sie zaladowac szczegolow sprawy portowania.${detail}`)
+      if (axios.isAxiosError(err) && err.response?.status === 404) {
+        setNotFound(true)
+      } else {
+        const detail = axios.isAxiosError(err) && err.response ? ` (HTTP ${err.response.status})` : ''
+        setError(`Nie udało się załadować szczegółów sprawy portowania.${detail}`)
+      }
       if (import.meta.env.DEV) {
         console.error('[RequestDetailPage] loadRequest failed:', err)
       }
     } finally {
       setIsLoading(false)
     }
-  }, [id])
+  }, [caseNumber, navigate])
 
   const loadCaseHistory = useCallback(async () => {
     if (!id) return
@@ -998,15 +1022,25 @@ export function RequestDetailPage() {
     }
   }, [id, isAdmin])
 
+  // Effect 1: fires on URL change — resets UI state and triggers primary load.
   useEffect(() => {
+    setInternalId('')
+    setRequest(null)
+    setNotFound(false)
+    setError(null)
     resetCommunicationFeedback()
     setCommunicationPreview(null)
     setAssignmentFeedbackError(null)
     setAssignmentFeedbackSuccess(null)
 
-    if (!id) return
-
+    if (!caseNumber) return
     void loadRequest()
+  }, [caseNumber, loadRequest, resetCommunicationFeedback])
+
+  // Effect 2: fires once internalId is known — triggers all secondary data loads.
+  useEffect(() => {
+    if (!internalId) return
+
     void loadCaseHistory()
     void loadInternalNotificationHistory()
     void loadInternalNotificationAttempts()
@@ -1021,7 +1055,7 @@ export function RequestDetailPage() {
     void loadTechnicalPayloads()
     void loadXmlPreviews()
   }, [
-    id,
+    internalId,
     loadAssignableUsers,
     loadAssignmentHistory,
     loadCaseHistory,
@@ -1032,11 +1066,9 @@ export function RequestDetailPage() {
     loadCommunicationHistory,
     loadIntegrationEvents,
     loadProcessSnapshot,
-    loadRequest,
     loadTechnicalPayloads,
     loadXmlPreviews,
     refreshDraftPreviews,
-    resetCommunicationFeedback,
   ])
 
   useEffect(() => {
@@ -1520,7 +1552,29 @@ export function RequestDetailPage() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-24 text-sm font-medium text-ink-500">
-        Ladowanie szczegolow sprawy...
+        Ładowanie szczegółów sprawy...
+      </div>
+    )
+  }
+
+  const backToList = () => {
+    if (location.state?.fromList) {
+      void navigate(ROUTES.REQUESTS + (location.state.listSearch ?? ''))
+    } else {
+      void navigate(ROUTES.REQUESTS)
+    }
+  }
+
+  if (notFound) {
+    return (
+      <div className="panel p-10 text-center">
+        <p className="mb-1 text-base font-semibold text-ink-900">Sprawa nie istnieje</p>
+        <p className="mb-6 text-sm text-ink-500">
+          Nie znaleziono sprawy o numerze <span className="font-mono font-medium text-ink-700">{caseNumber}</span>.
+        </p>
+        <Button onClick={backToList} variant="secondary">
+          Wróć do listy spraw
+        </Button>
       </div>
     )
   }
@@ -1529,10 +1583,10 @@ export function RequestDetailPage() {
     return (
       <div className="panel p-8 text-center">
         <p className="mb-4 text-sm font-medium text-red-600">
-          {error ?? 'Sprawa nie zostala znaleziona.'}
+          {error ?? 'Nie udało się załadować sprawy.'}
         </p>
-        <Button onClick={() => void navigate(ROUTES.REQUESTS)} variant="secondary">
-          Wroc do listy
+        <Button onClick={backToList} variant="secondary">
+          Wróć do listy
         </Button>
       </div>
     )
@@ -1556,7 +1610,7 @@ export function RequestDetailPage() {
           <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
             <div className="min-w-0">
               <Button
-                onClick={() => void navigate(ROUTES.REQUESTS)}
+                onClick={backToList}
                 variant="ghost"
                 size="sm"
                 className="mb-3 -ml-2"

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useNavigate, useSearchParams, useLocation } from 'react-router-dom'
 import { Badge, Button, ButtonLink, FilterChip, MetricCard, PageHeader, cx } from '@/components/ui'
 import { buildPath, ROUTES } from '@/constants/routes'
 import { useOperators } from '@/hooks/useOperators'
@@ -220,6 +220,7 @@ export function RequestRow({
 
 export function RequestsPage() {
   const navigate = useNavigate()
+  const location = useLocation()
   const { operators } = useOperators()
   const [searchParams, setSearchParams] = useSearchParams()
 
@@ -544,7 +545,11 @@ export function RequestsPage() {
                   <RequestRow
                     key={request.id}
                     request={request}
-                    onClick={() => void navigate(buildPath(ROUTES.REQUEST_DETAIL, request.id))}
+                    onClick={() =>
+                      void navigate(buildPath(ROUTES.REQUEST_DETAIL, request.caseNumber), {
+                        state: { fromList: true, listSearch: location.search },
+                      })
+                    }
                     formatDate={formatDate}
                   />
                 ))}

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -114,6 +114,17 @@ export async function getPortingRequestById(id: string): Promise<PortingRequestD
   return response.data.data.request
 }
 
+export async function getPortingRequestByCaseNumber(
+  caseNumber: string,
+): Promise<PortingRequestDetailDto> {
+  const response = await apiClient.get<{
+    success: true
+    data: { request: PortingRequestDetailDto }
+  }>(`/porting-requests/by-case-number/${encodeURIComponent(caseNumber)}`)
+
+  return response.data.data.request
+}
+
 export async function createPortingRequest(
   data: CreatePortingRequestPayload,
 ): Promise<PortingRequestDetailDto> {

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -4,7 +4,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 
 ---
 
-## Aktualny stan projektu (2026-04-14)
+## Aktualny stan projektu (2026-04-15)
 
 ### Stan prac / etapy
 
@@ -29,6 +29,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | Etap 2A.2 | Frontend redesign RequestDetailPage                              | DONE   |
 | Etap 2A.3 | Operacyjny UX polish po review                                  | DONE   |
 | Etap 2A.4 | Final micro-polish przed zamknieciem 2A                         | DONE   |
+| Etap 2B   | Routing/deeplinks/nawigacja lista-detail (canonical URL, UUID redirect, filtr po powrocie) | DONE |
 
 ---
 
@@ -261,10 +262,33 @@ Etap 2A.4:
   - focus po toggle pozostaje logicznie na headerze sekcji.
 - Skrocono naglowek kolumny notyfikacji na liscie do `Notyfikacje`.
 - Lekko wzmocniono mikro-linki w gornych kartach detail (`Akcje`, `Zmien`, `Historia`) bez robienia z nich duzych CTA.
-- Routing po `requestNumber` pozostaje osobnym follow-upem poza zakresem 2A.
+- Routing po `caseNumber` zrealizowany w Etapie 2B.
 
-Otwarte:
-- Po pozytywnym smoke tescie w przegladarce Etap 2A moze zostac zamkniety.
+### Etap 2B - routing/deeplinks/nawigacja lista-detail
+
+- Frontend:
+  - `ROUTES.REQUEST_DETAIL` zmieniony z `/requests/:id` na `/requests/:caseNumber` (canonical URL po biznesowym numerze sprawy).
+  - `buildPath` w `routes.ts` zgeneralizowany do `route.replace(/:[^/]+/, param)`.
+  - `RequestsPage`: klik w liste naviguje po `request.caseNumber` + przekazuje `location.state = { fromList: true, listSearch: location.search }`.
+  - `RequestDetailPage`:
+    - `useParams<{caseNumber}>()` zamiast `{id}`,
+    - `UUID_REGEX` detekcja: jesli URL jest UUID → `getPortingRequestById` + silent redirect na canonical `/requests/:caseNumber`,
+    - jesli URL jest caseNumber → `getPortingRequestByCaseNumber`,
+    - `internalId` / `const id = internalId` alias dla wstecznej kompatybilnosci z istniejacymi mutacjami,
+    - podzielony useEffect: Effect 1 reaguje na `caseNumber` (URL), Effect 2 na `internalId`,
+    - `backToList()` zwraca do listy z zachowanymi filterami z `location.state.listSearch`,
+    - `notFound` state i 404 UI z numerem sprawy.
+  - `portingRequests.api.ts`: nowa funkcja `getPortingRequestByCaseNumber` → `GET /porting-requests/by-case-number/:caseNumber`.
+- Backend:
+  - Nowy endpoint `GET /api/porting-requests/by-case-number/:caseNumber` zarejestrowany PRZED `/:id` (Fastify route tree).
+  - Nowa funkcja `getPortingRequestByCaseNumber(caseNumber, role)` w service — `findUnique({where:{caseNumber}})` + delegacja do `getPortingRequest(id, role)`.
+- Weryfikacja 2B:
+  - backend: 428 testow PASS,
+  - frontend: 157 testow PASS,
+  - `npx tsc --noEmit` PASS w obu appkach,
+  - runtime: `GET /api/porting-requests/by-case-number/FNP-20260409-921D05` → 200, invalid caseNumber → 404 biznesowy, UUID przez stary endpoint → 200, brak tokenu → 401,
+  - QA reczne 4/4 PASS (lista→detail po caseNumber, deeplink, UUID redirect, powrot z filtrem).
+- Stare UUID URL (`/requests/:uuid`) sa w pelni wstecznie kompatybilne — silent redirect do canonical.
 - Etap 2A nie oznacza jeszcze redesignu wszystkich ekranow; kolejne widoki powinny korzystac z `components/ui`.
 
 #### Konfiguracja transportu email


### PR DESCRIPTION
Etap 2B zakończony i ręcznie zweryfikowany na właściwym runtime.

Finalne QA: 4/4 PASS
- lista -> detail używa canonical URL /requests/:caseNumber
- bezpośredni deeplink po caseNumber działa
- legacy UUID URL robi silent redirect do /requests/:caseNumber
- powrót do listy zachowuje filtry/query params

Wcześniejsze false fail wynikały ze stale/orphaned runtime processes, nie z błędu implementacji.
Etap 2B gotowy do merge.