### PR TITLE
Dodaj retry UI dla prób dostarczenia notyfikacji

### DIFF
--- a/agent/loops/run-task.js
+++ b/agent/loops/run-task.js
@@ -1,0 +1,66 @@
+import { execSync } from "child_process";
+import fs from "fs";
+
+const MAX_ITERATIONS = 3;
+
+function runTests() {
+  try {
+    return execSync("npm test").toString();
+  } catch (e) {
+    return e.stdout.toString();
+  }
+}
+
+function getDiff() {
+  return execSync("git diff").toString();
+}
+
+(async () => {
+  const task = JSON.parse(fs.readFileSync("agent/state/task.json")).task;
+
+  let currentPrompt = fs.readFileSync("agent/prompts/codex-task.md", "utf-8")
+    .replace("{{task}}", task);
+
+  for (let i = 0; i < MAX_ITERATIONS; i++) {
+    console.log(`\n🚀 ITERACJA ${i + 1}`);
+
+    console.log("\n👉 Wklej do Codex:\n");
+    console.log(currentPrompt);
+
+    await new Promise(r => process.stdin.once("data", r));
+
+    const tests = runTests();
+    const diff = getDiff();
+
+    // prompt dla Claude
+    let reviewPrompt = fs.readFileSync("agent/prompts/claude-review.md", "utf-8")
+      .replace("{{task}}", task)
+      .replace("{{diff}}", diff)
+      .replace("{{tests}}", tests);
+
+    console.log("\n👉 Wklej do Claude:\n");
+    console.log(reviewPrompt);
+
+    console.log("\n⏳ Wklej odpowiedź Claude i ENTER...");
+    const input = await new Promise(resolve => {
+      let data = "";
+      process.stdin.on("data", chunk => {
+        data += chunk.toString();
+        if (data.includes("DECYZJA")) resolve(data);
+      });
+    });
+
+    if (input.includes("OK")) {
+      console.log("\n✅ Claude uznał zadanie za OK");
+      break;
+    }
+
+    if (input.includes("FIX")) {
+      const fixPrompt = input.split("FIX")[1];
+      currentPrompt = fixPrompt;
+      console.log("\n🔁 Poprawka wygenerowana");
+    }
+  }
+
+  console.log("\n👉 FINALNY AUDYT → ChatGPT");
+})();

--- a/agent/prompts/audit.md
+++ b/agent/prompts/audit.md
@@ -1,0 +1,28 @@
+Jesteś głównym architektem systemu NP-Manager.
+
+Kontekst:
+- system do zarządzania portowaniem (FNP)
+- frontend musi być prosty i operacyjny
+- backend jest źródłem prawdy
+
+Zadanie:
+{{task}}
+
+Zmiany w kodzie:
+{{diff}}
+
+Wynik testów:
+{{tests}}
+
+Twoje zadanie:
+
+1. Oceń czy zmiana jest poprawna architektonicznie
+2. Sprawdź czy nie ma regresji
+3. Sprawdź czy UX nie został pogorszony
+4. Wykryj potencjalne bugi
+
+Odpowiedz:
+
+- STATUS: OK / NOT OK
+- PROBLEMY:
+- POPRAWKI:

--- a/agent/prompts/claude-review.md
+++ b/agent/prompts/claude-review.md
@@ -1,0 +1,122 @@
+Jesteś lead developerem odpowiedzialnym za jakość zmian w NP-Manager.
+
+Kontekst:
+- zmiana dotyczy WYŁĄCZNIE frontend (apps/frontend/**)
+- backend jest source of truth
+- retry opiera się o:
+  - item.canRetry
+  - retryBlockedReasonCode
+  - istniejący endpoint retry
+
+Zadanie:
+{{task}}
+
+Zmiany w kodzie:
+{{diff}}
+
+Wynik testów:
+{{tests}}
+
+---
+
+TWOJE ZADANIE
+
+Przeprowadź twardą weryfikację w 4 krokach:
+
+KROK 1 — WYKONANIE FEATURE
+Sprawdź czy:
+- istnieje przycisk "Ponów"
+- jest renderowany tylko gdy item.canRetry === true
+- wywołuje onRetryAttempt(item.id)
+
+Jeśli którykolwiek warunek NIE jest spełniony → FIX
+
+---
+
+KROK 2 — UX / INTERAKCJA
+Sprawdź czy:
+- istnieje loading state ("Ponawiam...")
+- przycisk jest disabled podczas retry
+- użytkownik widzi:
+  - success message
+  - error message
+- NIE ma resetu całego panelu
+
+Jeśli coś brakuje → FIX
+
+---
+
+KROK 3 — ARCHITEKTURA
+Sprawdź czy:
+- NIE zmieniono plików:
+  - apps/backend/**
+  - packages/shared/**
+  - prisma/**
+- NIE dodano lokalnej logiki retry (np. if/else zamiast backendu)
+- użyto istniejącego endpointu retry
+
+Jeśli naruszono którykolwiek punkt → FIX
+
+---
+
+KROK 4 — JAKOŚĆ ZMIAN
+Sprawdź czy:
+- zmiany są ograniczone tylko do potrzebnych plików
+- NIE ma zmian typu:
+  - package.json
+  - config
+  - inne niezwiązane pliki
+- kod jest spójny z istniejącym stylem
+
+Jeśli są zbędne zmiany → FIX
+
+---
+
+KROK 5 — TESTY
+- jeśli testy FAIL → FIX
+- ignoruj "0 test files"
+
+---
+
+ODPOWIEDŹ (OBOWIĄZKOWY FORMAT)
+
+DECYZJA: OK / FIX
+
+UZASADNIENIE:
+- krótko dlaczego
+
+JEŚLI FIX:
+
+Zwróć GOTOWY PROMPT dla Codex:
+
+- bardzo konkretny
+- wskazujący pliki
+- bez ogólników
+
+FORMAT:
+
+Popraw w pliku:
+<ścieżka>
+
+Zrób:
+- konkretna zmiana 1
+- konkretna zmiana 2
+
+Nie zmieniaj:
+- backend
+- innych plików
+
+---
+
+JEŚLI OK:
+
+Potwierdź:
+- feature działa poprawnie
+- UX jest kompletny
+- brak regresji
+- brak nieautoryzowanych zmian
+
+---
+
+ZASADA:
+Jeśli masz jakiekolwiek wątpliwości → wybierz FIX

--- a/agent/prompts/codex-task.md
+++ b/agent/prompts/codex-task.md
@@ -1,0 +1,19 @@
+Jesteś Codex pracującym nad NP-Manager.
+
+Zadanie:
+{{task}}
+
+ZAKRES:
+- apps/frontend/**
+
+ZABRONIONE:
+- backend
+- prisma
+- shared
+
+Wymagania:
+- użyj istniejącego API retry
+- pokaż loading
+- pokaż success/error
+
+Zwróć pełny kod zmienionych plików.

--- a/agent/state/task.json
+++ b/agent/state/task.json
@@ -1,0 +1,4 @@
+{
+  "task": "Dodaj prosty przycisk retry w InternalNotificationAttemptsPanel z wykorzystaniem istniejącego endpointu retry",
+  "status": "pending"
+}

--- a/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx
+++ b/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx
@@ -1,5 +1,7 @@
-import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { InternalNotificationDeliveryAttemptDto } from '@np-manager/shared'
 import { InternalNotificationAttemptsPanel } from './InternalNotificationAttemptsPanel'
 
@@ -50,28 +52,71 @@ const ITEMS: InternalNotificationDeliveryAttemptDto[] = [
   },
 ]
 
-describe('InternalNotificationAttemptsPanel', () => {
-  it('renders delivery attempts without retry actions', () => {
-    const html = renderToStaticMarkup(
-      <InternalNotificationAttemptsPanel items={ITEMS} isLoading={false} error={null} />,
-    )
+function renderPanel(
+  overrides: Partial<ComponentProps<typeof InternalNotificationAttemptsPanel>> = {},
+) {
+  const onRetryAttempt = vi.fn()
 
-    expect(html).toContain('Proby dostarczenia notyfikacji')
-    expect(html).toContain('Ledger wykonanych prob transportu')
-    expect(html).toContain('Primary dispatch')
-    expect(html).toContain('Error fallback')
-    expect(html).toContain('bok@multiplay.pl')
-    expect(html).toContain('Blad wysylki')
-    expect(html).toContain('Blad transportu: Timeout SMTP')
-    expect(html).not.toContain('Retryuj')
-    expect(html).not.toContain('Ponow')
+  render(
+    <InternalNotificationAttemptsPanel
+      items={ITEMS}
+      isLoading={false}
+      error={null}
+      canRetryAttempts={true}
+      retryingAttemptId={null}
+      retrySuccessMessage={null}
+      retryErrorMessage={null}
+      onRetryAttempt={onRetryAttempt}
+      {...overrides}
+    />,
+  )
+
+  return { onRetryAttempt }
+}
+
+describe('InternalNotificationAttemptsPanel', () => {
+  afterEach(() => {
+    cleanup()
   })
 
-  it('renders empty state for request without persisted attempts', () => {
-    const html = renderToStaticMarkup(
-      <InternalNotificationAttemptsPanel items={[]} isLoading={false} error={null} />,
-    )
+  it('renders retry action only for retryable attempts', () => {
+    renderPanel()
 
-    expect(html).toContain('Brak zapisanych prob transportu w modelu attempts dla tej sprawy.')
+    expect(screen.getByRole('button', { name: 'Ponow' })).toBeTruthy()
+    expect(screen.getByText('Tego typu proby nie mozna ponowic.')).toBeTruthy()
+  })
+
+  it('calls retry callback for selected attempt', () => {
+    const { onRetryAttempt } = renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ponow' }))
+
+    expect(onRetryAttempt).toHaveBeenCalledWith('attempt-1')
+    expect(onRetryAttempt).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders retry loading state for active attempt', () => {
+    renderPanel({ retryingAttemptId: 'attempt-1' })
+
+    const loadingButton = screen.getByRole('button', { name: 'Ponawiam...' })
+    expect(loadingButton).toBeTruthy()
+    expect(loadingButton.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('hides retry button when role cannot trigger retry', () => {
+    renderPanel({ canRetryAttempts: false })
+
+    expect(screen.queryByRole('button', { name: 'Ponow' })).toBeNull()
+    expect(screen.getByText('Ponowienie dostepne dla zespolu operacyjnego.')).toBeTruthy()
+  })
+
+  it('renders retry feedback messages', () => {
+    renderPanel({
+      retrySuccessMessage: 'Ponowienie wykonane: dostarczono.',
+      retryErrorMessage: 'Nie udalo sie ponowic proby dostarczenia.',
+    })
+
+    expect(screen.getByText('Ponowienie wykonane: dostarczono.')).toBeTruthy()
+    expect(screen.getByText('Nie udalo sie ponowic proby dostarczenia.')).toBeTruthy()
   })
 })

--- a/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx
+++ b/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx
@@ -1,9 +1,15 @@
 import type { InternalNotificationDeliveryAttemptDto } from '@np-manager/shared'
+import { getInternalNotificationRetryBlockedReasonLabel } from '@/lib/internalNotificationRetryMessages'
 
 interface InternalNotificationAttemptsPanelProps {
   items: InternalNotificationDeliveryAttemptDto[]
   isLoading: boolean
   error: string | null
+  canRetryAttempts: boolean
+  retryingAttemptId: string | null
+  retrySuccessMessage: string | null
+  retryErrorMessage: string | null
+  onRetryAttempt: (attemptId: string) => void
 }
 
 function formatDateTime(value: string): string {
@@ -47,6 +53,11 @@ export function InternalNotificationAttemptsPanel({
   items,
   isLoading,
   error,
+  canRetryAttempts,
+  retryingAttemptId,
+  retrySuccessMessage,
+  retryErrorMessage,
+  onRetryAttempt,
 }: InternalNotificationAttemptsPanelProps) {
   return (
     <div className="card p-5">
@@ -59,6 +70,18 @@ export function InternalNotificationAttemptsPanel({
           auditow pozostaje w panelu historii powiadomien wewnetrznych.
         </p>
       </div>
+
+      {retrySuccessMessage && (
+        <div className="mb-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+          {retrySuccessMessage}
+        </div>
+      )}
+
+      {retryErrorMessage && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {retryErrorMessage}
+        </div>
+      )}
 
       {isLoading ? (
         <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">
@@ -74,59 +97,81 @@ export function InternalNotificationAttemptsPanel({
         </div>
       ) : (
         <div className="space-y-3">
-          {items.map((item) => (
-            <article key={item.id} className="rounded-lg border border-gray-200 bg-white p-4">
-              <div className="flex flex-wrap items-start justify-between gap-2">
-                <div>
-                  <h3 className="text-sm font-semibold text-gray-900">{item.eventLabel}</h3>
-                  <p className="mt-0.5 text-xs text-gray-500">
-                    {formatDateTime(item.createdAt)}
-                    {item.eventCode ? ` | ${item.eventCode}` : ''}
+          {items.map((item) => {
+            const isRetrying = retryingAttemptId === item.id
+            const canShowRetryButton = item.canRetry && canRetryAttempts
+
+            return (
+              <article key={item.id} className="rounded-lg border border-gray-200 bg-white p-4">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <h3 className="text-sm font-semibold text-gray-900">{item.eventLabel}</h3>
+                    <p className="mt-0.5 text-xs text-gray-500">
+                      {formatDateTime(item.createdAt)}
+                      {item.eventCode ? ` | ${item.eventCode}` : ''}
+                    </p>
+                  </div>
+                  <span
+                    className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getOutcomeClass(
+                      item.outcome,
+                    )}`}
+                  >
+                    {item.outcome}
+                  </span>
+                </div>
+
+                <dl className="mt-3 grid grid-cols-1 gap-2 text-sm text-gray-700 sm:grid-cols-2">
+                  <div>
+                    <dt className="text-xs text-gray-500">Pochodzenie proby</dt>
+                    <dd>{formatOrigin(item.attemptOrigin)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Kanal</dt>
+                    <dd>{formatChannel(item.channel)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Odbiorca</dt>
+                    <dd>{item.recipient}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Tryb</dt>
+                    <dd>{item.mode}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Rodzaj problemu</dt>
+                    <dd>{formatFailureKind(item.failureKind)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Licznik retry</dt>
+                    <dd>{item.retryCount}</dd>
+                  </div>
+                </dl>
+
+                {canShowRetryButton ? (
+                  <button
+                    type="button"
+                    onClick={() => onRetryAttempt(item.id)}
+                    disabled={isRetrying}
+                    className="mt-3 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isRetrying ? 'Ponawiam...' : 'Ponow'}
+                  </button>
+                ) : (
+                  <p className="mt-3 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+                    {item.canRetry
+                      ? 'Ponowienie dostepne dla zespolu operacyjnego.'
+                      : getInternalNotificationRetryBlockedReasonLabel(item.retryBlockedReasonCode)}
                   </p>
-                </div>
-                <span
-                  className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getOutcomeClass(
-                    item.outcome,
-                  )}`}
-                >
-                  {item.outcome}
-                </span>
-              </div>
+                )}
 
-              <dl className="mt-3 grid grid-cols-1 gap-2 text-sm text-gray-700 sm:grid-cols-2">
-                <div>
-                  <dt className="text-xs text-gray-500">Pochodzenie proby</dt>
-                  <dd>{formatOrigin(item.attemptOrigin)}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-gray-500">Kanal</dt>
-                  <dd>{formatChannel(item.channel)}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-gray-500">Odbiorca</dt>
-                  <dd>{item.recipient}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-gray-500">Tryb</dt>
-                  <dd>{item.mode}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-gray-500">Rodzaj problemu</dt>
-                  <dd>{formatFailureKind(item.failureKind)}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-gray-500">Licznik retry</dt>
-                  <dd>{item.retryCount}</dd>
-                </div>
-              </dl>
-
-              {item.errorMessage && (
-                <p className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-                  Blad transportu: {item.errorMessage}
-                </p>
-              )}
-            </article>
-          ))}
+                {item.errorMessage && (
+                  <p className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                    Blad transportu: {item.errorMessage}
+                  </p>
+                )}
+              </article>
+            )
+          })}
         </div>
       )}
     </div>

--- a/apps/frontend/src/lib/internalNotificationRetryMessages.test.ts
+++ b/apps/frontend/src/lib/internalNotificationRetryMessages.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getInternalNotificationRetryBlockedReasonLabel,
+  getInternalNotificationRetryErrorMessage,
+  getInternalNotificationRetrySuccessMessage,
+} from './internalNotificationRetryMessages'
+
+describe('internalNotificationRetryMessages', () => {
+  it('maps retry blocked reason code to readable message', () => {
+    expect(getInternalNotificationRetryBlockedReasonLabel('RETRY_LIMIT_REACHED')).toBe(
+      'Limit ponowien osiagniety.',
+    )
+  })
+
+  it('returns fallback blocked message for missing reason code', () => {
+    expect(getInternalNotificationRetryBlockedReasonLabel(null)).toBe(
+      'Ponowienie jest niedostepne.',
+    )
+  })
+
+  it('maps retry 409 error with reason code', () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 409,
+        data: {
+          error: {
+            retryBlockedReasonCode: 'NOT_LATEST_IN_CHAIN',
+          },
+        },
+      },
+    }
+
+    expect(getInternalNotificationRetryErrorMessage(error)).toBe(
+      'Dostepna jest juz nowsza proba.',
+    )
+  })
+
+  it('maps retry 403 error to permission message', () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 403,
+      },
+    }
+
+    expect(getInternalNotificationRetryErrorMessage(error)).toBe(
+      'Nie masz uprawnien do ponowienia tej proby.',
+    )
+  })
+
+  it('returns generic retry error for non-axios error', () => {
+    expect(getInternalNotificationRetryErrorMessage(new Error('boom'))).toBe(
+      'Nie udalo sie ponowic proby dostarczenia.',
+    )
+  })
+
+  it('builds success message from retry attempt outcome', () => {
+    expect(getInternalNotificationRetrySuccessMessage('SENT')).toBe(
+      'Ponowienie wykonane: dostarczono.',
+    )
+  })
+})

--- a/apps/frontend/src/lib/internalNotificationRetryMessages.ts
+++ b/apps/frontend/src/lib/internalNotificationRetryMessages.ts
@@ -1,0 +1,59 @@
+import axios from 'axios'
+import type {
+  InternalNotificationAttemptOutcomeDto,
+  InternalNotificationRetryBlockedReasonCodeDto,
+} from '@np-manager/shared'
+
+const RETRY_BLOCKED_REASON_MESSAGES: Record<InternalNotificationRetryBlockedReasonCodeDto, string> =
+  {
+    RETRY_LIMIT_REACHED: 'Limit ponowien osiagniety.',
+    NOT_LATEST_IN_CHAIN: 'Dostepna jest juz nowsza proba.',
+    ORIGIN_NOT_RETRYABLE: 'Tego typu proby nie mozna ponowic.',
+    OUTCOME_NOT_RETRYABLE: 'Ten wynik nie kwalifikuje sie do ponowienia.',
+  }
+
+const RETRY_OUTCOME_LABELS: Record<InternalNotificationAttemptOutcomeDto, string> = {
+  SENT: 'dostarczono',
+  STUBBED: 'wysylka testowa',
+  DISABLED: 'wysylka wylaczona',
+  MISCONFIGURED: 'blad konfiguracji',
+  FAILED: 'blad wysylki',
+  SKIPPED: 'pominieto',
+}
+
+export function getInternalNotificationRetryBlockedReasonLabel(
+  reasonCode: InternalNotificationRetryBlockedReasonCodeDto | null,
+): string {
+  if (!reasonCode) {
+    return 'Ponowienie jest niedostepne.'
+  }
+
+  return RETRY_BLOCKED_REASON_MESSAGES[reasonCode]
+}
+
+export function getInternalNotificationRetryErrorMessage(error: unknown): string {
+  if (!axios.isAxiosError(error)) {
+    return 'Nie udalo sie ponowic proby dostarczenia.'
+  }
+
+  const responseData = error.response?.data as
+    | { error?: { retryBlockedReasonCode?: InternalNotificationRetryBlockedReasonCodeDto } }
+    | undefined
+  const reasonCode = responseData?.error?.retryBlockedReasonCode
+
+  if (error.response?.status === 409 && reasonCode) {
+    return getInternalNotificationRetryBlockedReasonLabel(reasonCode)
+  }
+
+  if (error.response?.status === 403) {
+    return 'Nie masz uprawnien do ponowienia tej proby.'
+  }
+
+  return 'Nie udalo sie ponowic proby dostarczenia.'
+}
+
+export function getInternalNotificationRetrySuccessMessage(
+  outcome: InternalNotificationAttemptOutcomeDto,
+): string {
+  return `Ponowienie wykonane: ${RETRY_OUTCOME_LABELS[outcome]}.`
+}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -30,6 +30,7 @@ import {
   getPortingRequestXmlPreview,
   markPortingCommunicationAsSent,
   previewPortingCommunicationDraft,
+  retryInternalNotificationAttempt,
   retryPortingCommunication,
   sendPortingCommunication,
   triggerManualPliCbdExport,
@@ -90,6 +91,10 @@ import { PortingInternalNotificationsPanel } from '@/components/PortingInternalN
 import { InternalNotificationAttemptsPanel } from '@/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel'
 import { NotificationFailureHistoryPanel } from '@/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel'
 import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
+import {
+  getInternalNotificationRetryErrorMessage,
+  getInternalNotificationRetrySuccessMessage,
+} from '@/lib/internalNotificationRetryMessages'
 import {
   canManagePortingOwnership,
   canSelectAnyAssignee,
@@ -619,6 +624,12 @@ export function RequestDetailPage() {
   const [internalNotificationAttemptsError, setInternalNotificationAttemptsError] = useState<
     string | null
   >(null)
+  const [internalNotificationAttemptsRetrySuccess, setInternalNotificationAttemptsRetrySuccess] =
+    useState<string | null>(null)
+  const [internalNotificationAttemptsRetryError, setInternalNotificationAttemptsRetryError] =
+    useState<string | null>(null)
+  const [retryingInternalNotificationAttemptId, setRetryingInternalNotificationAttemptId] =
+    useState<string | null>(null)
   const [notificationFailureItems, setNotificationFailureItems] = useState<
     NotificationFailureHistoryItemDto[]
   >([])
@@ -716,6 +727,7 @@ export function RequestDetailPage() {
     () => ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER'].includes(user?.role ?? ''),
     [user?.role],
   )
+  const canRetryInternalNotificationAttempts = canManageStatus
   const isAdmin = useMemo(() => user?.role === 'ADMIN', [user?.role])
   const { capabilities: systemCapabilities } = useSystemCapabilities()
   const canUsePliCbdExport = systemCapabilities.pliCbd.capabilities.export
@@ -914,6 +926,38 @@ export function RequestDetailPage() {
       setIsInternalNotificationAttemptsLoading(false)
     }
   }, [id])
+
+  const handleRetryInternalNotificationAttempt = useCallback(
+    async (attemptId: string) => {
+      if (!id || !canRetryInternalNotificationAttempts || retryingInternalNotificationAttemptId) {
+        return
+      }
+
+      setRetryingInternalNotificationAttemptId(attemptId)
+      setInternalNotificationAttemptsRetrySuccess(null)
+      setInternalNotificationAttemptsRetryError(null)
+
+      try {
+        const result = await retryInternalNotificationAttempt(id, attemptId)
+        setInternalNotificationAttemptsRetrySuccess(
+          getInternalNotificationRetrySuccessMessage(result.retryAttempt.outcome),
+        )
+        await loadInternalNotificationAttempts()
+      } catch (errorValue) {
+        setInternalNotificationAttemptsRetryError(
+          getInternalNotificationRetryErrorMessage(errorValue),
+        )
+      } finally {
+        setRetryingInternalNotificationAttemptId(null)
+      }
+    },
+    [
+      canRetryInternalNotificationAttempts,
+      id,
+      loadInternalNotificationAttempts,
+      retryingInternalNotificationAttemptId,
+    ],
+  )
 
   const loadNotificationFailures = useCallback(async () => {
     if (!id) return
@@ -1170,6 +1214,9 @@ export function RequestDetailPage() {
     setCommunicationPreview(null)
     setAssignmentFeedbackError(null)
     setAssignmentFeedbackSuccess(null)
+    setInternalNotificationAttemptsRetrySuccess(null)
+    setInternalNotificationAttemptsRetryError(null)
+    setRetryingInternalNotificationAttemptId(null)
 
     if (!caseNumber) return
     void loadRequest()
@@ -1975,6 +2022,11 @@ export function RequestDetailPage() {
                 items={internalNotificationAttemptItems}
                 isLoading={isInternalNotificationAttemptsLoading}
                 error={internalNotificationAttemptsError}
+                canRetryAttempts={canRetryInternalNotificationAttempts}
+                retryingAttemptId={retryingInternalNotificationAttemptId}
+                retrySuccessMessage={internalNotificationAttemptsRetrySuccess}
+                retryErrorMessage={internalNotificationAttemptsRetryError}
+                onRetryAttempt={(attemptId) => void handleRetryInternalNotificationAttempt(attemptId)}
               />
             </div>
           </SectionCard>

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -24,6 +24,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR19A-1 | NotificationOps foundation: first-class delivery attempts + dual-write | DONE   |
 | PR19A-2 | Request-level read layer dla internal notification attempts        | DONE   |
 | PR19B-1 | Backend retry eligibility + request-scoped retry endpoint          | DONE   |
+| PR19B-2 / Etap 5A | RequestDetail retry UI dla internal notification attempts | DONE |
 | PR20E | Full server-side operational status filters for global queue       | DONE   |
 | Etap 2A.1 | Frontend redesign foundation + app shell + RequestsPage          | DONE   |
 | Etap 2A.2 | Frontend redesign RequestDetailPage                              | DONE   |
@@ -207,6 +208,26 @@ Dispatch jest non-blocking (`.catch(() => {})`) i nie blokuje glownego flow API.
   - zewnetrzne I/O transportu nie jest trzymane w dlugiej transakcji DB,
   - eligibility jest sprawdzane przed transportem i ponownie w krotkiej transakcji zapisu,
   - w rzadkim wyscigu po wykonaniu transportu, ale przed zapisem, transakcja moze odrzucic retry jako juz nie-latest.
+
+### PR19B-2 / Etap 5A - retry action w UI dla internal notification attempts
+
+- Scope: frontend-first, waski slice na `RequestDetailPage` + `InternalNotificationAttemptsPanel`.
+- `InternalNotificationAttemptsPanel`:
+  - pokazuje akcje `Ponow` tylko dla rekordow `canRetry=true`,
+  - dla `canRetry=false` pokazuje czytelny powod blokady mapowany z `retryBlockedReasonCode`,
+  - nie pokazuje surowych backendowych reason-code jako jedynej tresci.
+- `RequestDetailPage`:
+  - podpina akcje retry do endpointu `POST /api/porting-requests/:id/internal-notification-attempts/:attemptId/retry`,
+  - po sukcesie pokazuje feedback operacyjny i odswieza listy attempts,
+  - po bledzie pokazuje czytelny feedback bez resetowania calego panelu.
+- Frontend respektuje backend source-of-truth:
+  - eligibility pochodzi z `canRetry` / `retryBlockedReasonCode`,
+  - brak lokalnego "silnika retry" i brak lokalnych reguly zastawiajacych backend.
+- Zakres celowo poza PR19B-2:
+  - brak zmian Prisma schema,
+  - brak zmian backend transport adapterow,
+  - brak zmian NOTE parsing,
+  - brak rozbudowy globalnego ops center i brak redesignu kolejki.
 
 ### PR15 - operacyjne raportowanie commercial owner i health notyfikacji
 


### PR DESCRIPTION
## Cel
- Dodać operatorowy retry dla `InternalNotificationDeliveryAttempt` w detail sprawy.
- Pokazać czytelne blokady retry i feedback po akcji.

## Zakres zmian
- `InternalNotificationAttemptsPanel` renderuje `Ponów` tylko dla `canRetry=true`.
- Dla `canRetry=false` pokazuje nietechniczny powód z `retryBlockedReasonCode`.
- `RequestDetailPage` podpina retry endpoint, pokazuje success/error i odświeża attempts po sukcesie.
- Dodano mały helper mapowania komunikatów retry oraz aktualizację continuity.

## Zmienione pliki / obszary
- `apps/frontend/src/components/InternalNotificationAttemptsPanel/*`
- `apps/frontend/src/lib/internalNotificationRetryMessages*`
- `apps/frontend/src/pages/Requests/RequestDetailPage.tsx`
- `docs/PROJECT_CONTINUITY.md`

## Testy i walidacja
- `npm run test -w apps/frontend`
- `npx tsc --noEmit -p apps/frontend/tsconfig.json`

## Ryzyka / otwarte punkty
- Brak osobnego inputu `reason` dla retry; backend go wspiera, ale UX pozostaje najwęższy.
- `RequestDetailPage` nie ma osobnego testu integracyjnego całego flow retry.
- Manual QA nadal warto przejść na danych z `canRetry=true/false` i na przypadkach `409/403`.

## Checklist przed merge
- [x] Retry widoczne tylko dla rekordów retryowalnych
- [x] Blokady są czytelne i nietechniczne
- [x] Success/error nie resetuje panelu
- [x] Panel odświeża dane po sukcesie
- [x] Testy frontend i typecheck przechodzą