### PR TITLE
Dodaj pipeline oparty o scope i globalny odczyt prób internal notification

### DIFF
--- a/agent/loops/run-task.js
+++ b/agent/loops/run-task.js
@@ -3,64 +3,191 @@ import fs from "fs";
 
 const MAX_ITERATIONS = 3;
 
-function runTests() {
+function readUtf8(path) {
+  return fs.readFileSync(path, "utf-8");
+}
+
+function runCommand(command) {
   try {
-    return execSync("npm test").toString();
-  } catch (e) {
-    return e.stdout.toString();
+    return execSync(command, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (error) {
+    const stdout = error?.stdout?.toString?.() ?? "";
+    const stderr = error?.stderr?.toString?.() ?? "";
+    return `${stdout}\n${stderr}`.trim();
   }
 }
 
+function runTests() {
+  return runCommand("npm test");
+}
+
 function getDiff() {
-  return execSync("git diff").toString();
+  return runCommand("git diff");
+}
+
+function toBulletList(items) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return "- brak";
+  }
+
+  return items.map((item) => `- ${item}`).join("\n");
+}
+
+function toCommaList(items) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return "brak";
+  }
+
+  return items.join(", ");
+}
+
+function loadTask() {
+  const raw = readUtf8("agent/state/task.json");
+  const task = JSON.parse(raw);
+
+  const requiredFields = [
+    "id",
+    "title",
+    "goal",
+    "scope",
+    "allowedAreas",
+    "forbiddenAreas",
+    "constraints",
+    "definitionOfDone",
+  ];
+
+  for (const field of requiredFields) {
+    if (!(field in task)) {
+      throw new Error(`Brakuje pola "${field}" w agent/state/task.json`);
+    }
+  }
+
+  return task;
+}
+
+function buildTaskSummary(task) {
+  return [
+    `ID: ${task.id}`,
+    `TYTUŁ: ${task.title}`,
+    `CEL: ${task.goal}`,
+    `SCOPE: ${task.scope}`,
+    `DOZWOLONE OBSZARY: ${toCommaList(task.allowedAreas)}`,
+    `ZABRONIONE OBSZARY: ${toCommaList(task.forbiddenAreas)}`,
+    `OGRANICZENIA:\n${toBulletList(task.constraints)}`,
+    `DEFINITION OF DONE:\n${toBulletList(task.definitionOfDone)}`,
+  ].join("\n\n");
+}
+
+function renderTemplate(template, task, extraReplacements = {}) {
+  const replacements = {
+    "{{task}}": buildTaskSummary(task),
+    "{{taskId}}": task.id,
+    "{{taskTitle}}": task.title,
+    "{{taskGoal}}": task.goal,
+    "{{taskScope}}": task.scope,
+    "{{taskAllowedAreas}}": toCommaList(task.allowedAreas),
+    "{{taskForbiddenAreas}}": toCommaList(task.forbiddenAreas),
+    "{{taskConstraints}}": toBulletList(task.constraints),
+    "{{taskDefinitionOfDone}}": toBulletList(task.definitionOfDone),
+    "{{diff}}": "",
+    "{{tests}}": "",
+    ...extraReplacements,
+  };
+
+  let output = template;
+
+  for (const [key, value] of Object.entries(replacements)) {
+    output = output.split(key).join(value);
+  }
+
+  return output;
+}
+
+function extractFixPrompt(input) {
+  const marker = "PROMPT_DLA_CODEX:";
+  const markerIndex = input.indexOf(marker);
+
+  if (markerIndex === -1) {
+    return input.trim();
+  }
+
+  return input.slice(markerIndex + marker.length).trim();
+}
+
+function readSinglePaste() {
+  return new Promise((resolve) => {
+    process.stdin.once("data", (chunk) => {
+      resolve(chunk.toString());
+    });
+  });
 }
 
 (async () => {
-  const task = JSON.parse(fs.readFileSync("agent/state/task.json")).task;
+  const task = loadTask();
 
-  let currentPrompt = fs.readFileSync("agent/prompts/codex-task.md", "utf-8")
-    .replace("{{task}}", task);
+  let currentPrompt = renderTemplate(
+    readUtf8("agent/prompts/codex-task.md"),
+    task
+  );
 
   for (let i = 0; i < MAX_ITERATIONS; i++) {
-    console.log(`\n🚀 ITERACJA ${i + 1}`);
-
-    console.log("\n👉 Wklej do Codex:\n");
+    console.log(`\n🚀 ITERACJA ${i + 1}/${MAX_ITERATIONS}`);
+    console.log("\n==================================================");
+    console.log("PROMPT DLA CODEX");
+    console.log("==================================================\n");
     console.log(currentPrompt);
 
-    await new Promise(r => process.stdin.once("data", r));
+    console.log("\n⏳ Po wklejeniu promptu do Codex wciśnij ENTER...");
+    await readSinglePaste();
 
     const tests = runTests();
     const diff = getDiff();
 
-    // prompt dla Claude
-    let reviewPrompt = fs.readFileSync("agent/prompts/claude-review.md", "utf-8")
-      .replace("{{task}}", task)
-      .replace("{{diff}}", diff)
-      .replace("{{tests}}", tests);
+    const reviewPrompt = renderTemplate(
+      readUtf8("agent/prompts/claude-review.md"),
+      task,
+      {
+        "{{diff}}": diff || "(brak zmian w diff)",
+        "{{tests}}": tests || "(brak outputu testów)",
+      }
+    );
 
-    console.log("\n👉 Wklej do Claude:\n");
+    console.log("\n==================================================");
+    console.log("PROMPT DLA CLAUDE REVIEW");
+    console.log("==================================================\n");
     console.log(reviewPrompt);
 
-    console.log("\n⏳ Wklej odpowiedź Claude i ENTER...");
-    const input = await new Promise(resolve => {
-      let data = "";
-      process.stdin.on("data", chunk => {
-        data += chunk.toString();
-        if (data.includes("DECYZJA")) resolve(data);
-      });
-    });
+    console.log(
+      '\n⏳ Wklej CAŁĄ odpowiedź Claude jednym paste i naciśnij ENTER...'
+    );
+    const input = await readSinglePaste();
 
-    if (input.includes("OK")) {
+    if (input.includes("DECYZJA: OK")) {
       console.log("\n✅ Claude uznał zadanie za OK");
-      break;
+      console.log("\n👉 FINALNY AUDYT → ChatGPT");
+      return;
     }
 
-    if (input.includes("FIX")) {
-      const fixPrompt = input.split("FIX")[1];
-      currentPrompt = fixPrompt;
-      console.log("\n🔁 Poprawka wygenerowana");
+    if (input.includes("DECYZJA: FIX")) {
+      currentPrompt = extractFixPrompt(input);
+      console.log("\n🔁 Wczytano prompt naprawczy dla Codex");
+      continue;
     }
+
+    console.log(
+      "\n⚠️ Nie wykryto jasnej decyzji 'DECYZJA: OK' ani 'DECYZJA: FIX'."
+    );
+    console.log("Traktuję odpowiedź jako FIX i przekazuję ją dalej do kolejnej iteracji.\n");
+    currentPrompt = extractFixPrompt(input);
   }
 
-  console.log("\n👉 FINALNY AUDYT → ChatGPT");
-})();
+  console.log("\n🛑 Osiągnięto maksymalną liczbę iteracji.");
+  console.log("👉 Zrób ręczny audyt końcowy w ChatGPT.");
+})().catch((error) => {
+  console.error("\n❌ Błąd działania pipeline:");
+  console.error(error);
+  process.exit(1);
+});

--- a/agent/prompts/audit.md
+++ b/agent/prompts/audit.md
@@ -2,27 +2,66 @@ Jesteś głównym architektem systemu NP-Manager.
 
 Kontekst:
 - system do zarządzania portowaniem (FNP)
-- frontend musi być prosty i operacyjny
 - backend jest źródłem prawdy
+- frontend ma być prosty i operacyjny
+- zakres zmiany wynika z task.json
 
-Zadanie:
+DANE ZADANIA
+
+ID:
+{{taskId}}
+
+TYTUŁ:
+{{taskTitle}}
+
+CEL:
+{{taskGoal}}
+
+SCOPE:
+{{taskScope}}
+
+DOZWOLONE OBSZARY:
+{{taskAllowedAreas}}
+
+ZABRONIONE OBSZARY:
+{{taskForbiddenAreas}}
+
+OGRANICZENIA:
+{{taskConstraints}}
+
+DEFINITION OF DONE:
+{{taskDefinitionOfDone}}
+
+SKRÓT ZADANIA:
 {{task}}
 
-Zmiany w kodzie:
+ZMIANY W KODZIE:
 {{diff}}
 
-Wynik testów:
+WYNIK TESTÓW:
 {{tests}}
 
 Twoje zadanie:
 
 1. Oceń czy zmiana jest poprawna architektonicznie
-2. Sprawdź czy nie ma regresji
-3. Sprawdź czy UX nie został pogorszony
-4. Wykryj potencjalne bugi
+2. Sprawdź czy scope taska nie został naruszony
+3. Sprawdź czy nie ma regresji
+4. Sprawdź czy UX nie został pogorszony
+5. Wykryj potencjalne bugi
+6. Oceń czy nie ma ukrytych zmian poza zakresem
 
-Odpowiedz:
+Odpowiedz w formacie:
 
-- STATUS: OK / NOT OK
-- PROBLEMY:
-- POPRAWKI:
+STATUS: OK / NOT OK
+
+MOCNE STRONY:
+- ...
+
+PROBLEMY:
+- ...
+
+POPRAWKI:
+- ...
+
+WERDYKT:
+- krótka końcowa ocena

--- a/agent/prompts/claude-review.md
+++ b/agent/prompts/claude-review.md
@@ -1,122 +1,147 @@
 Jesteś lead developerem odpowiedzialnym za jakość zmian w NP-Manager.
 
 Kontekst:
-- zmiana dotyczy WYŁĄCZNIE frontend (apps/frontend/**)
+- system jest backend-driven
 - backend jest source of truth
-- retry opiera się o:
-  - item.canRetry
-  - retryBlockedReasonCode
-  - istniejący endpoint retry
+- zakres zmian wynika z task.json, a nie z domysłów
+- review ma sprawdzić zarówno poprawność feature, jak i zgodność ze scope taska
 
-Zadanie:
+DANE ZADANIA
+
+ID:
+{{taskId}}
+
+TYTUŁ:
+{{taskTitle}}
+
+CEL:
+{{taskGoal}}
+
+SCOPE:
+{{taskScope}}
+
+DOZWOLONE OBSZARY:
+{{taskAllowedAreas}}
+
+ZABRONIONE OBSZARY:
+{{taskForbiddenAreas}}
+
+OGRANICZENIA:
+{{taskConstraints}}
+
+DEFINITION OF DONE:
+{{taskDefinitionOfDone}}
+
+SKRÓT ZADANIA:
 {{task}}
 
-Zmiany w kodzie:
+ZMIANY W KODZIE:
 {{diff}}
 
-Wynik testów:
+WYNIK TESTÓW:
 {{tests}}
 
 ---
 
 TWOJE ZADANIE
 
-Przeprowadź twardą weryfikację w 4 krokach:
+Przeprowadź twardą weryfikację w 6 krokach.
 
-KROK 1 — WYKONANIE FEATURE
+KROK 1 — ZGODNOŚĆ ZE SCOPE
 Sprawdź czy:
-- istnieje przycisk "Ponów"
-- jest renderowany tylko gdy item.canRetry === true
-- wywołuje onRetryAttempt(item.id)
+- zmiany mieszczą się w allowedAreas
+- forbiddenAreas nie zostały naruszone
+- nie ma ukrytego rozszerzenia zakresu
+- nie wykonano zbędnych zmian poza taskiem
 
 Jeśli którykolwiek warunek NIE jest spełniony → FIX
 
 ---
 
-KROK 2 — UX / INTERAKCJA
+KROK 2 — WYKONANIE ZADANIA
 Sprawdź czy:
-- istnieje loading state ("Ponawiam...")
-- przycisk jest disabled podczas retry
-- użytkownik widzi:
-  - success message
-  - error message
-- NIE ma resetu całego panelu
+- implementacja rzeczywiście realizuje goal
+- definitionOfDone jest spełnione
+- zmiana obejmuje minimalny potrzebny vertical slice
+- nie pominięto potrzebnej warstwy (np. backend/shared), jeśli task tego wymagał
 
-Jeśli coś brakuje → FIX
+Jeśli coś jest niepełne → FIX
 
 ---
 
 KROK 3 — ARCHITEKTURA
 Sprawdź czy:
-- NIE zmieniono plików:
-  - apps/backend/**
-  - packages/shared/**
-  - prisma/**
-- NIE dodano lokalnej logiki retry (np. if/else zamiast backendu)
-- użyto istniejącego endpointu retry
+- respektowany jest backend as source of truth
+- nie przeniesiono logiki tam, gdzie nie powinna być
+- nie dodano obejścia zamiast właściwej zmiany
+- kod jest spójny z architekturą NP-Manager
 
-Jeśli naruszono którykolwiek punkt → FIX
+Jeśli jest problem architektoniczny → FIX
 
 ---
 
 KROK 4 — JAKOŚĆ ZMIAN
 Sprawdź czy:
-- zmiany są ograniczone tylko do potrzebnych plików
-- NIE ma zmian typu:
-  - package.json
-  - config
-  - inne niezwiązane pliki
-- kod jest spójny z istniejącym stylem
+- zmieniono tylko potrzebne pliki
+- nie ma zbędnych zmian w package.json, configach, toolingach lub innych niezwiązanych plikach
+- kod jest spójny z istniejącym stylem repo
+- nie ma oczywistych regresji
 
-Jeśli są zbędne zmiany → FIX
+Jeśli są zbędne lub ryzykowne zmiany → FIX
 
 ---
 
 KROK 5 — TESTY
-- jeśli testy FAIL → FIX
-- ignoruj "0 test files"
+Sprawdź czy:
+- testy są adekwatne do zakresu
+- wynik testów nie wskazuje realnego problemu
+- można odróżnić prawdziwy FAIL od znanych sytuacji typu "0 test files"
+
+Jeśli testy ujawniają problem → FIX
 
 ---
 
-ODPOWIEDŹ (OBOWIĄZKOWY FORMAT)
+KROK 6 — WERDYKT
+Jeśli masz jakiekolwiek istotne wątpliwości → wybierz FIX
+
+---
+
+ODPOWIEDŹ — OBOWIĄZKOWY FORMAT
 
 DECYZJA: OK / FIX
 
 UZASADNIENIE:
 - krótko dlaczego
 
+PROBLEMY:
+- punktami, tylko jeśli istnieją
+
 JEŚLI FIX:
 
-Zwróć GOTOWY PROMPT dla Codex:
-
-- bardzo konkretny
-- wskazujący pliki
-- bez ogólników
-
-FORMAT:
-
-Popraw w pliku:
-<ścieżka>
+PROMPT_DLA_CODEX:
+Popraw dokładnie wskazane problemy.
+Trzymaj się scope:
+- dozwolone: {{taskAllowedAreas}}
+- zabronione: {{taskForbiddenAreas}}
 
 Zrób:
 - konkretna zmiana 1
 - konkretna zmiana 2
+- konkretna zmiana 3
 
 Nie zmieniaj:
-- backend
-- innych plików
+- żadnych plików poza allowedAreas
+- niczego poza zakresem taska
 
----
+Zwróć:
+- pełny kod zmienionych plików
+- krótką listę zmian
+- krótkie uzasadnienie
 
 JEŚLI OK:
 
 Potwierdź:
-- feature działa poprawnie
-- UX jest kompletny
-- brak regresji
+- task jest wykonany poprawnie
+- scope nie został naruszony
 - brak nieautoryzowanych zmian
-
----
-
-ZASADA:
-Jeśli masz jakiekolwiek wątpliwości → wybierz FIX
+- brak oczywistych regresji

--- a/agent/prompts/codex-task.md
+++ b/agent/prompts/codex-task.md
@@ -1,19 +1,63 @@
-Jesteś Codex pracującym nad NP-Manager.
+Jesteś Codex pracującym nad projektem NP-Manager.
 
-Zadanie:
+Kontekst projektu:
+- Stack: Fastify + Prisma + React + Zustand + Tailwind
+- Architektura: backend-driven, backend jest source of truth
+- System: FNP / NP-Manager
+- Nie wymyślaj lokalnej logiki w frontendzie, jeśli właściwe miejsce jest w backendzie
+
+DANE ZADANIA
+
+ID:
+{{taskId}}
+
+TYTUŁ:
+{{taskTitle}}
+
+CEL:
+{{taskGoal}}
+
+SCOPE:
+{{taskScope}}
+
+DOZWOLONE OBSZARY:
+{{taskAllowedAreas}}
+
+ZABRONIONE OBSZARY:
+{{taskForbiddenAreas}}
+
+OGRANICZENIA:
+{{taskConstraints}}
+
+DEFINITION OF DONE:
+{{taskDefinitionOfDone}}
+
+SKRÓT ZADANIA:
 {{task}}
 
-ZAKRES:
-- apps/frontend/**
+TRYB PRACY
 
-ZABRONIONE:
-- backend
-- prisma
-- shared
+1. Najpierw przeanalizuj zakres taska.
+2. Trzymaj się wyłącznie allowedAreas.
+3. Nie zmieniaj forbiddenAreas.
+4. Jeśli task dopuszcza backend lub shared i zmiana jest tam potrzebna, wykonaj ją tam zamiast robić obejście.
+5. Nie rób szerokiego refactoru.
+6. Nie zmieniaj migracji, auth, RBAC ani innych obszarów poza taskiem, jeśli task nie wymaga tego wprost.
+7. Zmieniaj tylko minimalny vertical slice potrzebny do realizacji zadania.
 
-Wymagania:
-- użyj istniejącego API retry
-- pokaż loading
-- pokaż success/error
+WYMAGANY SPOSÓB ODPOWIEDZI
 
-Zwróć pełny kod zmienionych plików.
+Zwróć:
+
+1. listę zmienionych plików
+2. krótką listę zmian
+3. pełny kod każdego zmienionego pliku
+4. krótkie uzasadnienie architektoniczne
+5. listę uruchomionych testów / komend walidacyjnych
+
+WAŻNE
+
+- Nie zakładaj z góry, że task jest frontend-only.
+- Zakres wynika z task.json.
+- Jeśli czegoś nie trzeba zmieniać, nie dotykaj tego.
+- Nie modyfikuj plików poza zakresem tylko po to, żeby "posprzątać".

--- a/agent/state/task.json
+++ b/agent/state/task.json
@@ -1,4 +1,24 @@
 {
-  "task": "Dodaj prosty przycisk retry w InternalNotificationAttemptsPanel z wykorzystaniem istniejącego endpointu retry",
-  "status": "pending"
+  "id": "pr20a-global-internal-notification-attempts-read-api",
+  "title": "Dodaj globalny read endpoint dla internal notification attempts",
+  "goal": "Udostępnić backendowy operacyjny odczyt prób notyfikacji wewnętrznych do przyszłej globalnej listy UI.",
+  "scope": "backend",
+  "allowedAreas": ["backend", "shared"],
+  "forbiddenAreas": ["frontend"],
+  "constraints": [
+    "Implement only the minimal vertical slice required by the task",
+    "Do not introduce unrelated refactors",
+    "Do not add Prisma migrations unless explicitly required",
+    "Do not change auth or RBAC unless explicitly required",
+    "Do not modify existing retry semantics",
+    "Do not change notification transport adapters",
+    "Do not change NOTE parsing compatibility behavior"
+  ],
+  "definitionOfDone": [
+    "A new read endpoint for internal notification attempts list exists",
+    "Shared DTOs required by the endpoint are added or updated",
+    "Backend tests covering the new endpoint or service are added or updated",
+    "Type checks and builds pass",
+    "No unrelated files are modified"
+  ]
 }

--- a/apps/backend/src/__tests__/app.runtime-routes.test.ts
+++ b/apps/backend/src/__tests__/app.runtime-routes.test.ts
@@ -15,6 +15,7 @@ describe('runtime route diagnostics', () => {
         '/api/operators',
         '/api/porting-requests',
         '/api/admin',
+        '/api/internal-notification-attempts',
         '/api/system',
       ])
 
@@ -23,6 +24,7 @@ describe('runtime route diagnostics', () => {
         { method: 'GET', url: '/api/system/capabilities', registered: true },
         { method: 'GET', url: '/api/admin/system-mode-settings', registered: true },
         { method: 'PUT', url: '/api/admin/system-mode-settings', registered: true },
+        { method: 'GET', url: '/api/internal-notification-attempts', registered: true },
         { method: 'GET', url: '/api/porting-requests', registered: true },
         { method: 'GET', url: '/api/porting-requests/:id', registered: true },
         {

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -13,6 +13,7 @@ import { adminUsersRouter } from './modules/admin-users/admin-users.router'
 import { adminPortingNotificationSettingsRouter } from './modules/admin-settings/admin-porting-notification-settings.router'
 import { adminNotificationFallbackSettingsRouter } from './modules/admin-settings/admin-notification-fallback-settings.router'
 import { adminSystemModeSettingsRouter } from './modules/admin-settings/admin-system-mode-settings.router'
+import { internalNotificationAttemptsRouter } from './modules/porting-requests/internal-notification-attempts.router'
 import { internalNotificationFailuresRouter } from './modules/porting-requests/internal-notification-failures.router'
 import { systemCapabilitiesRouter } from './modules/system-capabilities/system-capabilities.router'
 import { bootstrapSystemCapabilities } from './modules/system-capabilities/system-capabilities.bootstrap'
@@ -27,6 +28,7 @@ const REGISTERED_API_PREFIXES = [
   '/api/operators',
   '/api/porting-requests',
   '/api/admin',
+  '/api/internal-notification-attempts',
   '/api/system',
 ] as const
 
@@ -35,6 +37,7 @@ export const REQUIRED_RUNTIME_ROUTES = [
   { method: 'GET', url: '/api/system/capabilities' },
   { method: 'GET', url: '/api/admin/system-mode-settings' },
   { method: 'PUT', url: '/api/admin/system-mode-settings' },
+  { method: 'GET', url: '/api/internal-notification-attempts' },
   { method: 'GET', url: '/api/porting-requests' },
   { method: 'GET', url: '/api/porting-requests/:id' },
   { method: 'POST', url: '/api/porting-requests/:id/communications/preview' },
@@ -113,6 +116,9 @@ export async function buildApp() {
   await app.register(adminPortingNotificationSettingsRouter, { prefix: '/api/admin' })
   await app.register(adminNotificationFallbackSettingsRouter, { prefix: '/api/admin' })
   await app.register(adminSystemModeSettingsRouter, { prefix: '/api/admin' })
+  await app.register(internalNotificationAttemptsRouter, {
+    prefix: '/api/internal-notification-attempts',
+  })
   await app.register(internalNotificationFailuresRouter, { prefix: '/api/internal-notification-failures' })
   await app.register(systemCapabilitiesRouter, { prefix: '/api/system' })
 

--- a/apps/backend/src/modules/porting-requests/__tests__/global-internal-notification-attempts.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/global-internal-notification-attempts.service.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockAttemptFindMany, mockAttemptCount } = vi.hoisted(() => ({
+  mockAttemptFindMany: vi.fn(),
+  mockAttemptCount: vi.fn(),
+}))
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    internalNotificationDeliveryAttempt: {
+      findMany: (...args: unknown[]) => mockAttemptFindMany(...args),
+      count: (...args: unknown[]) => mockAttemptCount(...args),
+    },
+  },
+}))
+
+import { getGlobalInternalNotificationAttempts } from '../global-internal-notification-attempts.service'
+
+function buildAttempt(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'attempt-1',
+    requestId: 'request-1',
+    request: { caseNumber: 'FNP-20260411-ABC123' },
+    eventCode: 'STATUS_CHANGED',
+    eventLabel: 'Zmiana statusu sprawy',
+    attemptOrigin: 'PRIMARY',
+    channel: 'EMAIL',
+    recipient: 'bok@test.pl',
+    mode: 'REAL',
+    outcome: 'FAILED',
+    errorCode: 'DELIVERY_FAILED',
+    errorMessage: 'Timeout SMTP',
+    failureKind: 'DELIVERY',
+    retryOfAttemptId: null,
+    retryCount: 0,
+    isLatestForChain: true,
+    triggeredByUserId: 'manager-1',
+    triggeredByUser: {
+      firstName: 'Marta',
+      lastName: 'Manager',
+      email: 'manager@np-manager.local',
+    },
+    createdAt: new Date('2026-04-11T10:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+describe('getGlobalInternalNotificationAttempts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns global attempts with request case number and retry eligibility', async () => {
+    mockAttemptFindMany.mockResolvedValue([buildAttempt()])
+    mockAttemptCount.mockResolvedValue(1)
+
+    const result = await getGlobalInternalNotificationAttempts()
+
+    expect(result.total).toBe(1)
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0]).toMatchObject({
+      attemptId: 'attempt-1',
+      requestId: 'request-1',
+      caseNumber: 'FNP-20260411-ABC123',
+      eventCode: 'STATUS_CHANGED',
+      eventLabel: 'Zmiana statusu sprawy',
+      recipient: 'bok@test.pl',
+      channel: 'EMAIL',
+      outcome: 'FAILED',
+      retryCount: 0,
+      canRetry: true,
+      retryBlockedReasonCode: null,
+      errorMessage: 'Timeout SMTP',
+      createdAt: '2026-04-11T10:00:00.000Z',
+    })
+  })
+
+  it('includes triggered user display name when available', async () => {
+    mockAttemptFindMany.mockResolvedValue([buildAttempt()])
+    mockAttemptCount.mockResolvedValue(1)
+
+    const result = await getGlobalInternalNotificationAttempts()
+
+    expect(result.items[0]?.triggeredByDisplayName).toBe(
+      'Marta Manager (manager@np-manager.local)',
+    )
+  })
+
+  it('returns retry blocked reason for non-retryable successful attempt', async () => {
+    mockAttemptFindMany.mockResolvedValue([
+      buildAttempt({
+        outcome: 'SENT',
+        errorCode: null,
+        errorMessage: null,
+        failureKind: null,
+      }),
+    ])
+    mockAttemptCount.mockResolvedValue(1)
+
+    const result = await getGlobalInternalNotificationAttempts()
+
+    expect(result.items[0]?.canRetry).toBe(false)
+    expect(result.items[0]?.retryBlockedReasonCode).toBe('OUTCOME_NOT_RETRYABLE')
+  })
+
+  it('orders newest first and applies limit and offset', async () => {
+    mockAttemptFindMany.mockResolvedValue([])
+    mockAttemptCount.mockResolvedValue(0)
+
+    await getGlobalInternalNotificationAttempts({ limit: 10, offset: 20 })
+
+    const callArg = mockAttemptFindMany.mock.calls[0]![0]
+    expect(callArg.orderBy).toEqual([{ createdAt: 'desc' }, { id: 'asc' }])
+    expect(callArg.take).toBe(10)
+    expect(callArg.skip).toBe(20)
+  })
+
+  it('caps limit at 100', async () => {
+    mockAttemptFindMany.mockResolvedValue([])
+    mockAttemptCount.mockResolvedValue(0)
+
+    await getGlobalInternalNotificationAttempts({ limit: 999 })
+
+    expect(mockAttemptFindMany.mock.calls[0]![0].take).toBe(100)
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/internal-notification-attempts.router.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/internal-notification-attempts.router.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { globalInternalNotificationAttemptsQuerySchema } from '../internal-notification-attempts.router'
+
+describe('globalInternalNotificationAttemptsQuerySchema', () => {
+  it('uses default pagination', () => {
+    const result = globalInternalNotificationAttemptsQuerySchema.parse({})
+
+    expect(result).toEqual({
+      limit: 50,
+      offset: 0,
+    })
+  })
+
+  it('coerces limit and offset query params', () => {
+    const result = globalInternalNotificationAttemptsQuerySchema.parse({
+      limit: '25',
+      offset: '50',
+    })
+
+    expect(result).toEqual({
+      limit: 25,
+      offset: 50,
+    })
+  })
+})

--- a/apps/backend/src/modules/porting-requests/global-internal-notification-attempts.service.ts
+++ b/apps/backend/src/modules/porting-requests/global-internal-notification-attempts.service.ts
@@ -1,0 +1,144 @@
+import type {
+  GlobalInternalNotificationAttemptItemDto,
+  GlobalInternalNotificationAttemptsResultDto,
+} from '@np-manager/shared'
+import { prisma } from '../../config/database'
+import { resolveInternalNotificationRetryEligibility } from './porting-internal-notification-retry-eligibility.helper'
+
+const DEFAULT_LIMIT = 50
+const MAX_LIMIT = 100
+
+export interface GlobalInternalNotificationAttemptsParams {
+  limit?: number
+  offset?: number
+}
+
+type GlobalAttemptRecord = {
+  id: string
+  requestId: string
+  request: { caseNumber: string }
+  eventCode: string
+  eventLabel: string
+  attemptOrigin: 'PRIMARY' | 'ERROR_FALLBACK' | 'RETRY'
+  channel: 'EMAIL' | 'TEAMS'
+  recipient: string
+  mode: 'REAL' | 'STUB' | 'DISABLED' | 'POLICY'
+  outcome: 'SENT' | 'STUBBED' | 'DISABLED' | 'MISCONFIGURED' | 'FAILED' | 'SKIPPED'
+  errorCode: string | null
+  errorMessage: string | null
+  failureKind: 'DELIVERY' | 'CONFIGURATION' | 'POLICY' | null
+  retryOfAttemptId: string | null
+  retryCount: number
+  isLatestForChain: boolean
+  triggeredByUserId: string | null
+  triggeredByUser: { firstName: string; lastName: string; email: string } | null
+  createdAt: Date
+}
+
+const globalAttemptSelect = {
+  id: true,
+  requestId: true,
+  request: {
+    select: {
+      caseNumber: true,
+    },
+  },
+  eventCode: true,
+  eventLabel: true,
+  attemptOrigin: true,
+  channel: true,
+  recipient: true,
+  mode: true,
+  outcome: true,
+  errorCode: true,
+  errorMessage: true,
+  failureKind: true,
+  retryOfAttemptId: true,
+  retryCount: true,
+  isLatestForChain: true,
+  triggeredByUserId: true,
+  triggeredByUser: {
+    select: {
+      firstName: true,
+      lastName: true,
+      email: true,
+    },
+  },
+  createdAt: true,
+} as const
+
+export async function getGlobalInternalNotificationAttempts(
+  params: GlobalInternalNotificationAttemptsParams = {},
+): Promise<GlobalInternalNotificationAttemptsResultDto> {
+  const limit = normalizeLimit(params.limit)
+  const offset = normalizeOffset(params.offset)
+
+  const [records, total] = await Promise.all([
+    prisma.internalNotificationDeliveryAttempt.findMany({
+      orderBy: [{ createdAt: 'desc' }, { id: 'asc' }],
+      take: limit,
+      skip: offset,
+      select: globalAttemptSelect,
+    }),
+    prisma.internalNotificationDeliveryAttempt.count(),
+  ])
+
+  return {
+    items: records.map(mapToDto),
+    total,
+  }
+}
+
+function mapToDto(record: GlobalAttemptRecord): GlobalInternalNotificationAttemptItemDto {
+  const { canRetry, retryBlockedReasonCode } = resolveInternalNotificationRetryEligibility(record)
+
+  return {
+    attemptId: record.id,
+    requestId: record.requestId,
+    caseNumber: record.request.caseNumber,
+    eventCode: record.eventCode,
+    eventLabel: record.eventLabel,
+    attemptOrigin: record.attemptOrigin,
+    channel: record.channel,
+    recipient: record.recipient,
+    mode: record.mode,
+    outcome: record.outcome,
+    errorCode: record.errorCode,
+    errorMessage: record.errorMessage,
+    failureKind: record.failureKind,
+    retryOfAttemptId: record.retryOfAttemptId,
+    retryCount: record.retryCount,
+    isLatestForChain: record.isLatestForChain,
+    triggeredByUserId: record.triggeredByUserId,
+    triggeredByDisplayName: formatTriggeredByDisplayName(record.triggeredByUser),
+    canRetry,
+    retryBlockedReasonCode,
+    createdAt: record.createdAt.toISOString(),
+  }
+}
+
+function formatTriggeredByDisplayName(
+  user: { firstName: string; lastName: string; email: string } | null,
+): string | null {
+  if (!user) {
+    return null
+  }
+
+  return `${user.firstName} ${user.lastName} (${user.email})`
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (!value || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_LIMIT
+  }
+
+  return Math.min(Math.floor(value), MAX_LIMIT)
+}
+
+function normalizeOffset(value: number | undefined): number {
+  if (!value || !Number.isFinite(value) || value < 0) {
+    return 0
+  }
+
+  return Math.floor(value)
+}

--- a/apps/backend/src/modules/porting-requests/internal-notification-attempts.router.ts
+++ b/apps/backend/src/modules/porting-requests/internal-notification-attempts.router.ts
@@ -1,0 +1,29 @@
+import type { FastifyInstance } from 'fastify'
+import type { UserRole } from '@prisma/client'
+import { z } from 'zod'
+import { authenticate } from '../../shared/middleware/authenticate'
+import { authorize } from '../../shared/middleware/authorize'
+import { getGlobalInternalNotificationAttempts } from './global-internal-notification-attempts.service'
+
+const globalAttemptsReadRoles: UserRole[] = ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER']
+
+export const globalInternalNotificationAttemptsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
+})
+
+export async function internalNotificationAttemptsRouter(app: FastifyInstance): Promise<void> {
+  app.get(
+    '/',
+    { preHandler: [authenticate, authorize(globalAttemptsReadRoles)] },
+    async (request, reply) => {
+      const query = globalInternalNotificationAttemptsQuerySchema.parse(request.query)
+      const result = await getGlobalInternalNotificationAttempts({
+        limit: query.limit,
+        offset: query.offset,
+      })
+
+      return reply.status(200).send({ success: true, data: result })
+    },
+  )
+}

--- a/packages/shared/src/dto/porting-internal-notifications.dto.ts
+++ b/packages/shared/src/dto/porting-internal-notifications.dto.ts
@@ -107,6 +107,35 @@ export interface GlobalNotificationFailureQueueResultDto {
   total: number
 }
 
+export interface GlobalInternalNotificationAttemptItemDto {
+  attemptId: string
+  requestId: string
+  caseNumber: string
+  eventCode: string
+  eventLabel: string
+  attemptOrigin: InternalNotificationAttemptOriginDto
+  channel: InternalNotificationAttemptChannelDto
+  recipient: string
+  mode: InternalNotificationAttemptModeDto
+  outcome: InternalNotificationAttemptOutcomeDto
+  errorCode: string | null
+  errorMessage: string | null
+  failureKind: InternalNotificationFailureKindDto
+  retryOfAttemptId: string | null
+  retryCount: number
+  isLatestForChain: boolean
+  triggeredByUserId: string | null
+  triggeredByDisplayName: string | null
+  canRetry: boolean
+  retryBlockedReasonCode: InternalNotificationRetryBlockedReasonCodeDto | null
+  createdAt: string
+}
+
+export interface GlobalInternalNotificationAttemptsResultDto {
+  items: GlobalInternalNotificationAttemptItemDto[]
+  total: number
+}
+
 export interface RetryInternalNotificationAttemptDto {
   reason?: string
 }

--- a/pipeline/INSTRUKCJA.md
+++ b/pipeline/INSTRUKCJA.md
@@ -1,0 +1,386 @@
+# NP-Manager Dev Pipeline V2 – Instrukcja obsługi
+
+> Wersja gotowa do pracy lokalnej: guardy, walidacja build/test, review prompt i raport etapu.
+
+---
+
+## 1. Po co to jest
+
+Budujesz NP-Manager przy pomocy AI i chcesz pracować w uporządkowany sposób:
+- jeden model pisze kod,
+- drugi model robi review,
+- Ty masz kontrolę nad zakresem, testami i historią cykli.
+
+Ten pipeline pomaga Ci to robić bez chaosu. Skrypt:
+- prowadzi Cię przez etapy z `plan.json`,
+- generuje gotowe prompty do skopiowania,
+- zapisuje diff zmian,
+- pilnuje guardów bezpieczeństwa,
+- uruchamia walidację techniczną,
+- generuje prompt do review,
+- zapisuje historię i raport etapu.
+
+### Czego skrypt NIE robi
+
+- nie rozmawia z AI przez API,
+- nie klika za Ciebie w Codex / Claude / ChatGPT,
+- nie commituje automatycznie kodu.
+
+To nadal jest półautomat, ale uporządkowany i bezpieczny.
+
+---
+
+## 2. Jakie pliki wchodzą w skład pipeline'u
+
+W folderze `pipeline/` masz 4 najważniejsze pliki:
+
+- `run.js` – główny skrypt / orchestrator,
+- `plan.json` – plan etapów i konfiguracja guardów,
+- `state.json` – aktualny stan pracy,
+- `INSTRUKCJA.md` – ten dokument.
+
+Dodatkowo skrypt sam tworzy foldery pomocnicze:
+
+- `pipeline/prompts/` – gotowe prompty do wklejenia,
+- `pipeline/diffs/` – zapis diffów,
+- `pipeline/reports/` – wyniki walidacji,
+- `pipeline/logs/` – raporty zakończonych etapów.
+
+### Ważne
+
+Artefakty tworzone przez pipeline są ignorowane przy analizie `git diff` i `git status` wewnątrz skryptu. Dzięki temu reviewer AI widzi głównie zmiany w kodzie aplikacji, a nie pliki pomocnicze pipeline'u.
+
+---
+
+## 3. Jednorazowe wdrożenie na laptopie
+
+### Krok 1 – skopiuj pliki
+
+Do folderu `pipeline/` w repo NP-Manager skopiuj:
+- `run.js`
+- `plan.json`
+- `state.json`
+- `INSTRUKCJA.md`
+
+### Krok 2 – przejdź do repo
+
+W terminalu:
+
+```bash
+cd C:\Users\cicha\OneDrive\Desktop\Projekt\np-manager
+```
+
+### Krok 3 – uruchom test startu
+
+```bash
+node pipeline\run.js
+```
+
+Jeśli widzisz menu z opcjami `[1] [2] [3] [4] [Q]`, to pipeline działa poprawnie.
+
+---
+
+## 4. Co jest już ustawione w tej wersji
+
+Ta wersja jest przygotowana tak, żebyś nie startował z placeholdera.
+
+### Etap 1
+
+Etap 1 jest już oznaczony jako historycznie ukończony.
+
+### Etap 2
+
+Aktywny etap to:
+
+**Auto-dismiss komunikatu sukcesu retry w RequestDetailPage**
+
+Czyli pierwszy realny prompt, jaki pipeline wygeneruje, będzie już dotyczył konkretnego zadania frontendowego, a nie pustego szablonu.
+
+---
+
+## 5. Jak działa codzienny flow pracy
+
+Po uruchomieniu:
+
+```bash
+node pipeline\run.js
+```
+
+zobaczysz menu.
+
+### Opcja [1] – Generuj prompt dla AI (kod)
+
+Używaj tej opcji, gdy chcesz zlecić modelowi napisanie lub poprawienie kodu.
+
+#### Co robi skrypt
+
+- czyta aktywny etap z `plan.json`,
+- bierze pod uwagę aktualny cykl z `state.json`,
+- jeśli poprzednia decyzja była `FIX`, dokleja feedback z poprzedniego cyklu,
+- zapisuje gotowy prompt do:
+
+`pipeline/prompts/codex-prompt.md`
+
+#### Co robisz Ty
+
+1. Otwórz `pipeline/prompts/codex-prompt.md`
+2. Skopiuj całość
+3. Wklej do Codex albo Claude Code
+4. Poczekaj aż AI rzeczywiście zapisze pliki na dysku
+5. Wróć do terminala i wybierz `[2]`
+
+---
+
+### Opcja [2] – AI skończyło: diff + guardy + walidacja + review prompt
+
+To jest najważniejsza opcja po pracy modelu.
+
+#### Co robi skrypt krok po kroku
+
+1. sprawdza `git status` (bez artefaktów pipeline'u),
+2. zapisuje diff do `pipeline/diffs/...`,
+3. sprawdza guardy (`forbidden_paths` + `allow_paths`),
+4. jeśli guardy są OK – uruchamia walidację techniczną,
+5. zapisuje raport walidacji do `pipeline/reports/...`,
+6. generuje prompt do review w:
+
+`pipeline/prompts/review-prompt.md`
+
+#### HARD STOP – bardzo ważne
+
+Jeśli skrypt wykryje zmiany w zabronionych ścieżkach, np.:
+- `apps/backend/`
+- `prisma/`
+- `packages/shared/`
+- `package.json`
+
+wtedy:
+- zapisze diff jako ślad audytowy,
+- pokaże listę naruszeń,
+- pokaże gotowe komendy `git checkout -- ...`,
+- **NIE uruchomi walidacji**,
+- **NIE wygeneruje review promptu**,
+- zakończy opcję `[2]`.
+
+Dopiero po cofnięciu niedozwolonych zmian albo dopisaniu wyjątku do `allow_paths` możesz uruchomić `[2]` ponownie.
+
+#### Co robisz Ty po poprawnym przejściu [2]
+
+1. Otwórz `pipeline/prompts/review-prompt.md`
+2. Skopiuj całość
+3. Wklej do drugiego modelu AI (nie tego, który pisał kod)
+4. Odbierz odpowiedź z decyzją `OK` albo `FIX`
+5. Wróć do terminala i wybierz `[3]`
+
+---
+
+### Opcja [3] – Wklej decyzję AI (OK / FIX)
+
+Po review wpisujesz decyzję.
+
+#### Jeśli decyzja to OK
+
+Skrypt:
+- zapisze wynik do historii,
+- oznaczy etap jako `done: true` w `plan.json`,
+- zresetuje cykl dla kolejnego etapu,
+- wygeneruje raport etapu w `pipeline/logs/...`,
+- pokaże dalsze kroki.
+
+#### Jeśli decyzja to FIX
+
+Skrypt:
+- zapisze feedback reviewera,
+- zwiększy numer cyklu,
+- przy następnym `[1]` dołączy poprawki do promptu dla modelu wykonawczego.
+
+#### Jeśli dojdziesz do 3 cykli FIX
+
+Skrypt nie będzie już kręcił się w nieskończoność. Dostaniesz komunikat, że trzeba:
+- rozbić etap na mniejsze zadania,
+- poprawić ręcznie,
+- albo zacząć od nowa z lepszym opisem.
+
+---
+
+### Opcja [4] – Pokaż raport etapu
+
+Po zakończeniu etapu decyzją `OK` możesz wyświetlić raport etapu.
+
+To jest materiał do końcowego audytu architektonicznego w ChatGPT.
+
+#### Co robisz dalej
+
+1. Otwórz raport
+2. Wklej go do ChatGPT
+3. Poproś o audyt architektoniczny
+4. Jeśli audyt jest OK – zrób commit i push
+
+---
+
+## 6. Jak wygląda pełny cykl pracy
+
+W skrócie:
+
+1. `[1]` – generujesz prompt dla modelu wykonawczego
+2. wklejasz prompt do Codex / Claude Code
+3. model zapisuje kod
+4. `[2]` – pipeline robi diff, guardy, walidację i prompt do review
+5. review prompt wklejasz do drugiego modelu AI
+6. `[3]` – wpisujesz `OK` albo `FIX`
+7. po `OK` robisz audyt w ChatGPT
+8. commit + push
+
+W jednej linii:
+
+```text
+[1] prompt → AI pisze kod → [2] diff+guardy+walidacja+review → drugi model ocenia → [3] OK/FIX → audyt ChatGPT → commit
+```
+
+---
+
+## 7. Co robić w typowych problemach
+
+### Problem 1 – prompt wygenerował się, ale AI nic nie zapisało
+
+Objaw:
+- w opcji `[2]` skrypt nie widzi zmian,
+- diff jest pusty.
+
+Co zrobić:
+1. Sprawdź pliki w VS Code
+2. Zapisz je ręcznie, jeśli trzeba (`Ctrl+S`)
+3. Jeśli AI tylko opisało zmiany, wróć do modelu i napisz:
+   
+   **"Nie opisałeś tylko zmian – zapisz pliki realnie na dysku."**
+4. Uruchom `[2]` ponownie
+
+---
+
+### Problem 2 – HARD STOP przez forbidden_paths
+
+Objaw:
+- skrypt pokazuje czerwony komunikat,
+- listę zabronionych plików,
+- i zatrzymuje się.
+
+Co zrobić:
+
+#### Wariant A – cofnij niedozwolone zmiany
+
+Skorzystaj z komend podanych przez skrypt, np.:
+
+```bash
+git checkout -- "package.json"
+```
+
+Potem uruchom `[2]` jeszcze raz.
+
+#### Wariant B – etap naprawdę wymaga wyjątku
+
+Jeśli wyjątkowo dany etap musi dotknąć pliku spoza standardowego zakresu, dopisz ścieżkę do `allow_paths` w odpowiednim etapie w `plan.json`.
+
+Potem uruchom `[2]` ponownie.
+
+---
+
+### Problem 3 – walidacja zwraca FAIL
+
+To nie oznacza jeszcze, że masz ręcznie wszystko poprawiać.
+
+W praktyce:
+- zostaw wynik FAIL w review promptcie,
+- daj reviewerowi pełen kontekst,
+- reviewer prawie na pewno zwróci `FIX` z konkretnymi poprawkami.
+
+---
+
+### Problem 4 – walidacja zwraca SKIPPED
+
+To znaczy zwykle, że:
+- nie ma danego skryptu w workspace,
+- albo komenda z `plan.json` nie pasuje do Twojego repo.
+
+Wtedy:
+1. Otwórz `plan.json`
+2. Popraw komendy w sekcji `validation`
+3. Uruchom pipeline ponownie
+
+---
+
+### Problem 5 – skończył się limit w jednym modelu
+
+To nie szkodzi.
+
+Prompty są zapisane w plikach, więc możesz płynnie przejść do innego modelu.
+
+Przykład:
+- zacząłeś w Codex,
+- kończy Ci się limit,
+- bierzesz `pipeline/prompts/codex-prompt.md`,
+- wklejasz do Claude Code,
+- pracujesz dalej.
+
+Pipeline nie jest przywiązany do jednego modelu.
+
+---
+
+### Problem 6 – chcę zacząć od nowa
+
+Jeśli chcesz zresetować stan pracy:
+
+- usuń `pipeline/state.json`
+- uruchom `node pipeline\run.js` ponownie
+
+Skrypt odtworzy stan na podstawie pierwszego etapu z `done: false`.
+
+---
+
+## 8. Co zrobić po wdrożeniu tych 4 plików
+
+### Krok 1
+Podmień 4 pliki w `pipeline/`
+
+### Krok 2
+Uruchom:
+
+```bash
+node pipeline\run.js
+```
+
+### Krok 3
+Zrób szybki test guardów:
+- dodaj drobną zmianę w `package.json`,
+- uruchom `[2]`,
+- sprawdź czy dostaniesz HARD STOP,
+- cofnij zmianę.
+
+### Krok 4
+Wróć do normalnej pracy i zacznij od aktywnego etapu 2.
+
+---
+
+## 9. Słownik najważniejszych pojęć
+
+- **etap** – jedno zadanie z `plan.json`
+- **cykl** – jedna iteracja pracy nad etapem
+- **diff** – tekstowy zapis zmian w plikach
+- **review** – ocena zmian przez drugi model AI
+- **guard / hard stop** – blokada niedozwolonych zmian
+- **walidacja** – testy i build uruchamiane przez skrypt
+- **artefakty pipeline'u** – prompty, diffy, raporty i logi tworzone przez skrypt
+
+---
+
+## 10. Najkrótsza wersja obsługi
+
+Jeśli chcesz zapamiętać tylko jedno, to zapamiętaj to:
+
+1. `[1]` – wygeneruj prompt do modelu piszącego kod
+2. AI zapisuje kod
+3. `[2]` – pipeline robi diff, guardy, testy i prompt do review
+4. drugi model robi review
+5. `[3]` – wpisujesz `OK` albo `FIX`
+6. po `OK` robisz audyt w ChatGPT i commit
+
+Powodzenia 🚀

--- a/pipeline/diffs/etap-2-cykl-1.diff
+++ b/pipeline/diffs/etap-2-cykl-1.diff
@@ -1,0 +1,674 @@
+diff --git a/.claude/worktrees/dazzling-brahmagupta b/.claude/worktrees/dazzling-brahmagupta
+--- a/.claude/worktrees/dazzling-brahmagupta
++++ b/.claude/worktrees/dazzling-brahmagupta
+@@ -1 +1 @@
+-Subproject commit 48ae00bd2bee6ef6880a4f867b87f842d1bd2988
++Subproject commit 48ae00bd2bee6ef6880a4f867b87f842d1bd2988-dirty
+diff --git a/.claude/worktrees/exciting-colden b/.claude/worktrees/exciting-colden
+--- a/.claude/worktrees/exciting-colden
++++ b/.claude/worktrees/exciting-colden
+@@ -1 +1 @@
+-Subproject commit 3ecb1b7fd498c223e51c445370fc30316f03fff9
++Subproject commit 3ecb1b7fd498c223e51c445370fc30316f03fff9-dirty
+diff --git a/.claude/worktrees/funny-williamson-647695 b/.claude/worktrees/funny-williamson-647695
+--- a/.claude/worktrees/funny-williamson-647695
++++ b/.claude/worktrees/funny-williamson-647695
+@@ -1 +1 @@
+-Subproject commit fe2a900f3c4ea664a1ae7da138bfdb9a189159f5
++Subproject commit fe2a900f3c4ea664a1ae7da138bfdb9a189159f5-dirty
+diff --git a/.claude/worktrees/gallant-aryabhata b/.claude/worktrees/gallant-aryabhata
+--- a/.claude/worktrees/gallant-aryabhata
++++ b/.claude/worktrees/gallant-aryabhata
+@@ -1 +1 @@
+-Subproject commit 22bd5b2e355dcfb9f6ba0cfe132fda4485054fdd
++Subproject commit 22bd5b2e355dcfb9f6ba0cfe132fda4485054fdd-dirty
+diff --git a/.claude/worktrees/infallible-elbakyan b/.claude/worktrees/infallible-elbakyan
+--- a/.claude/worktrees/infallible-elbakyan
++++ b/.claude/worktrees/infallible-elbakyan
+@@ -1 +1 @@
+-Subproject commit fe4324d632288556208973a8f5250c1ea1850054
++Subproject commit fe4324d632288556208973a8f5250c1ea1850054-dirty
+diff --git a/agent/loops/run-task.js b/agent/loops/run-task.js
+index ce0347a..67bbb33 100644
+--- a/agent/loops/run-task.js
++++ b/agent/loops/run-task.js
+@@ -3,64 +3,191 @@ import fs from "fs";
+ 
+ const MAX_ITERATIONS = 3;
+ 
+-function runTests() {
++function readUtf8(path) {
++  return fs.readFileSync(path, "utf-8");
++}
++
++function runCommand(command) {
+   try {
+-    return execSync("npm test").toString();
+-  } catch (e) {
+-    return e.stdout.toString();
++    return execSync(command, {
++      encoding: "utf-8",
++      stdio: ["pipe", "pipe", "pipe"],
++    });
++  } catch (error) {
++    const stdout = error?.stdout?.toString?.() ?? "";
++    const stderr = error?.stderr?.toString?.() ?? "";
++    return `${stdout}\n${stderr}`.trim();
+   }
+ }
+ 
++function runTests() {
++  return runCommand("npm test");
++}
++
+ function getDiff() {
+-  return execSync("git diff").toString();
++  return runCommand("git diff");
++}
++
++function toBulletList(items) {
++  if (!Array.isArray(items) || items.length === 0) {
++    return "- brak";
++  }
++
++  return items.map((item) => `- ${item}`).join("\n");
++}
++
++function toCommaList(items) {
++  if (!Array.isArray(items) || items.length === 0) {
++    return "brak";
++  }
++
++  return items.join(", ");
++}
++
++function loadTask() {
++  const raw = readUtf8("agent/state/task.json");
++  const task = JSON.parse(raw);
++
++  const requiredFields = [
++    "id",
++    "title",
++    "goal",
++    "scope",
++    "allowedAreas",
++    "forbiddenAreas",
++    "constraints",
++    "definitionOfDone",
++  ];
++
++  for (const field of requiredFields) {
++    if (!(field in task)) {
++      throw new Error(`Brakuje pola "${field}" w agent/state/task.json`);
++    }
++  }
++
++  return task;
++}
++
++function buildTaskSummary(task) {
++  return [
++    `ID: ${task.id}`,
++    `TYTUŁ: ${task.title}`,
++    `CEL: ${task.goal}`,
++    `SCOPE: ${task.scope}`,
++    `DOZWOLONE OBSZARY: ${toCommaList(task.allowedAreas)}`,
++    `ZABRONIONE OBSZARY: ${toCommaList(task.forbiddenAreas)}`,
++    `OGRANICZENIA:\n${toBulletList(task.constraints)}`,
++    `DEFINITION OF DONE:\n${toBulletList(task.definitionOfDone)}`,
++  ].join("\n\n");
++}
++
++function renderTemplate(template, task, extraReplacements = {}) {
++  const replacements = {
++    "{{task}}": buildTaskSummary(task),
++    "{{taskId}}": task.id,
++    "{{taskTitle}}": task.title,
++    "{{taskGoal}}": task.goal,
++    "{{taskScope}}": task.scope,
++    "{{taskAllowedAreas}}": toCommaList(task.allowedAreas),
++    "{{taskForbiddenAreas}}": toCommaList(task.forbiddenAreas),
++    "{{taskConstraints}}": toBulletList(task.constraints),
++    "{{taskDefinitionOfDone}}": toBulletList(task.definitionOfDone),
++    "{{diff}}": "",
++    "{{tests}}": "",
++    ...extraReplacements,
++  };
++
++  let output = template;
++
++  for (const [key, value] of Object.entries(replacements)) {
++    output = output.split(key).join(value);
++  }
++
++  return output;
++}
++
++function extractFixPrompt(input) {
++  const marker = "PROMPT_DLA_CODEX:";
++  const markerIndex = input.indexOf(marker);
++
++  if (markerIndex === -1) {
++    return input.trim();
++  }
++
++  return input.slice(markerIndex + marker.length).trim();
++}
++
++function readSinglePaste() {
++  return new Promise((resolve) => {
++    process.stdin.once("data", (chunk) => {
++      resolve(chunk.toString());
++    });
++  });
+ }
+ 
+ (async () => {
+-  const task = JSON.parse(fs.readFileSync("agent/state/task.json")).task;
++  const task = loadTask();
+ 
+-  let currentPrompt = fs.readFileSync("agent/prompts/codex-task.md", "utf-8")
+-    .replace("{{task}}", task);
++  let currentPrompt = renderTemplate(
++    readUtf8("agent/prompts/codex-task.md"),
++    task
++  );
+ 
+   for (let i = 0; i < MAX_ITERATIONS; i++) {
+-    console.log(`\n🚀 ITERACJA ${i + 1}`);
+-
+-    console.log("\n👉 Wklej do Codex:\n");
++    console.log(`\n🚀 ITERACJA ${i + 1}/${MAX_ITERATIONS}`);
++    console.log("\n==================================================");
++    console.log("PROMPT DLA CODEX");
++    console.log("==================================================\n");
+     console.log(currentPrompt);
+ 
+-    await new Promise(r => process.stdin.once("data", r));
++    console.log("\n⏳ Po wklejeniu promptu do Codex wciśnij ENTER...");
++    await readSinglePaste();
+ 
+     const tests = runTests();
+     const diff = getDiff();
+ 
+-    // prompt dla Claude
+-    let reviewPrompt = fs.readFileSync("agent/prompts/claude-review.md", "utf-8")
+-      .replace("{{task}}", task)
+-      .replace("{{diff}}", diff)
+-      .replace("{{tests}}", tests);
++    const reviewPrompt = renderTemplate(
++      readUtf8("agent/prompts/claude-review.md"),
++      task,
++      {
++        "{{diff}}": diff || "(brak zmian w diff)",
++        "{{tests}}": tests || "(brak outputu testów)",
++      }
++    );
+ 
+-    console.log("\n👉 Wklej do Claude:\n");
++    console.log("\n==================================================");
++    console.log("PROMPT DLA CLAUDE REVIEW");
++    console.log("==================================================\n");
+     console.log(reviewPrompt);
+ 
+-    console.log("\n⏳ Wklej odpowiedź Claude i ENTER...");
+-    const input = await new Promise(resolve => {
+-      let data = "";
+-      process.stdin.on("data", chunk => {
+-        data += chunk.toString();
+-        if (data.includes("DECYZJA")) resolve(data);
+-      });
+-    });
++    console.log(
++      '\n⏳ Wklej CAŁĄ odpowiedź Claude jednym paste i naciśnij ENTER...'
++    );
++    const input = await readSinglePaste();
+ 
+-    if (input.includes("OK")) {
++    if (input.includes("DECYZJA: OK")) {
+       console.log("\n✅ Claude uznał zadanie za OK");
+-      break;
++      console.log("\n👉 FINALNY AUDYT → ChatGPT");
++      return;
+     }
+ 
+-    if (input.includes("FIX")) {
+-      const fixPrompt = input.split("FIX")[1];
+-      currentPrompt = fixPrompt;
+-      console.log("\n🔁 Poprawka wygenerowana");
++    if (input.includes("DECYZJA: FIX")) {
++      currentPrompt = extractFixPrompt(input);
++      console.log("\n🔁 Wczytano prompt naprawczy dla Codex");
++      continue;
+     }
++
++    console.log(
++      "\n⚠️ Nie wykryto jasnej decyzji 'DECYZJA: OK' ani 'DECYZJA: FIX'."
++    );
++    console.log("Traktuję odpowiedź jako FIX i przekazuję ją dalej do kolejnej iteracji.\n");
++    currentPrompt = extractFixPrompt(input);
+   }
+ 
+-  console.log("\n👉 FINALNY AUDYT → ChatGPT");
+-})();
+\ No newline at end of file
++  console.log("\n🛑 Osiągnięto maksymalną liczbę iteracji.");
++  console.log("👉 Zrób ręczny audyt końcowy w ChatGPT.");
++})().catch((error) => {
++  console.error("\n❌ Błąd działania pipeline:");
++  console.error(error);
++  process.exit(1);
++});
+\ No newline at end of file
+diff --git a/agent/prompts/audit.md b/agent/prompts/audit.md
+index 77e9927..f8262a7 100644
+--- a/agent/prompts/audit.md
++++ b/agent/prompts/audit.md
+@@ -2,27 +2,66 @@ Jesteś głównym architektem systemu NP-Manager.
+ 
+ Kontekst:
+ - system do zarządzania portowaniem (FNP)
+-- frontend musi być prosty i operacyjny
+ - backend jest źródłem prawdy
++- frontend ma być prosty i operacyjny
++- zakres zmiany wynika z task.json
+ 
+-Zadanie:
++DANE ZADANIA
++
++ID:
++{{taskId}}
++
++TYTUŁ:
++{{taskTitle}}
++
++CEL:
++{{taskGoal}}
++
++SCOPE:
++{{taskScope}}
++
++DOZWOLONE OBSZARY:
++{{taskAllowedAreas}}
++
++ZABRONIONE OBSZARY:
++{{taskForbiddenAreas}}
++
++OGRANICZENIA:
++{{taskConstraints}}
++
++DEFINITION OF DONE:
++{{taskDefinitionOfDone}}
++
++SKRÓT ZADANIA:
+ {{task}}
+ 
+-Zmiany w kodzie:
++ZMIANY W KODZIE:
+ {{diff}}
+ 
+-Wynik testów:
++WYNIK TESTÓW:
+ {{tests}}
+ 
+ Twoje zadanie:
+ 
+ 1. Oceń czy zmiana jest poprawna architektonicznie
+-2. Sprawdź czy nie ma regresji
+-3. Sprawdź czy UX nie został pogorszony
+-4. Wykryj potencjalne bugi
++2. Sprawdź czy scope taska nie został naruszony
++3. Sprawdź czy nie ma regresji
++4. Sprawdź czy UX nie został pogorszony
++5. Wykryj potencjalne bugi
++6. Oceń czy nie ma ukrytych zmian poza zakresem
++
++Odpowiedz w formacie:
++
++STATUS: OK / NOT OK
++
++MOCNE STRONY:
++- ...
++
++PROBLEMY:
++- ...
+ 
+-Odpowiedz:
++POPRAWKI:
++- ...
+ 
+-- STATUS: OK / NOT OK
+-- PROBLEMY:
+-- POPRAWKI:
+\ No newline at end of file
++WERDYKT:
++- krótka końcowa ocena
+\ No newline at end of file
+diff --git a/agent/prompts/claude-review.md b/agent/prompts/claude-review.md
+index 9a7711e..f779699 100644
+--- a/agent/prompts/claude-review.md
++++ b/agent/prompts/claude-review.md
+@@ -1,122 +1,147 @@
+ Jesteś lead developerem odpowiedzialnym za jakość zmian w NP-Manager.
+ 
+ Kontekst:
+-- zmiana dotyczy WYŁĄCZNIE frontend (apps/frontend/**)
++- system jest backend-driven
+ - backend jest source of truth
+-- retry opiera się o:
+-  - item.canRetry
+-  - retryBlockedReasonCode
+-  - istniejący endpoint retry
++- zakres zmian wynika z task.json, a nie z domysłów
++- review ma sprawdzić zarówno poprawność feature, jak i zgodność ze scope taska
+ 
+-Zadanie:
++DANE ZADANIA
++
++ID:
++{{taskId}}
++
++TYTUŁ:
++{{taskTitle}}
++
++CEL:
++{{taskGoal}}
++
++SCOPE:
++{{taskScope}}
++
++DOZWOLONE OBSZARY:
++{{taskAllowedAreas}}
++
++ZABRONIONE OBSZARY:
++{{taskForbiddenAreas}}
++
++OGRANICZENIA:
++{{taskConstraints}}
++
++DEFINITION OF DONE:
++{{taskDefinitionOfDone}}
++
++SKRÓT ZADANIA:
+ {{task}}
+ 
+-Zmiany w kodzie:
++ZMIANY W KODZIE:
+ {{diff}}
+ 
+-Wynik testów:
++WYNIK TESTÓW:
+ {{tests}}
+ 
+ ---
+ 
+ TWOJE ZADANIE
+ 
+-Przeprowadź twardą weryfikację w 4 krokach:
++Przeprowadź twardą weryfikację w 6 krokach.
+ 
+-KROK 1 — WYKONANIE FEATURE
++KROK 1 — ZGODNOŚĆ ZE SCOPE
+ Sprawdź czy:
+-- istnieje przycisk "Ponów"
+-- jest renderowany tylko gdy item.canRetry === true
+-- wywołuje onRetryAttempt(item.id)
++- zmiany mieszczą się w allowedAreas
++- forbiddenAreas nie zostały naruszone
++- nie ma ukrytego rozszerzenia zakresu
++- nie wykonano zbędnych zmian poza taskiem
+ 
+ Jeśli którykolwiek warunek NIE jest spełniony → FIX
+ 
+ ---
+ 
+-KROK 2 — UX / INTERAKCJA
++KROK 2 — WYKONANIE ZADANIA
+ Sprawdź czy:
+-- istnieje loading state ("Ponawiam...")
+-- przycisk jest disabled podczas retry
+-- użytkownik widzi:
+-  - success message
+-  - error message
+-- NIE ma resetu całego panelu
++- implementacja rzeczywiście realizuje goal
++- definitionOfDone jest spełnione
++- zmiana obejmuje minimalny potrzebny vertical slice
++- nie pominięto potrzebnej warstwy (np. backend/shared), jeśli task tego wymagał
+ 
+-Jeśli coś brakuje → FIX
++Jeśli coś jest niepełne → FIX
+ 
+ ---
+ 
+ KROK 3 — ARCHITEKTURA
+ Sprawdź czy:
+-- NIE zmieniono plików:
+-  - apps/backend/**
+-  - packages/shared/**
+-  - prisma/**
+-- NIE dodano lokalnej logiki retry (np. if/else zamiast backendu)
+-- użyto istniejącego endpointu retry
++- respektowany jest backend as source of truth
++- nie przeniesiono logiki tam, gdzie nie powinna być
++- nie dodano obejścia zamiast właściwej zmiany
++- kod jest spójny z architekturą NP-Manager
+ 
+-Jeśli naruszono którykolwiek punkt → FIX
++Jeśli jest problem architektoniczny → FIX
+ 
+ ---
+ 
+ KROK 4 — JAKOŚĆ ZMIAN
+ Sprawdź czy:
+-- zmiany są ograniczone tylko do potrzebnych plików
+-- NIE ma zmian typu:
+-  - package.json
+-  - config
+-  - inne niezwiązane pliki
+-- kod jest spójny z istniejącym stylem
++- zmieniono tylko potrzebne pliki
++- nie ma zbędnych zmian w package.json, configach, toolingach lub innych niezwiązanych plikach
++- kod jest spójny z istniejącym stylem repo
++- nie ma oczywistych regresji
+ 
+-Jeśli są zbędne zmiany → FIX
++Jeśli są zbędne lub ryzykowne zmiany → FIX
+ 
+ ---
+ 
+ KROK 5 — TESTY
+-- jeśli testy FAIL → FIX
+-- ignoruj "0 test files"
++Sprawdź czy:
++- testy są adekwatne do zakresu
++- wynik testów nie wskazuje realnego problemu
++- można odróżnić prawdziwy FAIL od znanych sytuacji typu "0 test files"
++
++Jeśli testy ujawniają problem → FIX
+ 
+ ---
+ 
+-ODPOWIEDŹ (OBOWIĄZKOWY FORMAT)
++KROK 6 — WERDYKT
++Jeśli masz jakiekolwiek istotne wątpliwości → wybierz FIX
++
++---
++
++ODPOWIEDŹ — OBOWIĄZKOWY FORMAT
+ 
+ DECYZJA: OK / FIX
+ 
+ UZASADNIENIE:
+ - krótko dlaczego
+ 
+-JEŚLI FIX:
+-
+-Zwróć GOTOWY PROMPT dla Codex:
+-
+-- bardzo konkretny
+-- wskazujący pliki
+-- bez ogólników
++PROBLEMY:
++- punktami, tylko jeśli istnieją
+ 
+-FORMAT:
++JEŚLI FIX:
+ 
+-Popraw w pliku:
+-<ścieżka>
++PROMPT_DLA_CODEX:
++Popraw dokładnie wskazane problemy.
++Trzymaj się scope:
++- dozwolone: {{taskAllowedAreas}}
++- zabronione: {{taskForbiddenAreas}}
+ 
+ Zrób:
+ - konkretna zmiana 1
+ - konkretna zmiana 2
++- konkretna zmiana 3
+ 
+ Nie zmieniaj:
+-- backend
+-- innych plików
++- żadnych plików poza allowedAreas
++- niczego poza zakresem taska
+ 
+----
++Zwróć:
++- pełny kod zmienionych plików
++- krótką listę zmian
++- krótkie uzasadnienie
+ 
+ JEŚLI OK:
+ 
+ Potwierdź:
+-- feature działa poprawnie
+-- UX jest kompletny
+-- brak regresji
++- task jest wykonany poprawnie
++- scope nie został naruszony
+ - brak nieautoryzowanych zmian
+-
+----
+-
+-ZASADA:
+-Jeśli masz jakiekolwiek wątpliwości → wybierz FIX
+\ No newline at end of file
++- brak oczywistych regresji
+\ No newline at end of file
+diff --git a/agent/prompts/codex-task.md b/agent/prompts/codex-task.md
+index fc14799..72b89c8 100644
+--- a/agent/prompts/codex-task.md
++++ b/agent/prompts/codex-task.md
+@@ -1,19 +1,63 @@
+-Jesteś Codex pracującym nad NP-Manager.
++Jesteś Codex pracującym nad projektem NP-Manager.
+ 
+-Zadanie:
++Kontekst projektu:
++- Stack: Fastify + Prisma + React + Zustand + Tailwind
++- Architektura: backend-driven, backend jest source of truth
++- System: FNP / NP-Manager
++- Nie wymyślaj lokalnej logiki w frontendzie, jeśli właściwe miejsce jest w backendzie
++
++DANE ZADANIA
++
++ID:
++{{taskId}}
++
++TYTUŁ:
++{{taskTitle}}
++
++CEL:
++{{taskGoal}}
++
++SCOPE:
++{{taskScope}}
++
++DOZWOLONE OBSZARY:
++{{taskAllowedAreas}}
++
++ZABRONIONE OBSZARY:
++{{taskForbiddenAreas}}
++
++OGRANICZENIA:
++{{taskConstraints}}
++
++DEFINITION OF DONE:
++{{taskDefinitionOfDone}}
++
++SKRÓT ZADANIA:
+ {{task}}
+ 
+-ZAKRES:
+-- apps/frontend/**
++TRYB PRACY
++
++1. Najpierw przeanalizuj zakres taska.
++2. Trzymaj się wyłącznie allowedAreas.
++3. Nie zmieniaj forbiddenAreas.
++4. Jeśli task dopuszcza backend lub shared i zmiana jest tam potrzebna, wykonaj ją tam zamiast robić obejście.
++5. Nie rób szerokiego refactoru.
++6. Nie zmieniaj migracji, auth, RBAC ani innych obszarów poza taskiem, jeśli task nie wymaga tego wprost.
++7. Zmieniaj tylko minimalny vertical slice potrzebny do realizacji zadania.
++
++WYMAGANY SPOSÓB ODPOWIEDZI
++
++Zwróć:
+ 
+-ZABRONIONE:
+-- backend
+-- prisma
+-- shared
++1. listę zmienionych plików
++2. krótką listę zmian
++3. pełny kod każdego zmienionego pliku
++4. krótkie uzasadnienie architektoniczne
++5. listę uruchomionych testów / komend walidacyjnych
+ 
+-Wymagania:
+-- użyj istniejącego API retry
+-- pokaż loading
+-- pokaż success/error
++WAŻNE
+ 
+-Zwróć pełny kod zmienionych plików.
+\ No newline at end of file
++- Nie zakładaj z góry, że task jest frontend-only.
++- Zakres wynika z task.json.
++- Jeśli czegoś nie trzeba zmieniać, nie dotykaj tego.
++- Nie modyfikuj plików poza zakresem tylko po to, żeby "posprzątać".
+\ No newline at end of file
+diff --git a/agent/state/task.json b/agent/state/task.json
+index b12aacf..98730d9 100644
+--- a/agent/state/task.json
++++ b/agent/state/task.json
+@@ -1,4 +1,24 @@
+ {
+-  "task": "Dodaj prosty przycisk retry w InternalNotificationAttemptsPanel z wykorzystaniem istniejącego endpointu retry",
+-  "status": "pending"
++  "id": "pr20a-global-internal-notification-attempts-read-api",
++  "title": "Dodaj globalny read endpoint dla internal notification attempts",
++  "goal": "Udostępnić backendowy operacyjny odczyt prób notyfikacji wewnętrznych do przyszłej globalnej listy UI.",
++  "scope": "backend",
++  "allowedAreas": ["backend", "shared"],
++  "forbiddenAreas": ["frontend"],
++  "constraints": [
++    "Implement only the minimal vertical slice required by the task",
++    "Do not introduce unrelated refactors",
++    "Do not add Prisma migrations unless explicitly required",
++    "Do not change auth or RBAC unless explicitly required",
++    "Do not modify existing retry semantics",
++    "Do not change notification transport adapters",
++    "Do not change NOTE parsing compatibility behavior"
++  ],
++  "definitionOfDone": [
++    "A new read endpoint for internal notification attempts list exists",
++    "Shared DTOs required by the endpoint are added or updated",
++    "Backend tests covering the new endpoint or service are added or updated",
++    "Type checks and builds pass",
++    "No unrelated files are modified"
++  ]
+ }
+\ No newline at end of file

--- a/pipeline/plan.json
+++ b/pipeline/plan.json
@@ -1,0 +1,76 @@
+{
+  "project": "NP-Manager",
+  "mode": "frontend-only",
+
+  "_comment_forbidden": "Ścieżki których AI nie może modyfikować w trybie frontend-only. Dostosuj jeśli Twoje monorepo ma inną strukturę.",
+  "forbidden_paths": [
+    "apps/backend/",
+    "prisma/",
+    "packages/shared/",
+    "package.json",
+    "package-lock.json",
+    "pnpm-lock.yaml",
+    "yarn.lock"
+  ],
+
+  "_comment_oversize": "Progi ostrzegawcze. Przekroczenie progu nie blokuje pracy, ale sygnalizuje reviewerowi, że zmiana mogła wyjść poza etap.",
+  "oversize_warning": {
+    "files": 15,
+    "lines": 1000
+  },
+
+  "_comment_validation": "Komendy uruchamiane po opcji [2]. Jeśli w repo nie ma danego workspace/skryptu, wynik zostanie oznaczony jako SKIPPED.",
+  "validation": [
+    {
+      "label": "Build shared (typy)",
+      "cmd": "npm run build -w packages/shared"
+    },
+    {
+      "label": "Testy shared",
+      "cmd": "npm run test -w packages/shared"
+    },
+    {
+      "label": "Testy backend",
+      "cmd": "npm run test -w apps/backend"
+    },
+    {
+      "label": "Testy frontend",
+      "cmd": "npm run test -w apps/frontend"
+    }
+  ],
+
+  "stages": [
+    {
+      "id": 1,
+      "name": "Retry UI w InternalNotificationAttemptsPanel",
+      "description": "Przycisk retry wywołujący istniejące API retry. Używa pól canRetry i retryBlockedReasonCode z backendu. Stan disabled gdy canRetry=false, czytelny komunikat dla zablokowanej próby, loading i feedback sukces/błąd.",
+      "scope": "frontend-only",
+      "files_hint": "apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx\napps/frontend/src/pages/Requests/RequestDetailPage.tsx",
+      "acceptance_criteria": [
+        "Przycisk retry lub równoważna akcja jest widoczna tylko tam, gdzie logika backendu na to pozwala",
+        "Stan disabled / komunikat zablokowania wynika z danych backendu, a nie z lokalnej logiki wymyślonej po stronie UI",
+        "Kliknięcie używa istniejącego endpointu retry bez tworzenia nowego API",
+        "Podczas requestu użytkownik widzi stan loading",
+        "Po sukcesie i błędzie użytkownik dostaje czytelny feedback"
+      ],
+      "allow_paths": [],
+      "done": true
+    },
+    {
+      "id": 2,
+      "name": "Auto-dismiss komunikatu sukcesu retry w RequestDetailPage",
+      "description": "Dodaj automatyczne znikanie komunikatu sukcesu po retry internal notification attempt. Komunikat sukcesu w RequestDetailPage powinien znikać sam po około 3 sekundach bez resetowania całego panelu i bez wpływu na komunikat błędu. Zachowaj obecny backend-driven flow: brak zmian w backendzie, brak nowego API, brak zmian w DTO. Jeśli komunikat błędu jest widoczny, nie ma być automatycznie czyszczony tym mechanizmem. Preferuj prosty useEffect + setTimeout z poprawnym cleanup.",
+      "scope": "frontend-only",
+      "files_hint": "apps/frontend/src/pages/Requests/RequestDetailPage.tsx\napps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx (jeśli potrzebny test)",
+      "acceptance_criteria": [
+        "Komunikat sukcesu retry znika automatycznie po około 3 sekundach",
+        "Mechanizm auto-dismiss nie resetuje całego panelu ani listy attempts",
+        "Komunikat błędu nie jest automatycznie czyszczony tym samym mechanizmem",
+        "Rozwiązanie ma cleanup timera i nie tworzy wycieków po unmount lub zmianie komunikatu",
+        "Brak zmian w backendzie, packages/shared, prisma i package.json"
+      ],
+      "allow_paths": [],
+      "done": false
+    }
+  ]
+}

--- a/pipeline/prompts/codex-prompt.md
+++ b/pipeline/prompts/codex-prompt.md
@@ -1,0 +1,51 @@
+# Zadanie: Auto-dismiss komunikatu sukcesu retry w RequestDetailPage
+Projekt: NP-Manager | Cykl: 1 | Tryb: frontend-only
+
+
+
+## Opis zadania
+
+Dodaj automatyczne znikanie komunikatu sukcesu po retry internal notification attempt. Komunikat sukcesu w RequestDetailPage powinien znikać sam po około 3 sekundach bez resetowania całego panelu i bez wpływu na komunikat błędu. Zachowaj obecny backend-driven flow: brak zmian w backendzie, brak nowego API, brak zmian w DTO. Jeśli komunikat błędu jest widoczny, nie ma być automatycznie czyszczony tym mechanizmem. Preferuj prosty useEffect + setTimeout z poprawnym cleanup.
+
+## Acceptance criteria
+
+1. Komunikat sukcesu retry znika automatycznie po około 3 sekundach
+2. Mechanizm auto-dismiss nie resetuje całego panelu ani listy attempts
+3. Komunikat błędu nie jest automatycznie czyszczony tym samym mechanizmem
+4. Rozwiązanie ma cleanup timera i nie tworzy wycieków po unmount lub zmianie komunikatu
+5. Brak zmian w backendzie, packages/shared, prisma i package.json
+
+## Zasady – bezwzględne
+
+- Zakres zmian: **frontend-only**
+- Zabronione ścieżki:
+- apps/backend/
+- prisma/
+- packages/shared/
+- package.json
+- package-lock.json
+- pnpm-lock.yaml
+- yarn.lock
+- Wyjątki dla tego etapu:
+- brak wyjątków
+- NIE modyfikuj package.json / lockfile / backendu / prismy / shared, chyba że allow_paths mówi inaczej.
+- NIE dodawaj nowych zależności npm.
+- NIE importuj kodu backendu do frontendu.
+- Używaj istniejących komponentów, hooków i publicznego kontraktu API.
+- Zachowaj styl kodu i nazewnictwo z repo.
+- Po zmianach pliki MUSZĄ być zapisane na dysku.
+
+## Pliki do edycji (wskazówka)
+
+apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx (jeśli potrzebny test)
+
+## Format pracy
+
+1. W 2-3 zdaniach opisz plan.
+2. Edytuj pliki i zapisz je na dysku.
+3. Na końcu wypisz:
+   - listę zmienionych plików,
+   - krótkie podsumowanie zmian.
+
+Zacznij od razu. Nie pytaj o potwierdzenie.

--- a/pipeline/prompts/review-prompt.md
+++ b/pipeline/prompts/review-prompt.md
@@ -1,0 +1,864 @@
+# Review zmian kodu
+Etap: **[UZUPEŁNIJ] – opisz tutaj kolejne zadanie frontendowe** | Cykl: 1 | Projekt: NP-Manager
+
+Jesteś senior developerem robiącym ostrą recenzję. Twoja rola: wyłapać błędy zanim trafią na produkcję.
+
+## Zadanie które miał wykonać AI
+
+Otwórz plan.json i zastąp ten placeholder realnym opisem następnego etapu. Im dokładniej opiszesz, tym lepszy kod wygeneruje AI. Wymień co ma robić komponent, jakiego API użyć, jakie stany obsłużyć.
+
+## Acceptance criteria
+
+1. Kryterium 1 – uzupełnij
+2. Kryterium 2 – uzupełnij
+
+## Zasady projektu (naruszenie = FIX)
+
+- Tryb: frontend-only
+- Zabronione ścieżki: `apps/backend/`, `prisma/`, `packages/shared/`, `package.json`, `package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`
+- Brak nowych zależności npm
+- Brak importów z backendu
+
+
+
+
+
+## Zmienione pliki (10)
+
+- `.claude/worktrees/dazzling-brahmagupta`
+- `.claude/worktrees/exciting-colden`
+- `.claude/worktrees/funny-williamson-647695`
+- `.claude/worktrees/gallant-aryabhata`
+- `.claude/worktrees/infallible-elbakyan`
+- `agent/loops/run-task.js`
+- `agent/prompts/audit.md`
+- `agent/prompts/claude-review.md`
+- `agent/prompts/codex-task.md`
+- `agent/state/task.json`
+
+## git diff
+
+```diff
+diff --git a/.claude/worktrees/dazzling-brahmagupta b/.claude/worktrees/dazzling-brahmagupta
+--- a/.claude/worktrees/dazzling-brahmagupta
++++ b/.claude/worktrees/dazzling-brahmagupta
+@@ -1 +1 @@
+-Subproject commit 48ae00bd2bee6ef6880a4f867b87f842d1bd2988
++Subproject commit 48ae00bd2bee6ef6880a4f867b87f842d1bd2988-dirty
+diff --git a/.claude/worktrees/exciting-colden b/.claude/worktrees/exciting-colden
+--- a/.claude/worktrees/exciting-colden
++++ b/.claude/worktrees/exciting-colden
+@@ -1 +1 @@
+-Subproject commit 3ecb1b7fd498c223e51c445370fc30316f03fff9
++Subproject commit 3ecb1b7fd498c223e51c445370fc30316f03fff9-dirty
+diff --git a/.claude/worktrees/funny-williamson-647695 b/.claude/worktrees/funny-williamson-647695
+--- a/.claude/worktrees/funny-williamson-647695
++++ b/.claude/worktrees/funny-williamson-647695
+@@ -1 +1 @@
+-Subproject commit fe2a900f3c4ea664a1ae7da138bfdb9a189159f5
++Subproject commit fe2a900f3c4ea664a1ae7da138bfdb9a189159f5-dirty
+diff --git a/.claude/worktrees/gallant-aryabhata b/.claude/worktrees/gallant-aryabhata
+--- a/.claude/worktrees/gallant-aryabhata
++++ b/.claude/worktrees/gallant-aryabhata
+@@ -1 +1 @@
+-Subproject commit 22bd5b2e355dcfb9f6ba0cfe132fda4485054fdd
++Subproject commit 22bd5b2e355dcfb9f6ba0cfe132fda4485054fdd-dirty
+diff --git a/.claude/worktrees/infallible-elbakyan b/.claude/worktrees/infallible-elbakyan
+--- a/.claude/worktrees/infallible-elbakyan
++++ b/.claude/worktrees/infallible-elbakyan
+@@ -1 +1 @@
+-Subproject commit fe4324d632288556208973a8f5250c1ea1850054
++Subproject commit fe4324d632288556208973a8f5250c1ea1850054-dirty
+diff --git a/agent/loops/run-task.js b/agent/loops/run-task.js
+index ce0347a..67bbb33 100644
+--- a/agent/loops/run-task.js
++++ b/agent/loops/run-task.js
+@@ -3,64 +3,191 @@ import fs from "fs";
+ 
+ const MAX_ITERATIONS = 3;
+ 
+-function runTests() {
++function readUtf8(path) {
++  return fs.readFileSync(path, "utf-8");
++}
++
++function runCommand(command) {
+   try {
+-    return execSync("npm test").toString();
+-  } catch (e) {
+-    return e.stdout.toString();
++    return execSync(command, {
++      encoding: "utf-8",
++      stdio: ["pipe", "pipe", "pipe"],
++    });
++  } catch (error) {
++    const stdout = error?.stdout?.toString?.() ?? "";
++    const stderr = error?.stderr?.toString?.() ?? "";
++    return `${stdout}\n${stderr}`.trim();
+   }
+ }
+ 
++function runTests() {
++  return runCommand("npm test");
++}
++
+ function getDiff() {
+-  return execSync("git diff").toString();
++  return runCommand("git diff");
++}
++
++function toBulletList(items) {
++  if (!Array.isArray(items) || items.length === 0) {
++    return "- brak";
++  }
++
++  return items.map((item) => `- ${item}`).join("\n");
++}
++
++function toCommaList(items) {
++  if (!Array.isArray(items) || items.length === 0) {
++    return "brak";
++  }
++
++  return items.join(", ");
++}
++
++function loadTask() {
++  const raw = readUtf8("agent/state/task.json");
++  const task = JSON.parse(raw);
++
++  const requiredFields = [
++    "id",
++    "title",
++    "goal",
++    "scope",
++    "allowedAreas",
++    "forbiddenAreas",
++    "constraints",
++    "definitionOfDone",
++  ];
++
++  for (const field of requiredFields) {
++    if (!(field in task)) {
++      throw new Error(`Brakuje pola "${field}" w agent/state/task.json`);
++    }
++  }
++
++  return task;
++}
++
++function buildTaskSummary(task) {
++  return [
++    `ID: ${task.id}`,
++    `TYTUŁ: ${task.title}`,
++    `CEL: ${task.goal}`,
++    `SCOPE: ${task.scope}`,
++    `DOZWOLONE OBSZARY: ${toCommaList(task.allowedAreas)}`,
++    `ZABRONIONE OBSZARY: ${toCommaList(task.forbiddenAreas)}`,
++    `OGRANICZENIA:\n${toBulletList(task.constraints)}`,
++    `DEFINITION OF DONE:\n${toBulletList(task.definitionOfDone)}`,
++  ].join("\n\n");
++}
++
++function renderTemplate(template, task, extraReplacements = {}) {
++  const replacements = {
++    "{{task}}": buildTaskSummary(task),
++    "{{taskId}}": task.id,
++    "{{taskTitle}}": task.title,
++    "{{taskGoal}}": task.goal,
++    "{{taskScope}}": task.scope,
++    "{{taskAllowedAreas}}": toCommaList(task.allowedAreas),
++    "{{taskForbiddenAreas}}": toCommaList(task.forbiddenAreas),
++    "{{taskConstraints}}": toBulletList(task.constraints),
++    "{{taskDefinitionOfDone}}": toBulletList(task.definitionOfDone),
++    "{{diff}}": "",
++    "{{tests}}": "",
++    ...extraReplacements,
++  };
++
++  let output = template;
++
++  for (const [key, value] of Object.entries(replacements)) {
++    output = output.split(key).join(value);
++  }
++
++  return output;
++}
++
++function extractFixPrompt(input) {
++  const marker = "PROMPT_DLA_CODEX:";
++  const markerIndex = input.indexOf(marker);
++
++  if (markerIndex === -1) {
++    return input.trim();
++  }
++
++  return input.slice(markerIndex + marker.length).trim();
++}
++
++function readSinglePaste() {
++  return new Promise((resolve) => {
++    process.stdin.once("data", (chunk) => {
++      resolve(chunk.toString());
++    });
++  });
+ }
+ 
+ (async () => {
+-  const task = JSON.parse(fs.readFileSync("agent/state/task.json")).task;
++  const task = loadTask();
+ 
+-  let currentPrompt = fs.readFileSync("agent/prompts/codex-task.md", "utf-8")
+-    .replace("{{task}}", task);
++  let currentPrompt = renderTemplate(
++    readUtf8("agent/prompts/codex-task.md"),
++    task
++  );
+ 
+   for (let i = 0; i < MAX_ITERATIONS; i++) {
+-    console.log(`\n🚀 ITERACJA ${i + 1}`);
+-
+-    console.log("\n👉 Wklej do Codex:\n");
++    console.log(`\n🚀 ITERACJA ${i + 1}/${MAX_ITERATIONS}`);
++    console.log("\n==================================================");
++    console.log("PROMPT DLA CODEX");
++    console.log("==================================================\n");
+     console.log(currentPrompt);
+ 
+-    await new Promise(r => process.stdin.once("data", r));
++    console.log("\n⏳ Po wklejeniu promptu do Codex wciśnij ENTER...");
++    await readSinglePaste();
+ 
+     const tests = runTests();
+     const diff = getDiff();
+ 
+-    // prompt dla Claude
+-    let reviewPrompt = fs.readFileSync("agent/prompts/claude-review.md", "utf-8")
+-      .replace("{{task}}", task)
+-      .replace("{{diff}}", diff)
+-      .replace("{{tests}}", tests);
++    const reviewPrompt = renderTemplate(
++      readUtf8("agent/prompts/claude-review.md"),
++      task,
++      {
++        "{{diff}}": diff || "(brak zmian w diff)",
++        "{{tests}}": tests || "(brak outputu testów)",
++      }
++    );
+ 
+-    console.log("\n👉 Wklej do Claude:\n");
++    console.log("\n==================================================");
++    console.log("PROMPT DLA CLAUDE REVIEW");
++    console.log("==================================================\n");
+     console.log(reviewPrompt);
+ 
+-    console.log("\n⏳ Wklej odpowiedź Claude i ENTER...");
+-    const input = await new Promise(resolve => {
+-      let data = "";
+-      process.stdin.on("data", chunk => {
+-        data += chunk.toString();
+-        if (data.includes("DECYZJA")) resolve(data);
+-      });
+-    });
++    console.log(
++      '\n⏳ Wklej CAŁĄ odpowiedź Claude jednym paste i naciśnij ENTER...'
++    );
++    const input = await readSinglePaste();
+ 
+-    if (input.includes("OK")) {
++    if (input.includes("DECYZJA: OK")) {
+       console.log("\n✅ Claude uznał zadanie za OK");
+-      break;
++      console.log("\n👉 FINALNY AUDYT → ChatGPT");
++      return;
+     }
+ 
+-    if (input.includes("FIX")) {
+-      const fixPrompt = input.split("FIX")[1];
+-      currentPrompt = fixPrompt;
+-      console.log("\n🔁 Poprawka wygenerowana");
++    if (input.includes("DECYZJA: FIX")) {
++      currentPrompt = extractFixPrompt(input);
++      console.log("\n🔁 Wczytano prompt naprawczy dla Codex");
++      continue;
+     }
++
++    console.log(
++      "\n⚠️ Nie wykryto jasnej decyzji 'DECYZJA: OK' ani 'DECYZJA: FIX'."
++    );
++    console.log("Traktuję odpowiedź jako FIX i przekazuję ją dalej do kolejnej iteracji.\n");
++    currentPrompt = extractFixPrompt(input);
+   }
+ 
+-  console.log("\n👉 FINALNY AUDYT → ChatGPT");
+-})();
+\ No newline at end of file
++  console.log("\n🛑 Osiągnięto maksymalną liczbę iteracji.");
++  console.log("👉 Zrób ręczny audyt końcowy w ChatGPT.");
++})().catch((error) => {
++  console.error("\n❌ Błąd działania pipeline:");
++  console.error(error);
++  process.exit(1);
++});
+\ No newline at end of file
+diff --git a/agent/prompts/audit.md b/agent/prompts/audit.md
+index 77e9927..f8262a7 100644
+--- a/agent/prompts/audit.md
++++ b/agent/prompts/audit.md
+@@ -2,27 +2,66 @@ Jesteś głównym architektem systemu NP-Manager.
+ 
+ Kontekst:
+ - system do zarządzania portowaniem (FNP)
+-- frontend musi być prosty i operacyjny
+ - backend jest źródłem prawdy
++- frontend ma być prosty i operacyjny
++- zakres zmiany wynika z task.json
+ 
+-Zadanie:
++DANE ZADANIA
++
++ID:
++{{taskId}}
++
++TYTUŁ:
++{{taskTitle}}
++
++CEL:
++{{taskGoal}}
++
++SCOPE:
++{{taskScope}}
++
++DOZWOLONE OBSZARY:
++{{taskAllowedAreas}}
++
++ZABRONIONE OBSZARY:
++{{taskForbiddenAreas}}
++
++OGRANICZENIA:
++{{taskConstraints}}
++
++DEFINITION OF DONE:
++{{taskDefinitionOfDone}}
++
++SKRÓT ZADANIA:
+ {{task}}
+ 
+-Zmiany w kodzie:
++ZMIANY W KODZIE:
+ {{diff}}
+ 
+-Wynik testów:
++WYNIK TESTÓW:
+ {{tests}}
+ 
+ Twoje zadanie:
+ 
+ 1. Oceń czy zmiana jest poprawna architektonicznie
+-2. Sprawdź czy nie ma regresji
+-3. Sprawdź czy UX nie został pogorszony
+-4. Wykryj potencjalne bugi
++2. Sprawdź czy scope taska nie został naruszony
++3. Sprawdź czy nie ma regresji
++4. Sprawdź czy UX nie został pogorszony
++5. Wykryj potencjalne bugi
++6. Oceń czy nie ma ukrytych zmian poza zakresem
++
++Odpowiedz w formacie:
++
++STATUS: OK / NOT OK
++
++MOCNE STRONY:
++- ...
++
++PROBLEMY:
++- ...
+ 
+-Odpowiedz:
++POPRAWKI:
++- ...
+ 
+-- STATUS: OK / NOT OK
+-- PROBLEMY:
+-- POPRAWKI:
+\ No newline at end of file
++WERDYKT:
++- krótka końcowa ocena
+\ No newline at end of file
+diff --git a/agent/prompts/claude-review.md b/agent/prompts/claude-review.md
+index 9a7711e..f779699 100644
+--- a/agent/prompts/claude-review.md
++++ b/agent/prompts/claude-review.md
+@@ -1,122 +1,147 @@
+ Jesteś lead developerem odpowiedzialnym za jakość zmian w NP-Manager.
+ 
+ Kontekst:
+-- zmiana dotyczy WYŁĄCZNIE frontend (apps/frontend/**)
++- system jest backend-driven
+ - backend jest source of truth
+-- retry opiera się o:
+-  - item.canRetry
+-  - retryBlockedReasonCode
+-  - istniejący endpoint retry
++- zakres zmian wynika z task.json, a nie z domysłów
++- review ma sprawdzić zarówno poprawność feature, jak i zgodność ze scope taska
+ 
+-Zadanie:
++DANE ZADANIA
++
++ID:
++{{taskId}}
++
++TYTUŁ:
++{{taskTitle}}
++
++CEL:
++{{taskGoal}}
++
++SCOPE:
++{{taskScope}}
++
++DOZWOLONE OBSZARY:
++{{taskAllowedAreas}}
++
++ZABRONIONE OBSZARY:
++{{taskForbiddenAreas}}
++
++OGRANICZENIA:
++{{taskConstraints}}
++
++DEFINITION OF DONE:
++{{taskDefinitionOfDone}}
++
++SKRÓT ZADANIA:
+ {{task}}
+ 
+-Zmiany w kodzie:
++ZMIANY W KODZIE:
+ {{diff}}
+ 
+-Wynik testów:
++WYNIK TESTÓW:
+ {{tests}}
+ 
+ ---
+ 
+ TWOJE ZADANIE
+ 
+-Przeprowadź twardą weryfikację w 4 krokach:
++Przeprowadź twardą weryfikację w 6 krokach.
+ 
+-KROK 1 — WYKONANIE FEATURE
++KROK 1 — ZGODNOŚĆ ZE SCOPE
+ Sprawdź czy:
+-- istnieje przycisk "Ponów"
+-- jest renderowany tylko gdy item.canRetry === true
+-- wywołuje onRetryAttempt(item.id)
++- zmiany mieszczą się w allowedAreas
++- forbiddenAreas nie zostały naruszone
++- nie ma ukrytego rozszerzenia zakresu
++- nie wykonano zbędnych zmian poza taskiem
+ 
+ Jeśli którykolwiek warunek NIE jest spełniony → FIX
+ 
+ ---
+ 
+-KROK 2 — UX / INTERAKCJA
++KROK 2 — WYKONANIE ZADANIA
+ Sprawdź czy:
+-- istnieje loading state ("Ponawiam...")
+-- przycisk jest disabled podczas retry
+-- użytkownik widzi:
+-  - success message
+-  - error message
+-- NIE ma resetu całego panelu
++- implementacja rzeczywiście realizuje goal
++- definitionOfDone jest spełnione
++- zmiana obejmuje minimalny potrzebny vertical slice
++- nie pominięto potrzebnej warstwy (np. backend/shared), jeśli task tego wymagał
+ 
+-Jeśli coś brakuje → FIX
++Jeśli coś jest niepełne → FIX
+ 
+ ---
+ 
+ KROK 3 — ARCHITEKTURA
+ Sprawdź czy:
+-- NIE zmieniono plików:
+-  - apps/backend/**
+-  - packages/shared/**
+-  - prisma/**
+-- NIE dodano lokalnej logiki retry (np. if/else zamiast backendu)
+-- użyto istniejącego endpointu retry
++- respektowany jest backend as source of truth
++- nie przeniesiono logiki tam, gdzie nie powinna być
++- nie dodano obejścia zamiast właściwej zmiany
++- kod jest spójny z architekturą NP-Manager
+ 
+-Jeśli naruszono którykolwiek punkt → FIX
++Jeśli jest problem architektoniczny → FIX
+ 
+ ---
+ 
+ KROK 4 — JAKOŚĆ ZMIAN
+ Sprawdź czy:
+-- zmiany są ograniczone tylko do potrzebnych plików
+-- NIE ma zmian typu:
+-  - package.json
+-  - config
+-  - inne niezwiązane pliki
+-- kod jest spójny z istniejącym stylem
++- zmieniono tylko potrzebne pliki
++- nie ma zbędnych zmian w package.json, configach, toolingach lub innych niezwiązanych plikach
++- kod jest spójny z istniejącym stylem repo
++- nie ma oczywistych regresji
+ 
+-Jeśli są zbędne zmiany → FIX
++Jeśli są zbędne lub ryzykowne zmiany → FIX
+ 
+ ---
+ 
+ KROK 5 — TESTY
+-- jeśli testy FAIL → FIX
+-- ignoruj "0 test files"
++Sprawdź czy:
++- testy są adekwatne do zakresu
++- wynik testów nie wskazuje realnego problemu
++- można odróżnić prawdziwy FAIL od znanych sytuacji typu "0 test files"
++
++Jeśli testy ujawniają problem → FIX
+ 
+ ---
+ 
+-ODPOWIEDŹ (OBOWIĄZKOWY FORMAT)
++KROK 6 — WERDYKT
++Jeśli masz jakiekolwiek istotne wątpliwości → wybierz FIX
++
++---
++
++ODPOWIEDŹ — OBOWIĄZKOWY FORMAT
+ 
+ DECYZJA: OK / FIX
+ 
+ UZASADNIENIE:
+ - krótko dlaczego
+ 
+-JEŚLI FIX:
+-
+-Zwróć GOTOWY PROMPT dla Codex:
+-
+-- bardzo konkretny
+-- wskazujący pliki
+-- bez ogólników
++PROBLEMY:
++- punktami, tylko jeśli istnieją
+ 
+-FORMAT:
++JEŚLI FIX:
+ 
+-Popraw w pliku:
+-<ścieżka>
++PROMPT_DLA_CODEX:
++Popraw dokładnie wskazane problemy.
++Trzymaj się scope:
++- dozwolone: {{taskAllowedAreas}}
++- zabronione: {{taskForbiddenAreas}}
+ 
+ Zrób:
+ - konkretna zmiana 1
+ - konkretna zmiana 2
++- konkretna zmiana 3
+ 
+ Nie zmieniaj:
+-- backend
+-- innych plików
++- żadnych plików poza allowedAreas
++- niczego poza zakresem taska
+ 
+----
++Zwróć:
++- pełny kod zmienionych plików
++- krótką listę zmian
++- krótkie uzasadnienie
+ 
+ JEŚLI OK:
+ 
+ Potwierdź:
+-- feature działa poprawnie
+-- UX jest kompletny
+-- brak regresji
++- task jest wykonany poprawnie
++- scope nie został naruszony
+ - brak nieautoryzowanych zmian
+-
+----
+-
+-ZASADA:
+-Jeśli masz jakiekolwiek wątpliwości → wybierz FIX
+\ No newline at end of file
++- brak oczywistych regresji
+\ No newline at end of file
+diff --git a/agent/prompts/codex-task.md b/agent/prompts/codex-task.md
+index fc14799..72b89c8 100644
+--- a/agent/prompts/codex-task.md
++++ b/agent/prompts/codex-task.md
+@@ -1,19 +1,63 @@
+-Jesteś Codex pracującym nad NP-Manager.
++Jesteś Codex pracującym nad projektem NP-Manager.
+ 
+-Zadanie:
++Kontekst projektu:
++- Stack: Fastify + Prisma + React + Zustand + Tailwind
++- Architektura: backend-driven, backend jest source of truth
++- System: FNP / NP-Manager
++- Nie wymyślaj lokalnej logiki w frontendzie, jeśli właściwe miejsce jest w backendzie
++
++DANE ZADANIA
++
++ID:
++{{taskId}}
++
++TYTUŁ:
++{{taskTitle}}
++
++CEL:
++{{taskGoal}}
++
++SCOPE:
++{{taskScope}}
++
++DOZWOLONE OBSZARY:
++{{taskAllowedAreas}}
++
++ZABRONIONE OBSZARY:
++{{taskForbiddenAreas}}
++
++OGRANICZENIA:
++{{taskConstraints}}
++
++DEFINITION OF DONE:
++{{taskDefinitionOfDone}}
++
++SKRÓT ZADANIA:
+ {{task}}
+ 
+-ZAKRES:
+-- apps/frontend/**
++TRYB PRACY
++
++1. Najpierw przeanalizuj zakres taska.
++2. Trzymaj się wyłącznie allowedAreas.
++3. Nie zmieniaj forbiddenAreas.
++4. Jeśli task dopuszcza backend lub shared i zmiana jest tam potrzebna, wykonaj ją tam zamiast robić obejście.
++5. Nie rób szerokiego refactoru.
++6. Nie zmieniaj migracji, auth, RBAC ani innych obszarów poza taskiem, jeśli task nie wymaga tego wprost.
++7. Zmieniaj tylko minimalny vertical slice potrzebny do realizacji zadania.
++
++WYMAGANY SPOSÓB ODPOWIEDZI
++
++Zwróć:
+ 
+-ZABRONIONE:
+-- backend
+-- prisma
+-- shared
++1. listę zmienionych plików
++2. krótką listę zmian
++3. pełny kod każdego zmienionego pliku
++4. krótkie uzasadnienie architektoniczne
++5. listę uruchomionych testów / komend walidacyjnych
+ 
+-Wymagania:
+-- użyj istniejącego API retry
+-- pokaż loading
+-- pokaż success/error
++WAŻNE
+ 
+-Zwróć pełny kod zmienionych plików.
+\ No newline at end of file
++- Nie zakładaj z góry, że task jest frontend-only.
++- Zakres wynika z task.json.
++- Jeśli czegoś nie trzeba zmieniać, nie dotykaj tego.
++- Nie modyfikuj plików poza zakresem tylko po to, żeby "posprzątać".
+\ No newline at end of file
+diff --git a/agent/state/task.json b/agent/state/task.json
+index b12aacf..98730d9 100644
+--- a/agent/state/task.json
++++ b/agent/state/task.json
+@@ -1,4 +1,24 @@
+ {
+-  "task": "Dodaj prosty przycisk retry w InternalNotificationAttemptsPanel z wykorzystaniem istniejącego endpointu retry",
+-  "status": "pending"
++  "id": "pr20a-global-internal-notification-attempts-read-api",
++  "title": "Dodaj globalny read endpoint dla internal notification attempts",
++  "goal": "Udostępnić backendowy operacyjny odczyt prób notyfikacji wewnętrznych do przyszłej globalnej listy UI.",
++  "scope": "backend",
++  "allowedAreas": ["backend", "shared"],
++  "forbiddenAreas": ["frontend"],
++  "constraints": [
++    "Implement only the minimal vertical slice required by the task",
++    "Do not introduce unrelated refactors",
++    "Do not add Prisma migrations unless explicitly required",
++    "Do not change auth or RBAC unless explicitly required",
++    "Do not modify existing retry semantics",
++    "Do not change notification transport adapters",
++    "Do not change NOTE parsing compatibility behavior"
++  ],
++  "definitionOfDone": [
++    "A new read endpoint for internal notification attempts list exists",
++    "Shared DTOs required by the endpoint are added or updated",
++    "Backend tests covering the new endpoint or service are added or updated",
++    "Type checks and builds pass",
++    "No unrelated files are modified"
++  ]
+ }
+\ No newline at end of file
+
+```
+
+## Wyniki walidacji technicznej
+
+### Build shared (typy)
+Komenda: `npm run build -w packages/shared`
+Status: **SUCCESS** (1907ms)
+
+```
+
+> @np-manager/shared@1.0.0 build
+> tsc
+
+
+```
+
+### Testy shared
+Komenda: `npm run test -w packages/shared`
+Status: **SUCCESS** (1003ms)
+
+```
+
+> @np-manager/shared@1.0.0 test
+> vitest run --passWithNoTests
+
+
+[1m[7m[36m RUN [39m[27m[22m [36mv2.1.9 [39m[90mC:/Users/cicha/OneDrive/Desktop/Projekt/np-manager/packages/shared[39m
+
+No test files found, exiting with code 0
+
+
+```
+
+### Testy backend (smoke)
+Komenda: `npm run test -w apps/backend`
+Status: **SUCCESS** (7895ms)
+
+```
+... (pokazano ostatnie 4000 znaków)
+zek","reqId":"da302313-c704-4990-a8f3-625b0112c140","req":{"method":"GET","url":"/health/ready","hostname":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
+{"level":30,"time":1776628628729,"pid":11480,"hostname":"Trolopiszek","reqId":"a4d45881-14a6-4f60-944d-208fa7459575","req":{"method":"GET","url":"/health/ready","hostname":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
+ [32m✓[39m prisma/__tests__/seed.communication-templates.test.ts [2m([22m[2m3 tests[22m[2m)[22m[90m 26[2mms[22m[39m
+ [32m✓[39m src/modules/porting-requests/__tests__/porting-request-communication.templates.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 5[2mms[22m[39m
+ [32m✓[39m src/modules/porting-requests/__tests__/porting-notification-events.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 7[2mms[22m[39m
+{"level":30,"time":1776628628762,"pid":11480,"hostname":"Trolopiszek","reqId":"f4cde81d-514c-4cd5-b6f5-7ad4dd96f402","req":{"method":"GET","url":"/health/ready","hostname":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
+{"level":30,"time":1776628628656,"pid":11480,"hostname":"Trolopiszek","reqId":"c5125ffd-624b-4593-a878-7e45127c3fd8","res":{"statusCode":200},"responseTime":7.069099992513657,"msg":"request completed"}
+{"level":30,"time":1776628628699,"pid":11480,"hostname":"Trolopiszek","reqId":"da302313-c704-4990-a8f3-625b0112c140","res":{"statusCode":200},"responseTime":1.4550000131130219,"msg":"request completed"}
+{"level":30,"time":1776628628734,"pid":11480,"hostname":"Trolopiszek","reqId":"a4d45881-14a6-4f60-944d-208fa7459575","res":{"statusCode":503},"responseTime":3.9476999938488007,"msg":"request completed"}
+{"level":30,"time":1776628628762,"pid":11480,"hostname":"Trolopiszek","reqId":"f4cde81d-514c-4cd5-b6f5-7ad4dd96f402","res":{"statusCode":503},"responseTime":0.5578999817371368,"msg":"request completed"}
+ [32m✓[39m src/__tests__/app.health.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 202[2mms[22m[39m
+ [32m✓[39m src/modules/admin-users/__tests__/admin-users.schema.test.ts [2m([22m[2m3 tests[22m[2m)[22m[90m 6[2mms[22m[39m
+ [32m✓[39m prisma/__tests__/seed.qa-communication-fixtures.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 5[2mms[22m[39m
+{"level":30,"time":1776628628914,"pid":24968,"hostname":"Trolopiszek","reqId":"4084f148-0906-48eb-8383-89e3d0975e82","req":{"method":"PATCH","url":"/api/auth/change-password","hostname":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
+{"level":30,"time":1776628628956,"pid":24968,"hostname":"Trolopiszek","reqId":"92f0ef43-8936-47dc-8293-9aed1287032d","req":{"method":"PATCH","url":"/api/auth/change-password","hostname":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
+{"level":30,"time":1776628628933,"pid":24968,"hostname":"Trolopiszek","reqId":"4084f148-0906-48eb-8383-89e3d0975e82","res":{"statusCode":401},"responseTime":11.952399998903275,"msg":"request completed"}
+{"level":30,"time":1776628628962,"pid":24968,"hostname":"Trolopiszek","reqId":"92f0ef43-8936-47dc-8293-9aed1287032d","res":{"statusCode":200},"responseTime":5.233900010585785,"msg":"request completed"}
+ [32m✓[39m src/__tests__/app.auth.routes.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 135[2mms[22m[39m
+ [32m✓[39m src/shared/errors/__tests__/error-handler.test.ts [2m([22m[2m1 test[22m[2m)[22m[90m 9[2mms[22m[39m
+ [32m✓[39m src/modules/porting-requests/__tests__/internal-notification-failures.router.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 4[2mms[22m[39m
+ [32m✓[39m src/__tests__/app.runtime-routes.test.ts [2m([22m[2m1 test[22m[2m)[22m[90m 58[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m63 passed[39m[22m[90m (63)[39m
+[2m      Tests [22m [1m[32m455 passed[39m[22m[90m (455)[39m
+[2m   Start at [22m 21:57:02
+[2m   Duration [22m 6.99s[2m (transform 10.39s, setup 0ms, collect 31.83s, tests 5.56s, environment 20ms, prepare 12.76s)[22m
+
+
+```
+
+### Testy frontend
+Komenda: `npm run test -w apps/frontend`
+Status: **SUCCESS** (7610ms)
+
+```
+... (pokazano ostatnie 4000 znaków)
+tionPanel.test.tsx [2m([22m[2m10 tests[22m[2m)[22m[90m 118[2mms[22m[39m
+ [32m✓[39m src/lib/notificationFailureQueueOperationalStatus.test.ts [2m([22m[2m11 tests[22m[2m)[22m[90m 8[2mms[22m[39m
+ [32m✓[39m src/components/admin-settings/SystemModeSettingsPanel.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 22[2mms[22m[39m
+ [32m✓[39m src/services/communicationTemplates.api.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 11[2mms[22m[39m
+ [32m✓[39m src/components/admin-users/AdminUsersModule.test.tsx [2m([22m[2m10 tests[22m[2m)[22m[90m 115[2mms[22m[39m
+ [32m✓[39m src/pages/Requests/RequestsPage.test.tsx [2m([22m[2m9 tests[22m[2m)[22m[90m 70[2mms[22m[39m
+ [32m✓[39m src/components/admin-settings/PortingNotificationSettingsPanel.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 22[2mms[22m[39m
+ [32m✓[39m src/services/adminSystemModeSettings.api.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 9[2mms[22m[39m
+ [32m✓[39m src/components/CommunicationTemplatesAdmin/CommunicationTemplatesAdmin.test.tsx [2m([22m[2m5 tests[22m[2m)[22m[90m 187[2mms[22m[39m
+ [32m✓[39m src/pages/Admin/SystemModeSettingsPage.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[90m 17[2mms[22m[39m
+ [32m✓[39m src/services/adminUsers.api.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 11[2mms[22m[39m
+ [32m✓[39m src/services/adminPortingNotificationSettings.api.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 8[2mms[22m[39m
+ [32m✓[39m src/lib/portingOwnership.test.ts [2m([22m[2m3 tests[22m[2m)[22m[90m 6[2mms[22m[39m
+ [32m✓[39m src/services/adminNotificationFallbackSettings.api.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 9[2mms[22m[39m
+ [32m✓[39m src/pages/Requests/requestDetailCapabilities.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 6[2mms[22m[39m
+ [32m✓[39m src/components/PortingInternalNotificationsPanel/PortingInternalNotificationsPanel.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 60[2mms[22m[39m
+ [32m✓[39m src/components/layout/AppLayout.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 137[2mms[22m[39m
+ [32m✓[39m src/pages/Admin/PortingNotificationSettingsPage.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 18[2mms[22m[39m
+ [32m✓[39m src/lib/communicationTemplateAdmin.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 7[2mms[22m[39m
+ [32m✓[39m src/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 49[2mms[22m[39m
+ [32m✓[39m src/services/auth.api.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 9[2mms[22m[39m
+ [32m✓[39m src/lib/internalNotificationRetryMessages.test.ts [2m([22m[2m6 tests[22m[2m)[22m[90m 6[2mms[22m[39m
+ [32m✓[39m src/stores/systemCapabilities.store.test.ts [2m([22m[2m1 test[22m[2m)[22m[90m 5[2mms[22m[39m
+ [32m✓[39m src/pages/Auth/ForcePasswordChangePage.test.tsx [2m([22m[2m1 test[22m[2m)[22m[90m 11[2mms[22m[39m
+ [32m✓[39m src/components/PortingCaseHistory/PortingCaseHistory.test.tsx [2m([22m[2m1 test[22m[2m)[22m[90m 12[2mms[22m[39m
+ [32m✓[39m src/pages/Admin/AdminUsersPage.test.tsx [2m([22m[2m1 test[22m[2m)[22m[90m 10[2mms[22m[39m
+ [32m✓[39m src/pages/Admin/CommunicationTemplatesAdminPage.test.tsx [2m([22m[2m1 test[22m[2m)[22m[90m 12[2mms[22m[39m
+ [32m✓[39m src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx [2m([22m[2m5 tests[22m[2m)[22m[90m 265[2mms[22m[39m
+ [32m✓[39m src/pages/Notifications/NotificationFailureQueuePage.test.tsx [2m([22m[2m10 tests[22m[2m)[22m[33m 525[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m36 passed[39m[22m[90m (36)[39m
+[2m      Tests [22m [1m[32m193 passed[39m[22m[90m (193)[39m
+[2m   Start at [22m 21:57:10
+[2m   Duration [22m 6.60s[2m (transform 3.73s, setup 0ms, collect 12.81s, tests 1.95s, environment 3.55s, prepare 7.08s)[22m
+
+
+```
+
+## Checklista review – odpowiedz na KAŻDY punkt (TAK / NIE / N/D)
+
+1. [ ] Feature działa zgodnie z opisem zadania?
+2. [ ] Wszystkie acceptance criteria spełnione?
+3. [ ] Brak naruszeń forbidden_paths? 
+4. [ ] Wyniki walidacji są zielone? 
+5. [ ] Brak nowych zależności npm?
+6. [ ] Brak importów z backendu do frontendu?
+7. [ ] Kod czytelny i spójny z istniejącym stylem?
+8. [ ] Brak "śmieciowych" zmian (zmiany whitespace, reformatowanie niezwiązane, martwy kod, zakomentowane fragmenty)?
+9. [ ] UX ma sens – stany loading/error/disabled obsłużone?
+10. [ ] Brak oczywistych błędów (null reference, brakujące props, niepoprawne typy)?
+
+## TWOJA DECYZJA
+
+Napisz dokładnie **jedną z dwóch linii** na końcu:
+
+```
+DECYZJA: OK
+```
+
+lub
+
+```
+DECYZJA: FIX
+```
+
+**Reguły decyzyjne – bezwzględne:**
+
+- Jeśli są naruszenia forbidden_paths → **FIX**
+- Jeśli walidacja zwróciła FAIL → **FIX**
+- Jeśli acceptance criteria nie są jednoznacznie spełnione → **FIX**
+- Jeśli masz jakąkolwiek wątpliwość → **FIX** (never OK on doubt)
+
+Po DECYZJA: FIX dodaj sekcję **"Co poprawić"** z konkretną listą punktorów. Bądź jednoznaczny – bez pytań.

--- a/pipeline/reports/etap-2-cykl-1.md
+++ b/pipeline/reports/etap-2-cykl-1.md
@@ -1,0 +1,111 @@
+# Walidacja – etap 2, cykl 1
+Data: 2026-04-19 19:57:17
+
+### Build shared (typy)
+Komenda: `npm run build -w packages/shared`
+Status: **SUCCESS** (1907ms)
+
+```
+
+> @np-manager/shared@1.0.0 build
+> tsc
+
+
+```
+
+### Testy shared
+Komenda: `npm run test -w packages/shared`
+Status: **SUCCESS** (1003ms)
+
+```
+
+> @np-manager/shared@1.0.0 test
+> vitest run --passWithNoTests
+
+
+[1m[7m[36m RUN [39m[27m[22m [36mv2.1.9 [39m[90mC:/Users/cicha/OneDrive/Desktop/Projekt/np-manager/packages/shared[39m
+
+No test files found, exiting with code 0
+
+
+```
+
+### Testy backend (smoke)
+Komenda: `npm run test -w apps/backend`
+Status: **SUCCESS** (7895ms)
+
+```
+... (pokazano ostatnie 4000 znaków)
+zek","reqId":"da302313-c704-4990-a8f3-625b0112c140","req":{"method":"GET","url":"/health/ready","hostname":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
+{"level":30,"time":1776628628729,"pid":11480,"hostname":"Trolopiszek","reqId":"a4d45881-14a6-4f60-944d-208fa7459575","req":{"method":"GET","url":"/health/ready","hostname":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
+ [32m✓[39m prisma/__tests__/seed.communication-templates.test.ts [2m([22m[2m3 tests[22m[2m)[22m[90m 26[2mms[22m[39m
+ [32m✓[39m src/modules/porting-requests/__tests__/porting-request-communication.templates.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 5[2mms[22m[39m
+ [32m✓[39m src/modules/porting-requests/__tests__/porting-notification-events.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 7[2mms[22m[39m
+{"level":30,"time":1776628628762,"pid":11480,"hostname":"Trolopiszek","reqId":"f4cde81d-514c-4cd5-b6f5-7ad4dd96f402","req":{"method":"GET","url":"/health/ready","hostname":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
+{"level":30,"time":1776628628656,"pid":11480,"hostname":"Trolopiszek","reqId":"c5125ffd-624b-4593-a878-7e45127c3fd8","res":{"statusCode":200},"responseTime":7.069099992513657,"msg":"request completed"}
+{"level":30,"time":1776628628699,"pid":11480,"hostname":"Trolopiszek","reqId":"da302313-c704-4990-a8f3-625b0112c140","res":{"statusCode":200},"responseTime":1.4550000131130219,"msg":"request completed"}
+{"level":30,"time":1776628628734,"pid":11480,"hostname":"Trolopiszek","reqId":"a4d45881-14a6-4f60-944d-208fa7459575","res":{"statusCode":503},"responseTime":3.9476999938488007,"msg":"request completed"}
+{"level":30,"time":1776628628762,"pid":11480,"hostname":"Trolopiszek","reqId":"f4cde81d-514c-4cd5-b6f5-7ad4dd96f402","res":{"statusCode":503},"responseTime":0.5578999817371368,"msg":"request completed"}
+ [32m✓[39m src/__tests__/app.health.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 202[2mms[22m[39m
+ [32m✓[39m src/modules/admin-users/__tests__/admin-users.schema.test.ts [2m([22m[2m3 tests[22m[2m)[22m[90m 6[2mms[22m[39m
+ [32m✓[39m prisma/__tests__/seed.qa-communication-fixtures.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 5[2mms[22m[39m
+{"level":30,"time":1776628628914,"pid":24968,"hostname":"Trolopiszek","reqId":"4084f148-0906-48eb-8383-89e3d0975e82","req":{"method":"PATCH","url":"/api/auth/change-password","hostname":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
+{"level":30,"time":1776628628956,"pid":24968,"hostname":"Trolopiszek","reqId":"92f0ef43-8936-47dc-8293-9aed1287032d","req":{"method":"PATCH","url":"/api/auth/change-password","hostname":"localhost:80","remoteAddress":"127.0.0.1"},"msg":"incoming request"}
+{"level":30,"time":1776628628933,"pid":24968,"hostname":"Trolopiszek","reqId":"4084f148-0906-48eb-8383-89e3d0975e82","res":{"statusCode":401},"responseTime":11.952399998903275,"msg":"request completed"}
+{"level":30,"time":1776628628962,"pid":24968,"hostname":"Trolopiszek","reqId":"92f0ef43-8936-47dc-8293-9aed1287032d","res":{"statusCode":200},"responseTime":5.233900010585785,"msg":"request completed"}
+ [32m✓[39m src/__tests__/app.auth.routes.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 135[2mms[22m[39m
+ [32m✓[39m src/shared/errors/__tests__/error-handler.test.ts [2m([22m[2m1 test[22m[2m)[22m[90m 9[2mms[22m[39m
+ [32m✓[39m src/modules/porting-requests/__tests__/internal-notification-failures.router.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 4[2mms[22m[39m
+ [32m✓[39m src/__tests__/app.runtime-routes.test.ts [2m([22m[2m1 test[22m[2m)[22m[90m 58[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m63 passed[39m[22m[90m (63)[39m
+[2m      Tests [22m [1m[32m455 passed[39m[22m[90m (455)[39m
+[2m   Start at [22m 21:57:02
+[2m   Duration [22m 6.99s[2m (transform 10.39s, setup 0ms, collect 31.83s, tests 5.56s, environment 20ms, prepare 12.76s)[22m
+
+
+```
+
+### Testy frontend
+Komenda: `npm run test -w apps/frontend`
+Status: **SUCCESS** (7610ms)
+
+```
+... (pokazano ostatnie 4000 znaków)
+tionPanel.test.tsx [2m([22m[2m10 tests[22m[2m)[22m[90m 118[2mms[22m[39m
+ [32m✓[39m src/lib/notificationFailureQueueOperationalStatus.test.ts [2m([22m[2m11 tests[22m[2m)[22m[90m 8[2mms[22m[39m
+ [32m✓[39m src/components/admin-settings/SystemModeSettingsPanel.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 22[2mms[22m[39m
+ [32m✓[39m src/services/communicationTemplates.api.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 11[2mms[22m[39m
+ [32m✓[39m src/components/admin-users/AdminUsersModule.test.tsx [2m([22m[2m10 tests[22m[2m)[22m[90m 115[2mms[22m[39m
+ [32m✓[39m src/pages/Requests/RequestsPage.test.tsx [2m([22m[2m9 tests[22m[2m)[22m[90m 70[2mms[22m[39m
+ [32m✓[39m src/components/admin-settings/PortingNotificationSettingsPanel.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 22[2mms[22m[39m
+ [32m✓[39m src/services/adminSystemModeSettings.api.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 9[2mms[22m[39m
+ [32m✓[39m src/components/CommunicationTemplatesAdmin/CommunicationTemplatesAdmin.test.tsx [2m([22m[2m5 tests[22m[2m)[22m[90m 187[2mms[22m[39m
+ [32m✓[39m src/pages/Admin/SystemModeSettingsPage.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[90m 17[2mms[22m[39m
+ [32m✓[39m src/services/adminUsers.api.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 11[2mms[22m[39m
+ [32m✓[39m src/services/adminPortingNotificationSettings.api.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 8[2mms[22m[39m
+ [32m✓[39m src/lib/portingOwnership.test.ts [2m([22m[2m3 tests[22m[2m)[22m[90m 6[2mms[22m[39m
+ [32m✓[39m src/services/adminNotificationFallbackSettings.api.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 9[2mms[22m[39m
+ [32m✓[39m src/pages/Requests/requestDetailCapabilities.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 6[2mms[22m[39m
+ [32m✓[39m src/components/PortingInternalNotificationsPanel/PortingInternalNotificationsPanel.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 60[2mms[22m[39m
+ [32m✓[39m src/components/layout/AppLayout.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 137[2mms[22m[39m
+ [32m✓[39m src/pages/Admin/PortingNotificationSettingsPage.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 18[2mms[22m[39m
+ [32m✓[39m src/lib/communicationTemplateAdmin.test.ts [2m([22m[2m4 tests[22m[2m)[22m[90m 7[2mms[22m[39m
+ [32m✓[39m src/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[90m 49[2mms[22m[39m
+ [32m✓[39m src/services/auth.api.test.ts [2m([22m[2m2 tests[22m[2m)[22m[90m 9[2mms[22m[39m
+ [32m✓[39m src/lib/internalNotificationRetryMessages.test.ts [2m([22m[2m6 tests[22m[2m)[22m[90m 6[2mms[22m[39m
+ [32m✓[39m src/stores/systemCapabilities.store.test.ts [2m([22m[2m1 test[22m[2m)[22m[90m 5[2mms[22m[39m
+ [32m✓[39m src/pages/Auth/ForcePasswordChangePage.test.tsx [2m([22m[2m1 test[22m[2m)[22m[90m 11[2mms[22m[39m
+ [32m✓[39m src/components/PortingCaseHistory/PortingCaseHistory.test.tsx [2m([22m[2m1 test[22m[2m)[22m[90m 12[2mms[22m[39m
+ [32m✓[39m src/pages/Admin/AdminUsersPage.test.tsx [2m([22m[2m1 test[22m[2m)[22m[90m 10[2mms[22m[39m
+ [32m✓[39m src/pages/Admin/CommunicationTemplatesAdminPage.test.tsx [2m([22m[2m1 test[22m[2m)[22m[90m 12[2mms[22m[39m
+ [32m✓[39m src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx [2m([22m[2m5 tests[22m[2m)[22m[90m 265[2mms[22m[39m
+ [32m✓[39m src/pages/Notifications/NotificationFailureQueuePage.test.tsx [2m([22m[2m10 tests[22m[2m)[22m[33m 525[2mms[22m[39m
+
+[2m Test Files [22m [1m[32m36 passed[39m[22m[90m (36)[39m
+[2m      Tests [22m [1m[32m193 passed[39m[22m[90m (193)[39m
+[2m   Start at [22m 21:57:10
+[2m   Duration [22m 6.60s[2m (transform 3.73s, setup 0ms, collect 12.81s, tests 1.95s, environment 3.55s, prepare 7.08s)[22m
+
+
+```

--- a/pipeline/run.js
+++ b/pipeline/run.js
@@ -1,0 +1,738 @@
+/**
+ * NP-Manager Dev Pipeline V2 – Orchestrator
+ *
+ * Półautomat lokalny do pracy z AI.
+ * - generuje prompt do modelu wykonawczego,
+ * - zapisuje diff,
+ * - pilnuje zakresu zmian (guardy),
+ * - uruchamia walidację techniczną,
+ * - generuje prompt do review,
+ * - prowadzi historię cykli i raport etapu.
+ *
+ * Założenie domyślne: frontend-only.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execFileSync, execSync } = require("child_process");
+const readline = require("readline");
+
+// ─── Paths ───────────────────────────────────────────────────────────────────
+
+const ROOT = path.resolve(__dirname, "..");
+const PIPELINE_DIR = __dirname;
+const PLAN_FILE = path.join(PIPELINE_DIR, "plan.json");
+const STATE_FILE = path.join(PIPELINE_DIR, "state.json");
+const LOGS_DIR = path.join(PIPELINE_DIR, "logs");
+const PROMPTS_DIR = path.join(PIPELINE_DIR, "prompts");
+const DIFFS_DIR = path.join(PIPELINE_DIR, "diffs");
+const REPORTS_DIR = path.join(PIPELINE_DIR, "reports");
+
+// Artefakty tworzone przez pipeline wykluczamy z diff/status na potrzeby review.
+// Dzięki temu reviewer widzi głównie zmiany w aplikacji, a nie techniczne pliki pomocnicze.
+const PIPELINE_ARTIFACTS_EXCLUDES = [
+  ":(exclude)pipeline/prompts",
+  ":(exclude)pipeline/diffs",
+  ":(exclude)pipeline/reports",
+  ":(exclude)pipeline/logs",
+  ":(exclude)pipeline/state.json",
+  ":(exclude)pipeline/plan.json",
+];
+
+// ─── Helpers: IO ────────────────────────────────────────────────────────────
+
+function readJSON(file) {
+  if (!fs.existsSync(file)) return null;
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function writeJSON(file, data) {
+  fs.writeFileSync(file, JSON.stringify(data, null, 2), "utf8");
+}
+
+function writeFile(file, content) {
+  fs.writeFileSync(file, content, "utf8");
+}
+
+function ensureDirs() {
+  [LOGS_DIR, PROMPTS_DIR, DIFFS_DIR, REPORTS_DIR].forEach((dir) => {
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  });
+}
+
+function timestamp() {
+  return new Date().toISOString().replace("T", " ").substring(0, 19);
+}
+
+function ask(rl, question) {
+  return new Promise((resolve) => rl.question(question, resolve));
+}
+
+function tail(text, maxChars) {
+  if (!text) return "";
+  if (text.length <= maxChars) return text;
+  return `... (pokazano ostatnie ${maxChars} znaków)\n${text.slice(-maxChars)}`;
+}
+
+// ─── Helpers: console ───────────────────────────────────────────────────────
+
+function header(text) {
+  const line = "═".repeat(60);
+  console.log(`\n${line}`);
+  console.log(`  ${text}`);
+  console.log(`${line}`);
+}
+
+const info = (text) => console.log(`  ℹ  ${text}`);
+const ok = (text) => console.log(`  ✅ ${text}`);
+const warn = (text) => console.log(`  ⚠️  ${text}`);
+const err = (text) => console.log(`  ❌ ${text}`);
+const step = (text) => console.log(`  ➜  ${text}`);
+
+// ─── Helpers: git ───────────────────────────────────────────────────────────
+
+function runGit(args) {
+  return execFileSync("git", args, {
+    cwd: ROOT,
+    stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+  }).toString();
+}
+
+function gitDiff() {
+  try {
+    const pathspec = ["--", ".", ...PIPELINE_ARTIFACTS_EXCLUDES];
+    const diffAgainstHead = runGit(["diff", "HEAD", ...pathspec]);
+    if (diffAgainstHead.trim()) return diffAgainstHead;
+    const unstagedOnly = runGit(["diff", ...pathspec]);
+    return unstagedOnly || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitStatus() {
+  try {
+    return runGit(["status", "--short", "--", ".", ...PIPELINE_ARTIFACTS_EXCLUDES]).trim();
+  } catch {
+    return null;
+  }
+}
+
+function extractChangedFiles(diff) {
+  if (!diff) return [];
+  const result = new Set();
+  const re = /^diff --git a\/(.+?) b\/(.+?)$/gm;
+  let match;
+  while ((match = re.exec(diff)) !== null) {
+    result.add(match[2] || match[1]);
+  }
+  return [...result];
+}
+
+function diffSizeMetrics(diff) {
+  if (!diff) return { files: 0, added: 0, removed: 0 };
+  const files = extractChangedFiles(diff).length;
+  let added = 0;
+  let removed = 0;
+
+  for (const line of diff.split("\n")) {
+    if (line.startsWith("+++") || line.startsWith("---")) continue;
+    if (line.startsWith("+")) added += 1;
+    else if (line.startsWith("-")) removed += 1;
+  }
+
+  return { files, added, removed };
+}
+
+// ─── State ──────────────────────────────────────────────────────────────────
+
+function initState(plan) {
+  const firstPending = plan.stages.find((stage) => !stage.done);
+  if (!firstPending) return null;
+  return {
+    current_stage_id: firstPending.id,
+    cycle: 1,
+    max_cycles: 3,
+    last_updated: timestamp(),
+    history: [],
+  };
+}
+
+function loadOrInitState(plan) {
+  const existing = readJSON(STATE_FILE);
+  if (existing) return existing;
+  const fresh = initState(plan);
+  if (fresh) writeJSON(STATE_FILE, fresh);
+  return fresh;
+}
+
+function saveState(state) {
+  state.last_updated = timestamp();
+  writeJSON(STATE_FILE, state);
+}
+
+// ─── Rules / guards ─────────────────────────────────────────────────────────
+
+function matchesAny(filePath, patterns) {
+  return patterns.some((pattern) => filePath === pattern || filePath.startsWith(pattern));
+}
+
+function checkForbiddenPaths(files, forbidden, allowedForStage) {
+  const violations = [];
+  for (const file of files) {
+    if (matchesAny(file, allowedForStage)) continue;
+    if (matchesAny(file, forbidden)) violations.push(file);
+  }
+  return violations;
+}
+
+function checkOversize(metrics, thresholds) {
+  const warnings = [];
+  if (thresholds.files && metrics.files > thresholds.files) {
+    warnings.push(`Zmieniono ${metrics.files} plików (próg: ${thresholds.files})`);
+  }
+  const changedLines = metrics.added + metrics.removed;
+  if (thresholds.lines && changedLines > thresholds.lines) {
+    warnings.push(`Zmieniono ${changedLines} linii (próg: ${thresholds.lines})`);
+  }
+  return warnings;
+}
+
+// ─── Validation ─────────────────────────────────────────────────────────────
+
+function runCommand(cmd) {
+  const started = Date.now();
+  try {
+    const output = execSync(cmd, {
+      cwd: ROOT,
+      stdio: "pipe",
+      env: { ...process.env, CI: "1", FORCE_COLOR: "0" },
+    }).toString();
+
+    return {
+      cmd,
+      status: "SUCCESS",
+      durationMs: Date.now() - started,
+      output: tail(output, 4000),
+    };
+  } catch (error) {
+    const stdout = error.stdout ? error.stdout.toString() : "";
+    const stderr = error.stderr ? error.stderr.toString() : "";
+    const combined = `${stdout}\n${stderr}`.trim();
+
+    const missingScript = /Missing script|No workspaces found|ENOWORKSPACES/i.test(combined);
+
+    return {
+      cmd,
+      status: missingScript ? "SKIPPED" : "FAIL",
+      durationMs: Date.now() - started,
+      output: tail(combined, 4000),
+    };
+  }
+}
+
+function runValidation(validations) {
+  const results = [];
+  for (const validation of validations) {
+    step(`Uruchamiam: ${validation.label}`);
+    const result = runCommand(validation.cmd);
+    result.label = validation.label;
+    results.push(result);
+
+    if (result.status === "SUCCESS") ok(`${validation.label} – OK (${result.durationMs}ms)`);
+    else if (result.status === "SKIPPED") warn(`${validation.label} – pominięte (brak polecenia lub workspace)`);
+    else err(`${validation.label} – FAIL`);
+  }
+  return results;
+}
+
+function formatValidationSummary(results) {
+  if (!results.length) return "_(brak uruchomionej walidacji)_";
+  return results
+    .map((result) => {
+      const head = `### ${result.label}\nKomenda: \`${result.cmd}\`\nStatus: **${result.status}** (${result.durationMs}ms)`;
+      const body = result.output ? `\n\n\`\`\`\n${result.output}\n\`\`\`` : "";
+      return head + body;
+    })
+    .join("\n\n");
+}
+
+// ─── Prompt generators ──────────────────────────────────────────────────────
+
+function generateCodePrompt(stage, cycle, plan, lastFeedback = null) {
+  const fixNote = lastFeedback
+    ? `## ⚠️ Poprawki z poprzedniego cyklu (${cycle - 1})\n\nReviewer zgłosił:\n\n${lastFeedback}\n\nNapraw dokładnie te problemy. Nie dodawaj nic poza tym.`
+    : "";
+
+  const acceptanceCriteria = Array.isArray(stage.acceptance_criteria) && stage.acceptance_criteria.length
+    ? stage.acceptance_criteria.map((item, index) => `${index + 1}. ${item}`).join("\n")
+    : "_(brak – uzupełnij w plan.json)_";
+
+  const forbiddenList = (plan.forbidden_paths || []).map((item) => `- ${item}`).join("\n");
+  const allowPaths = Array.isArray(stage.allow_paths) && stage.allow_paths.length
+    ? stage.allow_paths.map((item) => `- ${item}`).join("\n")
+    : "- brak wyjątków";
+
+  return `# Zadanie: ${stage.name}
+Projekt: ${plan.project} | Cykl: ${cycle} | Tryb: ${stage.scope || plan.mode || "frontend-only"}
+
+${fixNote}
+
+## Opis zadania
+
+${stage.description}
+
+## Acceptance criteria
+
+${acceptanceCriteria}
+
+## Zasady – bezwzględne
+
+- Zakres zmian: **${stage.scope || plan.mode || "frontend-only"}**
+- Zabronione ścieżki:
+${forbiddenList}
+- Wyjątki dla tego etapu:
+${allowPaths}
+- NIE modyfikuj package.json / lockfile / backendu / prismy / shared, chyba że allow_paths mówi inaczej.
+- NIE dodawaj nowych zależności npm.
+- NIE importuj kodu backendu do frontendu.
+- Używaj istniejących komponentów, hooków i publicznego kontraktu API.
+- Zachowaj styl kodu i nazewnictwo z repo.
+- Po zmianach pliki MUSZĄ być zapisane na dysku.
+
+## Pliki do edycji (wskazówka)
+
+${stage.files_hint || "Ustal na podstawie opisu zadania i struktury repo."}
+
+## Format pracy
+
+1. W 2-3 zdaniach opisz plan.
+2. Edytuj pliki i zapisz je na dysku.
+3. Na końcu wypisz:
+   - listę zmienionych plików,
+   - krótkie podsumowanie zmian.
+
+Zacznij od razu. Nie pytaj o potwierdzenie.`;
+}
+
+function generateReviewPrompt({ stage, cycle, plan, diff, files, oversizeWarnings, validationResults }) {
+  const acceptanceCriteria = Array.isArray(stage.acceptance_criteria) && stage.acceptance_criteria.length
+    ? stage.acceptance_criteria.map((item, index) => `${index + 1}. ${item}`).join("\n")
+    : "_(brak – oceń wg opisu zadania)_";
+
+  const diffSection = diff && diff.trim()
+    ? `## git diff\n\n\`\`\`diff\n${diff}\n\`\`\``
+    : `## ⚠️ Brak zmian w git diff\n\nTo oznacza, że AI prawdopodobnie nie zapisało plików. W takim przypadku decyzja powinna być FIX.`;
+
+  const filesSection = files.length
+    ? `## Zmienione pliki (${files.length})\n\n${files.map((file) => `- \`${file}\``).join("\n")}`
+    : `## Zmienione pliki\n\n_(brak wykrytych zmian)_`;
+
+  const oversizeSection = oversizeWarnings.length
+    ? `## ⚠️ Ostrzeżenia o rozmiarze zmian\n\n${oversizeWarnings.map((item) => `- ${item}`).join("\n")}`
+    : "";
+
+  const validationSection = `## Wyniki walidacji technicznej\n\n${formatValidationSummary(validationResults)}`;
+  const anyFail = validationResults.some((result) => result.status === "FAIL");
+
+  return `# Review zmian kodu
+Etap: **${stage.name}** | Cykl: ${cycle} | Projekt: ${plan.project}
+
+Jesteś senior developerem robiącym ostrą recenzję. Twoja rola: wyłapać błędy zanim trafią do commita.
+
+## Zadanie które miał wykonać model
+
+${stage.description}
+
+## Acceptance criteria
+
+${acceptanceCriteria}
+
+## Zasady projektu
+
+- Tryb: ${stage.scope || plan.mode || "frontend-only"}
+- Zabronione ścieżki: ${(plan.forbidden_paths || []).map((item) => `\`${item}\``).join(", ")}
+- Brak nowych zależności npm
+- Brak importów z backendu do frontendu
+- Przy jakiejkolwiek wątpliwości wybierasz FIX
+
+${filesSection}
+
+${oversizeSection}
+
+${diffSection}
+
+${validationSection}
+
+## Checklista review – odpowiedz na każdy punkt (TAK / NIE / N/D)
+
+1. [ ] Feature działa zgodnie z opisem zadania?
+2. [ ] Wszystkie acceptance criteria są spełnione?
+3. [ ] Zakres zmian jest zgodny z frontend-only / allow_paths?
+4. [ ] Wyniki walidacji są akceptowalne? ${anyFail ? "**(są FAIL-e – prawdopodobnie FIX)**" : ""}
+5. [ ] Brak nowych zależności npm?
+6. [ ] Brak importów z backendu do frontendu?
+7. [ ] Kod jest czytelny i spójny z istniejącym stylem?
+8. [ ] Brak śmieciowych zmian (np. niepowiązany reformat, martwy kod, zakomentowane bloki)?
+9. [ ] UX ma sens – loading / error / disabled / empty state są obsłużone?
+10. [ ] Brak oczywistych błędów (null reference, niepoprawne typy, brakujące props)?
+
+## Twoja decyzja
+
+Na końcu odpowiedzi wpisz dokładnie jedną linię:
+
+DECYZJA: OK
+
+albo
+
+DECYZJA: FIX
+
+Jeśli wybierasz FIX, po tej linii dodaj sekcję:
+
+Co poprawić:
+- ...
+- ...
+
+Reguły bezwzględne:
+- jeśli walidacja zwróciła FAIL → FIX
+- jeśli acceptance criteria nie są jednoznacznie spełnione → FIX
+- jeśli masz jakąkolwiek wątpliwość → FIX`;
+}
+
+function generateStageReport(stage, state) {
+  const history = state.history.filter((entry) => entry.stage_id === stage.id);
+  const cycles = history.length;
+  const finalDecision = history[history.length - 1]?.decision || "UNKNOWN";
+
+  const historyText = history
+    .map((entry, index) => {
+      const feedbackBlock = entry.feedback
+        ? `\n- Feedback reviewera:\n${entry.feedback
+            .split("\n")
+            .map((line) => `  > ${line}`)
+            .join("\n")}`
+        : "";
+      return `### Cykl ${index + 1}\n- Decyzja: **${entry.decision}**\n- Czas: ${entry.timestamp}${feedbackBlock}`;
+    })
+    .join("\n\n");
+
+  return `# Raport etapu: ${stage.name}
+Projekt: NP-Manager | Data: ${timestamp()} | ID etapu: ${stage.id}
+
+## Opis zadania
+
+${stage.description}
+
+## Wynik
+
+- Liczba cykli: **${cycles}**
+- Finalna decyzja: **${finalDecision}**
+- Status: ${finalDecision === "OK" ? "✅ Gotowe do commitu" : "❌ Wymaga interwencji"}
+
+## Historia cykli
+
+${historyText || "_(brak historii)_"}
+
+---
+
+## Prompt do finalnego audytu (ChatGPT)
+
+Wklej ten raport do ChatGPT z prośbą:
+
+> Jesteś architektem systemowym. Zrób audyt tego ukończonego etapu NP-Managera.
+> Oceń: jakość zmian, zgodność z zakresem ${stage.scope || "frontend-only"}, ryzyka architektoniczne,
+> sugestie dla kolejnych etapów oraz potencjalne regresje.`;
+}
+
+// ─── Actions ────────────────────────────────────────────────────────────────
+
+async function actionGenerateCodePrompt(stage, state, plan) {
+  const lastEntry = state.history.filter((entry) => entry.stage_id === stage.id).slice(-1)[0];
+  const lastFeedback = lastEntry?.decision === "FIX" ? lastEntry.feedback : null;
+
+  const prompt = generateCodePrompt(stage, state.cycle, plan, lastFeedback);
+  const outFile = path.join(PROMPTS_DIR, "codex-prompt.md");
+  writeFile(outFile, prompt);
+
+  ok("Prompt wygenerowany");
+  console.log(`     📄 pipeline/prompts/codex-prompt.md\n`);
+  console.log("  Co teraz:");
+  step("1. Otwórz plik codex-prompt.md");
+  step("2. Skopiuj całą zawartość (Ctrl+A, Ctrl+C)");
+  step("3. Wklej do Codex albo Claude Code");
+  step("4. Poczekaj aż AI zapisze pliki na dysku");
+  step("5. Wróć tutaj i wybierz opcję [2]");
+}
+
+async function actionRunValidationAndReview(stage, state, plan, rl) {
+  info("Krok 1/3: sprawdzam zmiany w kodzie aplikacji (bez artefaktów pipeline'u)...");
+
+  const status = gitStatus();
+  if (!status) {
+    warn("git nie wykrywa żadnych zmian w kodzie aplikacji.");
+    warn("Sprawdź w VS Code, czy AI faktycznie zapisało pliki.");
+    warn("Jeśli pliki mają kropkę na zakładce – zapisz je (Ctrl+S) i uruchom [2] ponownie.");
+    const cont = await ask(rl, "  Kontynuować mimo to? (t/N): ");
+    if (cont.toLowerCase() !== "t") return;
+  } else {
+    console.log();
+    status.split("\n").forEach((line) => console.log(`     ${line}`));
+    console.log();
+  }
+
+  const diff = gitDiff();
+  const diffFile = path.join(DIFFS_DIR, `etap-${stage.id}-cykl-${state.cycle}.diff`);
+
+  if (diff) {
+    writeFile(diffFile, diff);
+    ok(`Diff zapisany: pipeline/diffs/etap-${stage.id}-cykl-${state.cycle}.diff`);
+  } else {
+    writeFile(diffFile, "BRAK ZMIAN\n");
+    warn("Diff pusty – zapisuję ślad audytowy.");
+  }
+
+  info("Krok 2/3: kontrola zakresu zmian (guardy)...");
+
+  const files = extractChangedFiles(diff);
+  const forbidden = plan.forbidden_paths || [];
+  const allowedForStage = stage.allow_paths || [];
+  const violations = checkForbiddenPaths(files, forbidden, allowedForStage);
+
+  const metrics = diffSizeMetrics(diff);
+  const oversizeWarnings = checkOversize(metrics, plan.oversize_warning || {});
+
+  if (violations.length) {
+    console.log();
+    err(`🛑 HARD STOP – wykryto ${violations.length} naruszenie(a) forbidden_paths:`);
+    violations.forEach((file) => console.log(`        - ${file}`));
+    console.log();
+    warn("Walidacja i prompt do review NIE zostaną wygenerowane.");
+    warn("Najpierw cofnij niedozwolone zmiany albo dopisz wyjątek do allow_paths.");
+    console.log();
+    console.log("  Gotowe komendy do cofnięcia zmian:");
+    violations.forEach((file) => console.log(`        git checkout -- \"${file}\"`));
+    console.log();
+    console.log("  Po poprawie uruchom opcję [2] ponownie.");
+    console.log();
+    info(`Ślad audytowy już zapisany w: pipeline/diffs/etap-${stage.id}-cykl-${state.cycle}.diff`);
+    return;
+  }
+
+  if (files.length) ok(`Scope OK – brak naruszeń forbidden_paths (${files.length} plików)`);
+  if (oversizeWarnings.length) {
+    warn("Ostrzeżenia o rozmiarze zmian:");
+    oversizeWarnings.forEach((item) => console.log(`     - ${item}`));
+  }
+
+  info("Krok 3/3: walidacja techniczna (build/test)...");
+  const validations = plan.validation || [];
+  let validationResults = [];
+
+  if (!validations.length) {
+    warn("Brak komend walidacji w plan.json – pomijam.");
+  } else {
+    console.log();
+    validationResults = runValidation(validations);
+    const reportFile = path.join(REPORTS_DIR, `etap-${stage.id}-cykl-${state.cycle}.md`);
+    const content = `# Walidacja – etap ${stage.id}, cykl ${state.cycle}\nData: ${timestamp()}\n\n${formatValidationSummary(validationResults)}\n`;
+    writeFile(reportFile, content);
+    ok(`Raport walidacji: pipeline/reports/etap-${stage.id}-cykl-${state.cycle}.md`);
+  }
+
+  const reviewPrompt = generateReviewPrompt({
+    stage,
+    cycle: state.cycle,
+    plan,
+    diff,
+    files,
+    oversizeWarnings,
+    validationResults,
+  });
+
+  const reviewFile = path.join(PROMPTS_DIR, "review-prompt.md");
+  writeFile(reviewFile, reviewPrompt);
+
+  console.log();
+  ok("Prompt do review wygenerowany");
+  console.log(`     📄 pipeline/prompts/review-prompt.md\n`);
+  console.log("  Co teraz:");
+  step("1. Otwórz review-prompt.md");
+  step("2. Skopiuj całą zawartość");
+  step("3. Wklej do drugiego modelu AI (nie tego, który pisał kod)");
+  step("4. Odbierz decyzję: OK albo FIX");
+  step("5. Wróć tutaj i wybierz opcję [3]");
+}
+
+async function actionInputDecision(stage, state, rl) {
+  const raw = await ask(rl, "  Wpisz decyzję AI (OK / FIX): ");
+  const decision = raw.trim().toUpperCase();
+
+  if (decision !== "OK" && decision !== "FIX") {
+    err("Nieprawidłowa decyzja. Wpisz dokładnie OK lub FIX.");
+    return;
+  }
+
+  let feedback = null;
+  if (decision === "FIX") {
+    console.log();
+    info("Wklej sekcję 'Co poprawić' od reviewera.");
+    info("Każda linia → Enter. Gdy skończysz → wpisz KONIEC i Enter.\n");
+    const lines = [];
+    while (true) {
+      const line = await ask(rl, "  > ");
+      if (line.trim().toUpperCase() === "KONIEC") break;
+      lines.push(line);
+    }
+    feedback = lines.join("\n").trim() || "(brak szczegółów od reviewera)";
+  }
+
+  state.history.push({
+    stage_id: stage.id,
+    cycle: state.cycle,
+    decision,
+    feedback,
+    timestamp: timestamp(),
+  });
+
+  if (decision === "OK") {
+    console.log();
+    ok(`Etap \"${stage.name}\" zaliczony po ${state.cycle} ${state.cycle === 1 ? "cyklu" : "cyklach"}`);
+
+    const planLive = readJSON(PLAN_FILE);
+    const stageInPlan = planLive.stages.find((item) => item.id === stage.id);
+    if (stageInPlan) stageInPlan.done = true;
+    writeJSON(PLAN_FILE, planLive);
+
+    const nextStage = planLive.stages.find((item) => !item.done);
+    if (nextStage) {
+      state.current_stage_id = nextStage.id;
+      state.cycle = 1;
+      info(`Następny etap: [${nextStage.id}] ${nextStage.name}`);
+    } else {
+      state.current_stage_id = null;
+      ok("Wszystkie etapy z planu ukończone!");
+    }
+
+    const report = generateStageReport(stage, state);
+    const reportFile = path.join(LOGS_DIR, `etap-${stage.id}-raport.md`);
+    writeFile(reportFile, report);
+    ok(`Raport etapu: pipeline/logs/etap-${stage.id}-raport.md`);
+    console.log();
+    info("Następne kroki:");
+    step("1. Wklej raport do ChatGPT do finalnego audytu architektonicznego");
+    step(`2. Jeśli audyt OK – zrób commit, np. git add . && git commit -m \"feat: ${stage.name}\"`);
+    step("3. git push i uruchom pipeline ponownie dla następnego etapu");
+  } else {
+    if (state.cycle >= state.max_cycles) {
+      console.log();
+      err(`Osiągnięto limit ${state.max_cycles} cykli dla tego etapu.`);
+      warn("Co możesz zrobić:");
+      step("A) Rozbij etap na mniejsze zadania w plan.json");
+      step("B) Popraw ręcznie kod i wróć do opcji [3] z decyzją OK");
+      step("C) Cofnij zmiany i zacznij etap od nowa z lepszym opisem");
+    } else {
+      state.cycle += 1;
+      console.log();
+      info(`Cykl ${state.cycle}/${state.max_cycles} – wybierz [1], aby wygenerować nowy prompt z poprawkami.`);
+    }
+  }
+
+  saveState(state);
+}
+
+async function actionShowReport(stage) {
+  const reportFile = path.join(LOGS_DIR, `etap-${stage.id}-raport.md`);
+  if (!fs.existsSync(reportFile)) {
+    warn("Raport jeszcze nie istnieje. Najpierw zakończ etap decyzją OK.");
+    return;
+  }
+  const content = fs.readFileSync(reportFile, "utf8");
+  console.log(`\n${content}`);
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+function getCurrentStage(plan, state) {
+  if (!state?.current_stage_id) return null;
+  return plan.stages.find((stage) => stage.id === state.current_stage_id) || null;
+}
+
+async function main() {
+  ensureDirs();
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+  while (true) {
+    const plan = readJSON(PLAN_FILE);
+    if (!plan) {
+      err("Nie znaleziono pipeline/plan.json.");
+      rl.close();
+      process.exit(1);
+    }
+
+    const state = loadOrInitState(plan);
+    if (!state || !state.current_stage_id) {
+      console.log();
+      ok("Wszystkie etapy z planu są zakończone. Brak pracy do wykonania.");
+      info("Dodaj nowe etapy w pipeline/plan.json i uruchom skrypt ponownie.");
+      rl.close();
+      process.exit(0);
+    }
+
+    const stage = getCurrentStage(plan, state);
+    if (!stage) {
+      err(`Nie znaleziono etapu ID=${state.current_stage_id} w plan.json.`);
+      rl.close();
+      process.exit(1);
+    }
+
+    header("NP-Manager Pipeline V2");
+    console.log(`  Etap:  [${stage.id}] ${stage.name}`);
+    console.log(`  Cykl:  ${state.cycle}/${state.max_cycles}`);
+    console.log(`  Tryb:  ${stage.scope || plan.mode || "frontend-only"}`);
+    console.log(`  Czas:  ${timestamp()}`);
+    console.log(`${"─".repeat(60)}`);
+    console.log("  [1] Generuj prompt dla AI (kod)");
+    console.log("  [2] AI skończyło – diff + walidacja + review prompt");
+    console.log("  [3] Wklej decyzję AI (OK / FIX)");
+    console.log("  [4] Pokaż raport etapu");
+    console.log("  [Q] Wyjdź");
+    console.log();
+
+    const choice = (await ask(rl, "  Wybierz opcję: ")).trim().toLowerCase();
+    console.log();
+
+    try {
+      switch (choice) {
+        case "1":
+          await actionGenerateCodePrompt(stage, state, plan);
+          break;
+        case "2":
+          await actionRunValidationAndReview(stage, state, plan, rl);
+          break;
+        case "3":
+          await actionInputDecision(stage, state, rl);
+          break;
+        case "4":
+          await actionShowReport(stage);
+          break;
+        case "q":
+          info("Do zobaczenia!");
+          rl.close();
+          process.exit(0);
+        default:
+          warn("Nieznana opcja. Wpisz 1, 2, 3, 4 lub Q.");
+      }
+    } catch (error) {
+      err(`Błąd w trakcie akcji: ${error.message}`);
+    }
+
+    console.log();
+  }
+}
+
+main().catch((error) => {
+  console.error(`\nBłąd krytyczny pipeline'u: ${error.message}`);
+  process.exit(1);
+});

--- a/pipeline/state.json
+++ b/pipeline/state.json
@@ -1,0 +1,16 @@
+{
+  "current_stage_id": 2,
+  "cycle": 1,
+  "max_cycles": 3,
+  "last_updated": "2026-04-19 00:00:00",
+  "history": [
+    {
+      "stage_id": 1,
+      "cycle": 1,
+      "decision": "OK",
+      "feedback": null,
+      "timestamp": "2026-04-19 00:00:00",
+      "_note": "Etap 1 oznaczony jako historycznie ukończony przed uruchomieniem tej wersji pipeline'u."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Cel: ujednolicić sterowanie pipeline przez scope-based execution oraz dodać globalny backendowy read model dla internal notification attempts.
- Zakres zmian: aktualizacja warstwy `agent/` i `pipeline/`, rejestracja nowego endpointu read-only, rozszerzenie DTO w `packages/shared` oraz testy backendowe dla nowej ścieżki.
- Zmienione obszary: `apps/backend`, `packages/shared`, `agent/*`, `pipeline/*`.

## Testing
- `npx vitest run src/__tests__/app.runtime-routes.test.ts src/modules/porting-requests/__tests__/global-internal-notification-attempts.service.test.ts src/modules/porting-requests/__tests__/internal-notification-attempts.router.test.ts`
- `npm run test -w apps/backend`
- `npm run test -w apps/frontend`
- `npx tsc --noEmit` w `apps/backend`
- `npx tsc --noEmit` w `apps/frontend`
- `npm run build`

## Ryzyka / otwarte punkty
- Nie dodawano migracji Prisma ani zmian w retry/transport adapters.
- Endpoint globalny ma minimalną paginację `limit/offset`; filtry można dodać później, jeśli UI tego wymaga.
- Manualne QA nowego widoku pipeline nie było wykonywane w tej sesji.

## Checklist przed merge
- [x] Testy backendu przechodzą
- [x] Testy frontendowe przechodzą
- [x] Typecheck przechodzi w obu appkach
- [x] Build przechodzi
- [x] Brak zmian poza zakresem funkcjonalnym dla backend/shared/pipeline/agent