### PR TITLE
feat(3a): assignment closeout — panel polish + dead code removal

### DIFF
--- a/apps/frontend/src/components/PortingAssignmentPanel/PortingAssignmentPanel.tsx
+++ b/apps/frontend/src/components/PortingAssignmentPanel/PortingAssignmentPanel.tsx
@@ -75,7 +75,7 @@ export function PortingAssignmentPanel({
   const isAnyAssignmentActionLoading = isAssigningToMe || isUpdatingAssignment || isUnassigning
 
   return (
-    <div className="card p-5" data-testid="porting-assignment-panel">
+    <div className="panel p-5" data-testid="porting-assignment-panel">
       <div className="mb-4">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">Przypisanie</h2>
         <p className="mt-1 text-sm text-gray-500">Kto aktualnie prowadzi te sprawe.</p>

--- a/apps/frontend/src/lib/portingOwnership.test.ts
+++ b/apps/frontend/src/lib/portingOwnership.test.ts
@@ -1,49 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import type {
-  PortingRequestAssignmentHistoryItemDto,
-  PortingRequestListItemDto,
-} from '@np-manager/shared'
+import type { PortingRequestAssignmentHistoryItemDto } from '@np-manager/shared'
 import {
   canManagePortingOwnership,
   canSelectAnyAssignee,
-  filterPortingRequestsByOwnership,
   formatAssigneeLabel,
   formatAssignmentHistoryHeadline,
   parseOwnershipFilter,
 } from './portingOwnership'
-
-function buildListItem(
-  id: string,
-  assignedUserId: string | null,
-  assignedDisplayName = 'Jan Kowalski',
-): PortingRequestListItemDto {
-  return {
-    id,
-    caseNumber: `SPR-${id}`,
-    clientId: 'client-1',
-    clientDisplayName: 'Klient testowy',
-    numberDisplay: '221234567',
-    donorOperatorId: 'operator-1',
-    donorOperatorName: 'Orange',
-    portingMode: 'DAY',
-    statusInternal: 'SUBMITTED',
-    assignedUserSummary: assignedUserId
-      ? {
-          id: assignedUserId,
-          email: `${assignedUserId}@np-manager.local`,
-          displayName: assignedDisplayName,
-          role: 'BOK_CONSULTANT',
-        }
-      : null,
-    commercialOwnerSummary: null,
-    hasNotificationFailures: false,
-    notificationHealthStatus: 'OK',
-    notificationFailureCount: 0,
-    notificationLastFailureAt: null,
-    notificationLastFailureOutcome: null,
-    createdAt: '2026-04-09T10:00:00.000Z',
-  }
-}
 
 describe('portingOwnership helpers', () => {
   it('formats assignee labels for assigned and unassigned cases', () => {
@@ -56,32 +19,6 @@ describe('portingOwnership helpers', () => {
       }),
     ).toBe('Jan Kowalski (user-1@np-manager.local)')
     expect(formatAssigneeLabel(null)).toBe('Nieprzypisana')
-  })
-
-  it('filters list to my requests', () => {
-    const items = [
-      buildListItem('1', 'user-1'),
-      buildListItem('2', 'user-2'),
-      buildListItem('3', null),
-    ]
-
-    const result = filterPortingRequestsByOwnership(items, 'MINE', 'user-1')
-
-    expect(result).toHaveLength(1)
-    expect(result[0]?.id).toBe('1')
-  })
-
-  it('filters list to unassigned requests', () => {
-    const items = [
-      buildListItem('1', 'user-1'),
-      buildListItem('2', null),
-      buildListItem('3', null),
-    ]
-
-    const result = filterPortingRequestsByOwnership(items, 'UNASSIGNED', 'user-1')
-
-    expect(result).toHaveLength(2)
-    expect(result.map((item) => item.id)).toEqual(['2', '3'])
   })
 
   it('builds readable assignment history headline', () => {

--- a/apps/frontend/src/lib/portingOwnership.ts
+++ b/apps/frontend/src/lib/portingOwnership.ts
@@ -1,7 +1,6 @@
 import type {
   PortingRequestAssigneeSummaryDto,
   PortingRequestAssignmentHistoryItemDto,
-  PortingRequestListItemDto,
   UserRole,
 } from '@np-manager/shared'
 
@@ -13,26 +12,6 @@ export function parseOwnershipFilter(value: string | null): OwnershipFilter {
   }
 
   return 'ALL'
-}
-
-export function filterPortingRequestsByOwnership(
-  items: PortingRequestListItemDto[],
-  ownershipFilter: OwnershipFilter,
-  currentUserId: string | null | undefined,
-): PortingRequestListItemDto[] {
-  if (ownershipFilter === 'MINE') {
-    if (!currentUserId) {
-      return []
-    }
-
-    return items.filter((item) => item.assignedUserSummary?.id === currentUserId)
-  }
-
-  if (ownershipFilter === 'UNASSIGNED') {
-    return items.filter((item) => item.assignedUserSummary === null)
-  }
-
-  return items
 }
 
 export function formatAssigneeLabel(assignee: PortingRequestAssigneeSummaryDto | null): string {

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -30,6 +30,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | Etap 2A.3 | Operacyjny UX polish po review                                  | DONE   |
 | Etap 2A.4 | Final micro-polish przed zamknieciem 2A                         | DONE   |
 | Etap 2B   | Routing/deeplinks/nawigacja lista-detail (canonical URL, UUID redirect, filtr po powrocie) | DONE |
+| Etap 3A   | Assignment closeout: visual polish PortingAssignmentPanel + usun martwy kod filterPortingRequestsByOwnership | DONE |
 
 ---
 
@@ -290,6 +291,22 @@ Etap 2A.4:
   - QA reczne 4/4 PASS (lista→detail po caseNumber, deeplink, UUID redirect, powrot z filtrem).
 - Stare UUID URL (`/requests/:uuid`) sa w pelni wstecznie kompatybilne — silent redirect do canonical.
 - Etap 2A nie oznacza jeszcze redesignu wszystkich ekranow; kolejne widoki powinny korzystac z `components/ui`.
+
+### Etap 3A - assignment / ownership closeout
+
+Wszystkie funkcje assignment zostaly zaimplementowane wczesniej (PR12C, PR12D). Etap 3A to wylacznie closeout: polish wizualny + usuniecie martwego kodu. Nie bylo nowych funkcji ani zmian backendu.
+
+Zmiany:
+- `PortingAssignmentPanel`: klasa `.card` zamieniona na `.panel` — spojnosci z `SectionCard` uzywana w sasiednich sekcjach `RequestDetailPage` (roznica: `shadow-sm` vs `shadow-panel`).
+- `portingOwnership.ts`: usunieto `filterPortingRequestsByOwnership` — funkcja stala sie martwym kodem po przeniesieniu filtrow ownership na backend w PR12D; nie byla uzywana produkcyjnie.
+- `portingOwnership.test.ts`: usunieto 2 testy i helper `buildListItem` ktore testowaly wylacznie usunieta funkcje.
+- `docs/PROJECT_CONTINUITY.md`: zaktualizowano o Etap 3A.
+
+Stan assignment po closeout:
+- Detail: `PortingAssignmentPanel` — aktualny opiekun, "Przypisz do mnie", zmiana assignee (ADMIN/BOK_CONSULTANT), zdejmij przypisanie, historia przypisan.
+- Lista: filtry `Moje sprawy` / `Nieprzypisane` — server-side, JWT-based, bez query manipulation.
+- RBAC: assign-to-self i reassign = ADMIN + BOK_CONSULTANT; historia = wszyscy zalogowani.
+- Weryfikacja 3A: frontend 155 testow PASS, tsc PASS w obu appkach.
 
 #### Konfiguracja transportu email
 


### PR DESCRIPTION
## Summary

Zamknięcie Etapu 3A. Cała logika assignment (panel, endpointy, RBAC, historia, filtry listy) była już zaimplementowana w PR12C i PR12D. Ten PR zawiera wyłącznie polish wizualny i cleanup martwego kodu.

- **`PortingAssignmentPanel`** — klasa `.card` → `.panel`; wyrównanie cienia do `SectionCard` używanej w sąsiednich sekcjach `RequestDetailPage` (`shadow-sm` → `shadow-panel`)
- **`portingOwnership.ts`** — usunięto `filterPortingRequestsByOwnership`; funkcja stała się martwym kodem gdy PR12D przeniósł filtry MINE/UNASSIGNED na backend (serwer używa `request.user.id` z JWT, nie query manipulation po stronie klienta)
- **`portingOwnership.test.ts`** — usunięto 2 testy i helper `buildListItem` testujące wyłącznie usuniętą funkcję
- **`docs/PROJECT_CONTINUITY.md`** — wpis Etap 3A w tabeli stanów + sekcja architektoniczna

## Test plan

- [ ] Frontend: `npx vitest run` → **155 passed** (delta: −2 testy martwego kodu)
- [ ] Frontend: `npx tsc --noEmit` → **0 błędów**
- [ ] Backend: bez zmian (358 unit testów PASS, tsc PASS)
- [ ] Manual: detail sprawy — sekcja Przypisanie wizualnie spójna z sąsiednimi sekcjami
- [ ] Manual: lista — filtry "Moje sprawy" / "Nieprzypisane" działają (server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)