### PR TITLE
feat(2c): auth return-to-target, 404/error polish, copy-link

### DIFF
--- a/apps/frontend/src/lib/authFlow.test.ts
+++ b/apps/frontend/src/lib/authFlow.test.ts
@@ -4,6 +4,7 @@ import {
   getForcePasswordChangeErrorMessage,
   getForcePasswordChangeRouteRedirect,
   getProtectedRouteRedirect,
+  resolvePostLoginDestination,
   validateForcePasswordChangeForm,
 } from './authFlow'
 
@@ -151,5 +152,48 @@ describe('authFlow helpers', () => {
     }
 
     expect(getForcePasswordChangeErrorMessage(error)).toBe('Obecne hasło jest nieprawidłowe.')
+  })
+})
+
+describe('resolvePostLoginDestination', () => {
+  const normalUser = { forcePasswordChange: false }
+  const lockedUser = { forcePasswordChange: true }
+
+  it('returns dashboard when no `from` is provided', () => {
+    expect(resolvePostLoginDestination(normalUser, undefined)).toBe('/')
+  })
+
+  it('returns dashboard when `from` is null', () => {
+    expect(resolvePostLoginDestination(normalUser, null)).toBe('/')
+  })
+
+  it('returns `from` when it is a valid internal path', () => {
+    expect(resolvePostLoginDestination(normalUser, '/requests/FNP-2026-001')).toBe(
+      '/requests/FNP-2026-001',
+    )
+  })
+
+  it('returns `from` preserving query params', () => {
+    expect(resolvePostLoginDestination(normalUser, '/requests?status=SUBMITTED')).toBe(
+      '/requests?status=SUBMITTED',
+    )
+  })
+
+  it('rejects `from` equal to /login (avoids redirect loop)', () => {
+    expect(resolvePostLoginDestination(normalUser, '/login')).toBe('/')
+  })
+
+  it('rejects `from` that does not start with / (external URL)', () => {
+    expect(resolvePostLoginDestination(normalUser, 'https://evil.com')).toBe('/')
+  })
+
+  it('forcePasswordChange always takes priority over valid `from`', () => {
+    expect(resolvePostLoginDestination(lockedUser, '/requests/FNP-2026-001')).toBe(
+      '/force-password-change',
+    )
+  })
+
+  it('forcePasswordChange takes priority even when `from` is absent', () => {
+    expect(resolvePostLoginDestination(lockedUser, undefined)).toBe('/force-password-change')
   })
 })

--- a/apps/frontend/src/lib/authFlow.ts
+++ b/apps/frontend/src/lib/authFlow.ts
@@ -24,6 +24,34 @@ export function getDefaultAuthenticatedRoute(user: Pick<AuthUser, 'forcePassword
   return user.forcePasswordChange ? ROUTES.FORCE_PASSWORD_CHANGE : ROUTES.DASHBOARD
 }
 
+/**
+ * Resolves the post-login redirect destination.
+ *
+ * Priority:
+ * 1. forcePasswordChange → /force-password-change (security, always)
+ * 2. valid `from` URL → return-to-target (deeplink flow)
+ * 3. fallback → dashboard
+ *
+ * A `from` value is considered valid when it:
+ * - is a non-empty string
+ * - starts with `/` (internal path, not external)
+ * - is not the login route itself (avoids redirect loop)
+ */
+export function resolvePostLoginDestination(
+  user: Pick<AuthUser, 'forcePasswordChange'>,
+  from: string | undefined | null,
+): string {
+  if (user.forcePasswordChange) {
+    return ROUTES.FORCE_PASSWORD_CHANGE
+  }
+
+  if (from && from.startsWith('/') && from !== ROUTES.LOGIN) {
+    return from
+  }
+
+  return ROUTES.DASHBOARD
+}
+
 export function getProtectedRouteRedirect(params: {
   isAuthenticated: boolean
   user: AuthUser | null

--- a/apps/frontend/src/pages/Login/LoginPage.tsx
+++ b/apps/frontend/src/pages/Login/LoginPage.tsx
@@ -1,8 +1,8 @@
 import { useState, type FormEvent } from 'react'
 import axios from 'axios'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import type { AuthUser } from '@np-manager/shared'
-import { getDefaultAuthenticatedRoute } from '@/lib/authFlow'
+import { resolvePostLoginDestination } from '@/lib/authFlow'
 import { apiClient } from '@/services/api.client'
 import { useAuthStore } from '@/stores/auth.store'
 
@@ -32,7 +32,11 @@ export function LoginPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const navigate = useNavigate()
+  const location = useLocation()
   const setAuth = useAuthStore((state) => state.setAuth)
+
+  // Target URL passed by ProtectedRoute when redirecting unauthenticated visitors to /login.
+  const from = (location.state as { from?: string } | null)?.from
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
@@ -56,7 +60,7 @@ export function LoginPage() {
 
       const { token, user } = response.data.data
       setAuth(token, user)
-      void navigate(getDefaultAuthenticatedRoute(user), { replace: true })
+      void navigate(resolvePostLoginDestination(user, from), { replace: true })
     } catch (err) {
       if (axios.isAxiosError(err)) {
         const status = err.response?.status

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -474,6 +474,7 @@ export function RequestDetailPage() {
   const [isLoading, setIsLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [copyLinkDone, setCopyLinkDone] = useState(false)
 
   const [caseHistoryItems, setCaseHistoryItems] = useState<PortingRequestCaseHistoryItemDto[]>([])
   const [isCaseHistoryLoading, setIsCaseHistoryLoading] = useState(true)
@@ -1565,12 +1566,20 @@ export function RequestDetailPage() {
     }
   }
 
+  const handleCopyLink = () => {
+    const canonical = window.location.origin + buildPath(ROUTES.REQUEST_DETAIL, caseNumber ?? '')
+    void navigator.clipboard.writeText(canonical).then(() => {
+      setCopyLinkDone(true)
+      setTimeout(() => setCopyLinkDone(false), 2000)
+    })
+  }
+
   if (notFound) {
     return (
       <div className="panel p-10 text-center">
-        <p className="mb-1 text-base font-semibold text-ink-900">Sprawa nie istnieje</p>
+        <p className="mb-1 text-base font-semibold text-ink-900">Nie znaleziono sprawy</p>
         <p className="mb-6 text-sm text-ink-500">
-          Nie znaleziono sprawy o numerze <span className="font-mono font-medium text-ink-700">{caseNumber}</span>.
+          Sprawa o numerze <span className="font-mono font-medium text-ink-700">{caseNumber}</span> nie istnieje lub została usunięta.
         </p>
         <Button onClick={backToList} variant="secondary">
           Wróć do listy spraw
@@ -1582,11 +1591,12 @@ export function RequestDetailPage() {
   if (error || !request) {
     return (
       <div className="panel p-8 text-center">
-        <p className="mb-4 text-sm font-medium text-red-600">
-          {error ?? 'Nie udało się załadować sprawy.'}
+        <p className="mb-1 text-base font-semibold text-ink-900">Nie udało się załadować sprawy</p>
+        <p className="mb-6 text-sm text-ink-500">
+          {error ?? 'Wystąpił nieoczekiwany błąd. Odśwież stronę lub wróć do listy.'}
         </p>
         <Button onClick={backToList} variant="secondary">
-          Wróć do listy
+          Wróć do listy spraw
         </Button>
       </div>
     )
@@ -1615,7 +1625,7 @@ export function RequestDetailPage() {
                 size="sm"
                 className="mb-3 -ml-2"
               >
-                {'<-'} Sprawy portowania
+                ← Sprawy portowania
               </Button>
               <div className="flex flex-wrap items-center gap-2">
                 <Badge tone="neutral">{request.caseNumber}</Badge>
@@ -1635,6 +1645,9 @@ export function RequestDetailPage() {
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
+              <Button onClick={handleCopyLink} variant="ghost" size="sm">
+                {copyLinkDone ? '✓ Skopiowano' : 'Kopiuj link'}
+              </Button>
               <ButtonLink to={ROUTES.REQUEST_NEW} variant="secondary">
                 + Nowa sprawa
               </ButtonLink>

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -37,7 +37,13 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
   })
 
   if (redirectTo) {
-    return <Navigate to={redirectTo} replace />
+    // Preserve the original URL so LoginPage can redirect back after successful login.
+    // Only pass `from` when redirecting to /login (not to /force-password-change).
+    const state =
+      redirectTo === ROUTES.LOGIN
+        ? { from: location.pathname + location.search }
+        : undefined
+    return <Navigate to={redirectTo} state={state} replace />
   }
 
   return <>{children}</>

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -30,6 +30,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | Etap 2A.3 | Operacyjny UX polish po review                                  | DONE   |
 | Etap 2A.4 | Final micro-polish przed zamknieciem 2A                         | DONE   |
 | Etap 2B   | Routing/deeplinks/nawigacja lista-detail (canonical URL, UUID redirect, filtr po powrocie) | DONE |
+| Etap 2C   | Auth return-to-target, 404/error polish, copy-link — domkniecie Etapu 2                    | DONE |
 | Etap 3A   | Assignment closeout: visual polish PortingAssignmentPanel + usun martwy kod filterPortingRequestsByOwnership | DONE |
 
 ---
@@ -291,6 +292,32 @@ Etap 2A.4:
   - QA reczne 4/4 PASS (lista→detail po caseNumber, deeplink, UUID redirect, powrot z filtrem).
 - Stare UUID URL (`/requests/:uuid`) sa w pelni wstecznie kompatybilne — silent redirect do canonical.
 - Etap 2A nie oznacza jeszcze redesignu wszystkich ekranow; kolejne widoki powinny korzystac z `components/ui`.
+
+### Etap 2C - domkniecie UX po 2B
+
+- Auth return-to-target:
+  - `ProtectedRoute` w `router.tsx` przekazuje `state = { from: pathname+search }` przy redirect na `/login`.
+  - Nowa funkcja `resolvePostLoginDestination(user, from)` w `authFlow.ts` — priorytet: `forcePasswordChange` > `from` (internal) > dashboard.
+  - `LoginPage` czyta `from` z `location.state` i nawiguje tam po zalogowaniu.
+  - Reguly bezpieczenstwa: `from` musi startowac od `/`, nie moze byc `/login` (anty-loop), `forcePasswordChange` zawsze wygrywa.
+- 404 vs blad techniczny:
+  - `notFound` (404) i `error` (techniczny) były juz rozdzielone; doprecyzowano copy:
+    - 404: `"Nie znaleziono sprawy"` + `"Sprawa o numerze X nie istnieje lub zostala usunieta."`
+    - blad: `"Nie udalo sie zaladowac sprawy"` + tresc bledu lub fallback
+  - Oba stany maja przycisk `"Wróc do listy spraw"` (spojny tekst).
+- Drobny polish:
+  - Przycisk powrotu zmieniony z `{'<-'}` na poprawny znak `←`.
+  - Blad: zmieniono przycisk z `"Wróc do listy"` na `"Wróc do listy spraw"` (spojnosc z 404).
+- Copy-link:
+  - Przycisk `"Kopiuj link"` / `"✓ Skopiowano"` (2s reset) w naglowku detalu sprawy.
+  - Kopiuje canonical URL: `window.location.origin + /requests/:caseNumber`.
+  - Implementacja: `navigator.clipboard.writeText` + `useState<boolean>` z `setTimeout`.
+- Testy:
+  - `resolvePostLoginDestination` — 8 nowych testow jednostkowych w `authFlow.test.ts` (8 scenariuszy: brak `from`, null, valid path, query params, /login loop, external URL, forcePasswordChange override).
+  - Lacznie: 165/165 frontend PASS (bylo 157).
+  - `npx tsc --noEmit` PASS.
+
+**Etap 2 (2A + 2B + 2C) uznany za zamkniety. Wszystko nowe to Etap 3.**
 
 ### Etap 3A - assignment / ownership closeout
 


### PR DESCRIPTION
- Auth: ProtectedRoute przekazuje state.from do /login; resolvePostLoginDestination() w authFlow.ts (priorytet: forcePasswordChange
  > valid from > dashboard); LoginPage czyta from i nawiguje po zalogowaniu
- 404 vs techniczny: doprecyzowane copy i spojny przycisk 'Wróc do listy spraw'
- Polish: przycisk powrotu z <- na poprawny znak ←
- Copy-link: przycisk 'Kopiuj link' w detalu, kopiuje canonical /requests/:caseNumber
- Testy: 8 nowych testow resolvePostLoginDestination w authFlow.test.ts (165/165 PASS)
- docs: PROJECT_CONTINUITY.md — Etap 2C DONE, Etap 2 zamkniety