### PR TITLE
feat(pr19b2): dodaj retry UI prob notyfikacji

### DIFF
--- a/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx
+++ b/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx
@@ -1,5 +1,7 @@
-import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it } from 'vitest'
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { InternalNotificationDeliveryAttemptDto } from '@np-manager/shared'
 import { InternalNotificationAttemptsPanel } from './InternalNotificationAttemptsPanel'
 
@@ -50,28 +52,71 @@ const ITEMS: InternalNotificationDeliveryAttemptDto[] = [
   },
 ]
 
-describe('InternalNotificationAttemptsPanel', () => {
-  it('renders delivery attempts without retry actions', () => {
-    const html = renderToStaticMarkup(
-      <InternalNotificationAttemptsPanel items={ITEMS} isLoading={false} error={null} />,
-    )
+function renderPanel(
+  overrides: Partial<ComponentProps<typeof InternalNotificationAttemptsPanel>> = {},
+) {
+  const onRetryAttempt = vi.fn()
 
-    expect(html).toContain('Proby dostarczenia notyfikacji')
-    expect(html).toContain('Ledger wykonanych prob transportu')
-    expect(html).toContain('Primary dispatch')
-    expect(html).toContain('Error fallback')
-    expect(html).toContain('bok@multiplay.pl')
-    expect(html).toContain('Blad wysylki')
-    expect(html).toContain('Blad transportu: Timeout SMTP')
-    expect(html).not.toContain('Retryuj')
-    expect(html).not.toContain('Ponow')
+  render(
+    <InternalNotificationAttemptsPanel
+      items={ITEMS}
+      isLoading={false}
+      error={null}
+      canRetryAttempts={true}
+      retryingAttemptId={null}
+      retrySuccessMessage={null}
+      retryErrorMessage={null}
+      onRetryAttempt={onRetryAttempt}
+      {...overrides}
+    />,
+  )
+
+  return { onRetryAttempt }
+}
+
+describe('InternalNotificationAttemptsPanel', () => {
+  afterEach(() => {
+    cleanup()
   })
 
-  it('renders empty state for request without persisted attempts', () => {
-    const html = renderToStaticMarkup(
-      <InternalNotificationAttemptsPanel items={[]} isLoading={false} error={null} />,
-    )
+  it('renders retry action only for retryable attempts', () => {
+    renderPanel()
 
-    expect(html).toContain('Brak zapisanych prob transportu w modelu attempts dla tej sprawy.')
+    expect(screen.getByRole('button', { name: 'Ponow' })).toBeTruthy()
+    expect(screen.getByText('Tego typu proby nie mozna ponowic.')).toBeTruthy()
+  })
+
+  it('calls retry callback for selected attempt', () => {
+    const { onRetryAttempt } = renderPanel()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ponow' }))
+
+    expect(onRetryAttempt).toHaveBeenCalledWith('attempt-1')
+    expect(onRetryAttempt).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders retry loading state for active attempt', () => {
+    renderPanel({ retryingAttemptId: 'attempt-1' })
+
+    const loadingButton = screen.getByRole('button', { name: 'Ponawiam...' })
+    expect(loadingButton).toBeTruthy()
+    expect(loadingButton.hasAttribute('disabled')).toBe(true)
+  })
+
+  it('hides retry button when role cannot trigger retry', () => {
+    renderPanel({ canRetryAttempts: false })
+
+    expect(screen.queryByRole('button', { name: 'Ponow' })).toBeNull()
+    expect(screen.getByText('Ponowienie dostepne dla zespolu operacyjnego.')).toBeTruthy()
+  })
+
+  it('renders retry feedback messages', () => {
+    renderPanel({
+      retrySuccessMessage: 'Ponowienie wykonane: dostarczono.',
+      retryErrorMessage: 'Nie udalo sie ponowic proby dostarczenia.',
+    })
+
+    expect(screen.getByText('Ponowienie wykonane: dostarczono.')).toBeTruthy()
+    expect(screen.getByText('Nie udalo sie ponowic proby dostarczenia.')).toBeTruthy()
   })
 })

--- a/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx
+++ b/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx
@@ -1,9 +1,15 @@
 import type { InternalNotificationDeliveryAttemptDto } from '@np-manager/shared'
+import { getInternalNotificationRetryBlockedReasonLabel } from '@/lib/internalNotificationRetryMessages'
 
 interface InternalNotificationAttemptsPanelProps {
   items: InternalNotificationDeliveryAttemptDto[]
   isLoading: boolean
   error: string | null
+  canRetryAttempts: boolean
+  retryingAttemptId: string | null
+  retrySuccessMessage: string | null
+  retryErrorMessage: string | null
+  onRetryAttempt: (attemptId: string) => void
 }
 
 function formatDateTime(value: string): string {
@@ -47,6 +53,11 @@ export function InternalNotificationAttemptsPanel({
   items,
   isLoading,
   error,
+  canRetryAttempts,
+  retryingAttemptId,
+  retrySuccessMessage,
+  retryErrorMessage,
+  onRetryAttempt,
 }: InternalNotificationAttemptsPanelProps) {
   return (
     <div className="card p-5">
@@ -59,6 +70,18 @@ export function InternalNotificationAttemptsPanel({
           auditow pozostaje w panelu historii powiadomien wewnetrznych.
         </p>
       </div>
+
+      {retrySuccessMessage && (
+        <div className="mb-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+          {retrySuccessMessage}
+        </div>
+      )}
+
+      {retryErrorMessage && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {retryErrorMessage}
+        </div>
+      )}
 
       {isLoading ? (
         <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">
@@ -74,59 +97,81 @@ export function InternalNotificationAttemptsPanel({
         </div>
       ) : (
         <div className="space-y-3">
-          {items.map((item) => (
-            <article key={item.id} className="rounded-lg border border-gray-200 bg-white p-4">
-              <div className="flex flex-wrap items-start justify-between gap-2">
-                <div>
-                  <h3 className="text-sm font-semibold text-gray-900">{item.eventLabel}</h3>
-                  <p className="mt-0.5 text-xs text-gray-500">
-                    {formatDateTime(item.createdAt)}
-                    {item.eventCode ? ` | ${item.eventCode}` : ''}
+          {items.map((item) => {
+            const isRetrying = retryingAttemptId === item.id
+            const canShowRetryButton = item.canRetry && canRetryAttempts
+
+            return (
+              <article key={item.id} className="rounded-lg border border-gray-200 bg-white p-4">
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <h3 className="text-sm font-semibold text-gray-900">{item.eventLabel}</h3>
+                    <p className="mt-0.5 text-xs text-gray-500">
+                      {formatDateTime(item.createdAt)}
+                      {item.eventCode ? ` | ${item.eventCode}` : ''}
+                    </p>
+                  </div>
+                  <span
+                    className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getOutcomeClass(
+                      item.outcome,
+                    )}`}
+                  >
+                    {item.outcome}
+                  </span>
+                </div>
+
+                <dl className="mt-3 grid grid-cols-1 gap-2 text-sm text-gray-700 sm:grid-cols-2">
+                  <div>
+                    <dt className="text-xs text-gray-500">Pochodzenie proby</dt>
+                    <dd>{formatOrigin(item.attemptOrigin)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Kanal</dt>
+                    <dd>{formatChannel(item.channel)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Odbiorca</dt>
+                    <dd>{item.recipient}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Tryb</dt>
+                    <dd>{item.mode}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Rodzaj problemu</dt>
+                    <dd>{formatFailureKind(item.failureKind)}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-xs text-gray-500">Licznik retry</dt>
+                    <dd>{item.retryCount}</dd>
+                  </div>
+                </dl>
+
+                {canShowRetryButton ? (
+                  <button
+                    type="button"
+                    onClick={() => onRetryAttempt(item.id)}
+                    disabled={isRetrying}
+                    className="mt-3 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isRetrying ? 'Ponawiam...' : 'Ponow'}
+                  </button>
+                ) : (
+                  <p className="mt-3 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+                    {item.canRetry
+                      ? 'Ponowienie dostepne dla zespolu operacyjnego.'
+                      : getInternalNotificationRetryBlockedReasonLabel(item.retryBlockedReasonCode)}
                   </p>
-                </div>
-                <span
-                  className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getOutcomeClass(
-                    item.outcome,
-                  )}`}
-                >
-                  {item.outcome}
-                </span>
-              </div>
+                )}
 
-              <dl className="mt-3 grid grid-cols-1 gap-2 text-sm text-gray-700 sm:grid-cols-2">
-                <div>
-                  <dt className="text-xs text-gray-500">Pochodzenie proby</dt>
-                  <dd>{formatOrigin(item.attemptOrigin)}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-gray-500">Kanal</dt>
-                  <dd>{formatChannel(item.channel)}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-gray-500">Odbiorca</dt>
-                  <dd>{item.recipient}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-gray-500">Tryb</dt>
-                  <dd>{item.mode}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-gray-500">Rodzaj problemu</dt>
-                  <dd>{formatFailureKind(item.failureKind)}</dd>
-                </div>
-                <div>
-                  <dt className="text-xs text-gray-500">Licznik retry</dt>
-                  <dd>{item.retryCount}</dd>
-                </div>
-              </dl>
-
-              {item.errorMessage && (
-                <p className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-                  Blad transportu: {item.errorMessage}
-                </p>
-              )}
-            </article>
-          ))}
+                {item.errorMessage && (
+                  <p className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                    Blad transportu: {item.errorMessage}
+                  </p>
+                )}
+              </article>
+            )
+          })}
         </div>
       )}
     </div>

--- a/apps/frontend/src/lib/internalNotificationRetryMessages.test.ts
+++ b/apps/frontend/src/lib/internalNotificationRetryMessages.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getInternalNotificationRetryBlockedReasonLabel,
+  getInternalNotificationRetryErrorMessage,
+  getInternalNotificationRetrySuccessMessage,
+} from './internalNotificationRetryMessages'
+
+describe('internalNotificationRetryMessages', () => {
+  it('maps retry blocked reason code to readable message', () => {
+    expect(getInternalNotificationRetryBlockedReasonLabel('RETRY_LIMIT_REACHED')).toBe(
+      'Limit ponowien osiagniety.',
+    )
+  })
+
+  it('returns fallback blocked message for missing reason code', () => {
+    expect(getInternalNotificationRetryBlockedReasonLabel(null)).toBe(
+      'Ponowienie jest niedostepne.',
+    )
+  })
+
+  it('maps retry 409 error with reason code', () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 409,
+        data: {
+          error: {
+            retryBlockedReasonCode: 'NOT_LATEST_IN_CHAIN',
+          },
+        },
+      },
+    }
+
+    expect(getInternalNotificationRetryErrorMessage(error)).toBe(
+      'Dostepna jest juz nowsza proba.',
+    )
+  })
+
+  it('maps retry 403 error to permission message', () => {
+    const error = {
+      isAxiosError: true,
+      response: {
+        status: 403,
+      },
+    }
+
+    expect(getInternalNotificationRetryErrorMessage(error)).toBe(
+      'Nie masz uprawnien do ponowienia tej proby.',
+    )
+  })
+
+  it('returns generic retry error for non-axios error', () => {
+    expect(getInternalNotificationRetryErrorMessage(new Error('boom'))).toBe(
+      'Nie udalo sie ponowic proby dostarczenia.',
+    )
+  })
+
+  it('builds success message from retry attempt outcome', () => {
+    expect(getInternalNotificationRetrySuccessMessage('SENT')).toBe(
+      'Ponowienie wykonane: dostarczono.',
+    )
+  })
+})

--- a/apps/frontend/src/lib/internalNotificationRetryMessages.ts
+++ b/apps/frontend/src/lib/internalNotificationRetryMessages.ts
@@ -1,0 +1,59 @@
+import axios from 'axios'
+import type {
+  InternalNotificationAttemptOutcomeDto,
+  InternalNotificationRetryBlockedReasonCodeDto,
+} from '@np-manager/shared'
+
+const RETRY_BLOCKED_REASON_MESSAGES: Record<InternalNotificationRetryBlockedReasonCodeDto, string> =
+  {
+    RETRY_LIMIT_REACHED: 'Limit ponowien osiagniety.',
+    NOT_LATEST_IN_CHAIN: 'Dostepna jest juz nowsza proba.',
+    ORIGIN_NOT_RETRYABLE: 'Tego typu proby nie mozna ponowic.',
+    OUTCOME_NOT_RETRYABLE: 'Ten wynik nie kwalifikuje sie do ponowienia.',
+  }
+
+const RETRY_OUTCOME_LABELS: Record<InternalNotificationAttemptOutcomeDto, string> = {
+  SENT: 'dostarczono',
+  STUBBED: 'wysylka testowa',
+  DISABLED: 'wysylka wylaczona',
+  MISCONFIGURED: 'blad konfiguracji',
+  FAILED: 'blad wysylki',
+  SKIPPED: 'pominieto',
+}
+
+export function getInternalNotificationRetryBlockedReasonLabel(
+  reasonCode: InternalNotificationRetryBlockedReasonCodeDto | null,
+): string {
+  if (!reasonCode) {
+    return 'Ponowienie jest niedostepne.'
+  }
+
+  return RETRY_BLOCKED_REASON_MESSAGES[reasonCode]
+}
+
+export function getInternalNotificationRetryErrorMessage(error: unknown): string {
+  if (!axios.isAxiosError(error)) {
+    return 'Nie udalo sie ponowic proby dostarczenia.'
+  }
+
+  const responseData = error.response?.data as
+    | { error?: { retryBlockedReasonCode?: InternalNotificationRetryBlockedReasonCodeDto } }
+    | undefined
+  const reasonCode = responseData?.error?.retryBlockedReasonCode
+
+  if (error.response?.status === 409 && reasonCode) {
+    return getInternalNotificationRetryBlockedReasonLabel(reasonCode)
+  }
+
+  if (error.response?.status === 403) {
+    return 'Nie masz uprawnien do ponowienia tej proby.'
+  }
+
+  return 'Nie udalo sie ponowic proby dostarczenia.'
+}
+
+export function getInternalNotificationRetrySuccessMessage(
+  outcome: InternalNotificationAttemptOutcomeDto,
+): string {
+  return `Ponowienie wykonane: ${RETRY_OUTCOME_LABELS[outcome]}.`
+}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -30,6 +30,7 @@ import {
   getPortingRequestXmlPreview,
   markPortingCommunicationAsSent,
   previewPortingCommunicationDraft,
+  retryInternalNotificationAttempt,
   retryPortingCommunication,
   sendPortingCommunication,
   triggerManualPliCbdExport,
@@ -90,6 +91,10 @@ import { PortingInternalNotificationsPanel } from '@/components/PortingInternalN
 import { InternalNotificationAttemptsPanel } from '@/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel'
 import { NotificationFailureHistoryPanel } from '@/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel'
 import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
+import {
+  getInternalNotificationRetryErrorMessage,
+  getInternalNotificationRetrySuccessMessage,
+} from '@/lib/internalNotificationRetryMessages'
 import {
   canManagePortingOwnership,
   canSelectAnyAssignee,
@@ -619,6 +624,12 @@ export function RequestDetailPage() {
   const [internalNotificationAttemptsError, setInternalNotificationAttemptsError] = useState<
     string | null
   >(null)
+  const [internalNotificationAttemptsRetrySuccess, setInternalNotificationAttemptsRetrySuccess] =
+    useState<string | null>(null)
+  const [internalNotificationAttemptsRetryError, setInternalNotificationAttemptsRetryError] =
+    useState<string | null>(null)
+  const [retryingInternalNotificationAttemptId, setRetryingInternalNotificationAttemptId] =
+    useState<string | null>(null)
   const [notificationFailureItems, setNotificationFailureItems] = useState<
     NotificationFailureHistoryItemDto[]
   >([])
@@ -716,6 +727,7 @@ export function RequestDetailPage() {
     () => ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER'].includes(user?.role ?? ''),
     [user?.role],
   )
+  const canRetryInternalNotificationAttempts = canManageStatus
   const isAdmin = useMemo(() => user?.role === 'ADMIN', [user?.role])
   const { capabilities: systemCapabilities } = useSystemCapabilities()
   const canUsePliCbdExport = systemCapabilities.pliCbd.capabilities.export
@@ -914,6 +926,38 @@ export function RequestDetailPage() {
       setIsInternalNotificationAttemptsLoading(false)
     }
   }, [id])
+
+  const handleRetryInternalNotificationAttempt = useCallback(
+    async (attemptId: string) => {
+      if (!id || !canRetryInternalNotificationAttempts || retryingInternalNotificationAttemptId) {
+        return
+      }
+
+      setRetryingInternalNotificationAttemptId(attemptId)
+      setInternalNotificationAttemptsRetrySuccess(null)
+      setInternalNotificationAttemptsRetryError(null)
+
+      try {
+        const result = await retryInternalNotificationAttempt(id, attemptId)
+        setInternalNotificationAttemptsRetrySuccess(
+          getInternalNotificationRetrySuccessMessage(result.retryAttempt.outcome),
+        )
+        await loadInternalNotificationAttempts()
+      } catch (errorValue) {
+        setInternalNotificationAttemptsRetryError(
+          getInternalNotificationRetryErrorMessage(errorValue),
+        )
+      } finally {
+        setRetryingInternalNotificationAttemptId(null)
+      }
+    },
+    [
+      canRetryInternalNotificationAttempts,
+      id,
+      loadInternalNotificationAttempts,
+      retryingInternalNotificationAttemptId,
+    ],
+  )
 
   const loadNotificationFailures = useCallback(async () => {
     if (!id) return
@@ -1170,6 +1214,9 @@ export function RequestDetailPage() {
     setCommunicationPreview(null)
     setAssignmentFeedbackError(null)
     setAssignmentFeedbackSuccess(null)
+    setInternalNotificationAttemptsRetrySuccess(null)
+    setInternalNotificationAttemptsRetryError(null)
+    setRetryingInternalNotificationAttemptId(null)
 
     if (!caseNumber) return
     void loadRequest()
@@ -1975,6 +2022,11 @@ export function RequestDetailPage() {
                 items={internalNotificationAttemptItems}
                 isLoading={isInternalNotificationAttemptsLoading}
                 error={internalNotificationAttemptsError}
+                canRetryAttempts={canRetryInternalNotificationAttempts}
+                retryingAttemptId={retryingInternalNotificationAttemptId}
+                retrySuccessMessage={internalNotificationAttemptsRetrySuccess}
+                retryErrorMessage={internalNotificationAttemptsRetryError}
+                onRetryAttempt={(attemptId) => void handleRetryInternalNotificationAttempt(attemptId)}
               />
             </div>
           </SectionCard>

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -24,6 +24,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR19A-1 | NotificationOps foundation: first-class delivery attempts + dual-write | DONE   |
 | PR19A-2 | Request-level read layer dla internal notification attempts        | DONE   |
 | PR19B-1 | Backend retry eligibility + request-scoped retry endpoint          | DONE   |
+| PR19B-2 / Etap 5A | RequestDetail retry UI dla internal notification attempts | DONE |
 | PR20E | Full server-side operational status filters for global queue       | DONE   |
 | Etap 2A.1 | Frontend redesign foundation + app shell + RequestsPage          | DONE   |
 | Etap 2A.2 | Frontend redesign RequestDetailPage                              | DONE   |
@@ -207,6 +208,26 @@ Dispatch jest non-blocking (`.catch(() => {})`) i nie blokuje glownego flow API.
   - zewnetrzne I/O transportu nie jest trzymane w dlugiej transakcji DB,
   - eligibility jest sprawdzane przed transportem i ponownie w krotkiej transakcji zapisu,
   - w rzadkim wyscigu po wykonaniu transportu, ale przed zapisem, transakcja moze odrzucic retry jako juz nie-latest.
+
+### PR19B-2 / Etap 5A - retry action w UI dla internal notification attempts
+
+- Scope: frontend-first, waski slice na `RequestDetailPage` + `InternalNotificationAttemptsPanel`.
+- `InternalNotificationAttemptsPanel`:
+  - pokazuje akcje `Ponow` tylko dla rekordow `canRetry=true`,
+  - dla `canRetry=false` pokazuje czytelny powod blokady mapowany z `retryBlockedReasonCode`,
+  - nie pokazuje surowych backendowych reason-code jako jedynej tresci.
+- `RequestDetailPage`:
+  - podpina akcje retry do endpointu `POST /api/porting-requests/:id/internal-notification-attempts/:attemptId/retry`,
+  - po sukcesie pokazuje feedback operacyjny i odswieza listy attempts,
+  - po bledzie pokazuje czytelny feedback bez resetowania calego panelu.
+- Frontend respektuje backend source-of-truth:
+  - eligibility pochodzi z `canRetry` / `retryBlockedReasonCode`,
+  - brak lokalnego "silnika retry" i brak lokalnych reguly zastawiajacych backend.
+- Zakres celowo poza PR19B-2:
+  - brak zmian Prisma schema,
+  - brak zmian backend transport adapterow,
+  - brak zmian NOTE parsing,
+  - brak rozbudowy globalnego ops center i brak redesignu kolejki.
 
 ### PR15 - operacyjne raportowanie commercial owner i health notyfikacji
 


### PR DESCRIPTION
1. Cel
Dodac operator-facing retry UI dla request-scoped internal notification attempts na bazie backendu PR19B-1.

2. Zakres zmian
- Przycisk Ponow widoczny tylko dla attemptow z canRetry=true.
- Czytelne powody blokady dla canRetry=false mapowane z retryBlockedReasonCode.
- RequestDetailPage wywoluje retry endpoint, pokazuje feedback i odswieza attempts po sukcesie.
- Dodany helper komunikatow i testy panelu/helpera.
- Aktualizacja docs/PROJECT_CONTINUITY.md dla PR19B-2 / Etap 5A.

3. Zmienione pliki / obszary
- apps/frontend/src/components/InternalNotificationAttemptsPanel/*
- apps/frontend/src/lib/internalNotificationRetryMessages*
- apps/frontend/src/pages/Requests/RequestDetailPage.tsx
- docs/PROJECT_CONTINUITY.md

4. Testy i walidacja
- npm run test -w apps/frontend - PASS, 36 plikow / 193 testy
- npx tsc --noEmit -p apps/frontend/tsconfig.json - PASS

5. Ryzyka / otwarte punkty
- Bez zmian backend retry engine, Prisma, NOTE parsing i 4B.x.
- Reason input dla retry pozostaje poza zakresem.
- Tooling ESM jest oddzielony na lokalnym branchu codex/tooling-semi-automation-esm i nie wchodzi do tego PR.

6. Checklist przed merge
- [x] Produktowy diff nie zawiera package.json ani agent/.claude artefaktow.
- [x] Frontend testy przeszly.
- [x] Frontend typecheck przeszedl.
- [ ] Manual QA: retry available, retry blocked, retry success, retry failure, refresh panelu po akcji.