### PR TITLE
feat(pr20b): add global internal notification attempts page with retry

### DIFF
--- a/apps/frontend/src/components/layout/AppLayout.test.tsx
+++ b/apps/frontend/src/components/layout/AppLayout.test.tsx
@@ -68,6 +68,7 @@ describe('AppLayout admin navigation', () => {
     expect(html).toContain('Tryb pracy systemu')
     expect(html).not.toContain('capabilities')
     expect(html).toContain('Powiadomienia portingu')
+    expect(html).toContain('Proby notyfikacji')
   })
 
   it('hides Users navigation link for non-admin', () => {

--- a/apps/frontend/src/components/layout/AppLayout.tsx
+++ b/apps/frontend/src/components/layout/AppLayout.tsx
@@ -21,6 +21,13 @@ const primaryNavItems: NavItem[] = [
   { label: 'Zadania', description: 'Praca zespolu', path: ROUTES.TASKS, icon: 'Z' },
   { label: 'Raporty', description: 'Kontrola i wyniki', path: ROUTES.REPORTS, icon: 'R', roles: ['ADMIN', 'MANAGER', 'AUDITOR'] },
   {
+    label: 'Proby notyfikacji',
+    description: 'Ledger dostarczen',
+    path: ROUTES.NOTIFICATION_ATTEMPTS,
+    icon: 'N',
+    roles: ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER'],
+  },
+  {
     label: 'Bledy notyfikacji',
     description: 'Kolejka interwencji',
     path: ROUTES.NOTIFICATION_FAILURES,

--- a/apps/frontend/src/constants/routes.ts
+++ b/apps/frontend/src/constants/routes.ts
@@ -43,6 +43,7 @@ export const ROUTES = {
   ADMIN_COMMUNICATION_TEMPLATE_NEW: '/admin/communication-templates/new',
   ADMIN_COMMUNICATION_TEMPLATE_DETAIL: '/admin/communication-templates/:id',
   ADMIN_COMMUNICATION_TEMPLATE_EDIT: '/admin/communication-templates/:id/edit',
+  NOTIFICATION_ATTEMPTS: '/notifications/attempts',
   NOTIFICATION_FAILURES: '/notifications/failures',
 
   ADMIN_DOCUMENT_TYPES: '/admin/document-types',

--- a/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.test.tsx
+++ b/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalInternalNotificationAttemptItemDto } from '@np-manager/shared'
+
+const { getGlobalInternalNotificationAttemptsMock, retryInternalNotificationAttemptMock } =
+  vi.hoisted(() => ({
+    getGlobalInternalNotificationAttemptsMock: vi.fn(),
+    retryInternalNotificationAttemptMock: vi.fn(),
+  }))
+
+vi.mock('@/services/internalNotificationAttempts.api', () => ({
+  getGlobalInternalNotificationAttempts: (...args: unknown[]) =>
+    getGlobalInternalNotificationAttemptsMock(...args),
+}))
+
+vi.mock('@/services/portingRequests.api', () => ({
+  retryInternalNotificationAttempt: (...args: unknown[]) =>
+    retryInternalNotificationAttemptMock(...args),
+}))
+
+import { InternalNotificationAttemptsPage } from './InternalNotificationAttemptsPage'
+
+function makeAttempt(
+  overrides: Partial<GlobalInternalNotificationAttemptItemDto> = {},
+): GlobalInternalNotificationAttemptItemDto {
+  return {
+    attemptId: 'attempt-1',
+    requestId: 'request-1',
+    caseNumber: 'FNP-20260411-ABC123',
+    eventCode: 'STATUS_CHANGED',
+    eventLabel: 'Zmiana statusu sprawy',
+    attemptOrigin: 'PRIMARY',
+    channel: 'EMAIL',
+    recipient: 'bok@test.pl',
+    mode: 'REAL',
+    outcome: 'FAILED',
+    errorCode: 'SMTP_FAILED',
+    errorMessage: 'SMTP unavailable',
+    failureKind: 'DELIVERY',
+    retryOfAttemptId: null,
+    retryCount: 1,
+    isLatestForChain: true,
+    triggeredByUserId: null,
+    triggeredByDisplayName: null,
+    canRetry: true,
+    retryBlockedReasonCode: null,
+    createdAt: '2026-04-11T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <InternalNotificationAttemptsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('InternalNotificationAttemptsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getGlobalInternalNotificationAttemptsMock.mockResolvedValue({
+      items: [makeAttempt()],
+      total: 1,
+    })
+    retryInternalNotificationAttemptMock.mockResolvedValue({
+      retryAttempt: makeAttempt({ attemptId: 'attempt-retry-1', outcome: 'SENT' }),
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('loads attempts and links each record to canonical request detail', async () => {
+    renderPage()
+
+    const caseLink = await screen.findByRole('link', { name: 'FNP-20260411-ABC123' })
+
+    expect(caseLink.getAttribute('href')).toBe('/requests/FNP-20260411-ABC123')
+    expect(screen.getByText('Zmiana statusu sprawy')).toBeTruthy()
+    expect(screen.getByText('bok@test.pl')).toBeTruthy()
+    expect(screen.getByText('Blad wysylki')).toBeTruthy()
+    expect(screen.getByText('SMTP unavailable')).toBeTruthy()
+    expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenCalledWith({
+      limit: 50,
+      offset: 0,
+    })
+  })
+
+  it('shows loading state', () => {
+    getGlobalInternalNotificationAttemptsMock.mockReturnValueOnce(new Promise(() => {}))
+
+    renderPage()
+
+    expect(screen.getByText('Ladowanie prob notyfikacji...')).toBeTruthy()
+  })
+
+  it('shows empty state when backend returns no attempts', async () => {
+    getGlobalInternalNotificationAttemptsMock.mockResolvedValueOnce({
+      items: [],
+      total: 0,
+    })
+
+    renderPage()
+
+    expect(await screen.findByText('Brak zapisanych prob notyfikacji.')).toBeTruthy()
+  })
+
+  it('shows error state instead of empty state after failed load', async () => {
+    getGlobalInternalNotificationAttemptsMock.mockRejectedValueOnce(new Error('API unavailable'))
+
+    renderPage()
+
+    expect(
+      await screen.findByText('Nie udalo sie pobrac globalnej listy prob notyfikacji.'),
+    ).toBeTruthy()
+    expect(screen.queryByText('Brak zapisanych prob notyfikacji.')).toBeNull()
+  })
+
+  it('keeps pagination read-only and backed by existing offset params', async () => {
+    getGlobalInternalNotificationAttemptsMock.mockResolvedValue({
+      items: [makeAttempt()],
+      total: 120,
+    })
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Nastepna' }))
+
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenCalledWith({
+        limit: 50,
+        offset: 50,
+      })
+    })
+  })
+
+  it('shows retry action only for retryable attempts', async () => {
+    getGlobalInternalNotificationAttemptsMock.mockResolvedValueOnce({
+      items: [
+        makeAttempt({ attemptId: 'attempt-retryable', canRetry: true }),
+        makeAttempt({
+          attemptId: 'attempt-blocked',
+          canRetry: false,
+          retryBlockedReasonCode: 'RETRY_LIMIT_REACHED',
+        }),
+      ],
+      total: 2,
+    })
+
+    renderPage()
+
+    expect(await screen.findByRole('button', { name: 'Ponow' })).toBeTruthy()
+    expect(screen.getByText('Limit ponowien osiagniety.')).toBeTruthy()
+  })
+
+  it('calls retry endpoint, shows row loading and refreshes attempts after success', async () => {
+    let resolveRetry: () => void = () => {}
+    retryInternalNotificationAttemptMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRetry = () =>
+          resolve({
+            retryAttempt: makeAttempt({ attemptId: 'attempt-retry-1', outcome: 'SENT' }),
+          })
+      }),
+    )
+    getGlobalInternalNotificationAttemptsMock
+      .mockResolvedValueOnce({ items: [makeAttempt()], total: 1 })
+      .mockResolvedValueOnce({
+        items: [makeAttempt({ attemptId: 'attempt-retry-1', outcome: 'SENT', retryCount: 2 })],
+        total: 1,
+      })
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponow' }))
+
+    expect(screen.getByRole('button', { name: 'Ponawiam...' }).hasAttribute('disabled')).toBe(true)
+    expect(retryInternalNotificationAttemptMock).toHaveBeenCalledWith('request-1', 'attempt-1')
+
+    resolveRetry()
+
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenCalledTimes(2)
+    })
+    expect(screen.getByText('Ponowienie wykonane: dostarczono.')).toBeTruthy()
+  })
+
+  it('shows retry error feedback without clearing loaded attempts', async () => {
+    retryInternalNotificationAttemptMock.mockRejectedValueOnce(new Error('API unavailable'))
+
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponow' }))
+
+    expect(await screen.findByText('Nie udalo sie ponowic proby dostarczenia.')).toBeTruthy()
+    expect(screen.getByText('Zmiana statusu sprawy')).toBeTruthy()
+    expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.tsx
+++ b/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.tsx
@@ -1,0 +1,360 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import type {
+  GlobalInternalNotificationAttemptItemDto,
+  InternalNotificationAttemptChannelDto,
+  InternalNotificationAttemptOriginDto,
+  InternalNotificationAttemptOutcomeDto,
+  InternalNotificationFailureKindDto,
+} from '@np-manager/shared'
+import { Badge, Button, MetricCard, type BadgeTone } from '@/components/ui'
+import { buildPath, ROUTES } from '@/constants/routes'
+import {
+  getInternalNotificationRetryBlockedReasonLabel,
+  getInternalNotificationRetryErrorMessage,
+  getInternalNotificationRetrySuccessMessage,
+} from '@/lib/internalNotificationRetryMessages'
+import { getGlobalInternalNotificationAttempts } from '@/services/internalNotificationAttempts.api'
+import { retryInternalNotificationAttempt } from '@/services/portingRequests.api'
+
+const PAGE_SIZE = 50
+
+function formatDateTime(value: string): string {
+  return new Date(value).toLocaleString('pl-PL', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function getChannelLabel(channel: InternalNotificationAttemptChannelDto): string {
+  if (channel === 'EMAIL') return 'E-mail'
+  return 'Teams'
+}
+
+function getOriginLabel(origin: InternalNotificationAttemptOriginDto): string {
+  if (origin === 'PRIMARY') return 'Primary'
+  if (origin === 'ERROR_FALLBACK') return 'Error fallback'
+  return 'Retry'
+}
+
+function getOutcomeLabel(outcome: InternalNotificationAttemptOutcomeDto): string {
+  if (outcome === 'SENT') return 'Wyslano'
+  if (outcome === 'STUBBED') return 'Stub'
+  if (outcome === 'DISABLED') return 'Wylaczone'
+  if (outcome === 'MISCONFIGURED') return 'Blad konfiguracji'
+  if (outcome === 'FAILED') return 'Blad wysylki'
+  return 'Pominieto'
+}
+
+function getOutcomeTone(outcome: InternalNotificationAttemptOutcomeDto): BadgeTone {
+  if (outcome === 'FAILED') return 'red'
+  if (outcome === 'MISCONFIGURED') return 'amber'
+  if (outcome === 'SENT' || outcome === 'STUBBED') return 'emerald'
+  return 'neutral'
+}
+
+function getFailureKindLabel(failureKind: InternalNotificationFailureKindDto): string {
+  if (failureKind === 'DELIVERY') return 'Transport'
+  if (failureKind === 'CONFIGURATION') return 'Konfiguracja'
+  if (failureKind === 'POLICY') return 'Polityka'
+  return '-'
+}
+
+function getVisibleRange(offset: number, itemsCount: number, total: number): string {
+  if (total === 0) return 'Brak rekordow'
+  return `${offset + 1}-${offset + itemsCount} z ${total}`
+}
+
+function buildRequestDetailPath(item: GlobalInternalNotificationAttemptItemDto): string {
+  return buildPath(ROUTES.REQUEST_DETAIL, encodeURIComponent(item.caseNumber))
+}
+
+interface AttemptsTableProps {
+  items: GlobalInternalNotificationAttemptItemDto[]
+  isLoading: boolean
+  error: string | null
+  retryingAttemptIds: string[]
+  onRetryAttempt: (item: GlobalInternalNotificationAttemptItemDto) => void
+}
+
+function AttemptsTable({
+  items,
+  isLoading,
+  error,
+  retryingAttemptIds,
+  onRetryAttempt,
+}: AttemptsTableProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-sm text-ink-500">
+        Ladowanie prob notyfikacji...
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="m-4 rounded-ui border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        {error}
+      </div>
+    )
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-14 text-center">
+        <p className="text-sm font-medium text-ink-700">Brak zapisanych prob notyfikacji.</p>
+        <p className="mt-1 text-sm text-ink-500">
+          Globalny ledger nie zawiera jeszcze wykonanych prob transportu.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-line bg-ink-50 text-left text-xs font-semibold uppercase text-ink-500">
+            <th className="px-4 py-3">Sprawa</th>
+            <th className="px-4 py-3">Zdarzenie</th>
+            <th className="px-4 py-3">Odbiorca</th>
+            <th className="px-4 py-3">Kanal</th>
+            <th className="px-4 py-3">Wynik</th>
+            <th className="px-4 py-3">Retry</th>
+            <th className="px-4 py-3">Utworzono</th>
+            <th className="px-4 py-3">Blad</th>
+            <th className="px-4 py-3">Akcja</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-line">
+          {items.map((item) => {
+            const isRetrying = retryingAttemptIds.includes(item.attemptId)
+
+            return (
+              <tr key={item.attemptId} className="bg-surface hover:bg-ink-50/70">
+                <td className="px-4 py-4 align-top">
+                  <Link
+                    to={buildRequestDetailPath(item)}
+                    className="font-mono text-xs font-semibold text-brand-700 hover:underline"
+                  >
+                    {item.caseNumber}
+                  </Link>
+                  <div className="mt-1 text-xs text-ink-400">{item.requestId}</div>
+                </td>
+                <td className="min-w-[220px] px-4 py-4 align-top">
+                  <div className="font-medium text-ink-900">
+                    {item.eventLabel || item.eventCode}
+                  </div>
+                  <div className="mt-1 flex flex-wrap gap-1.5 text-xs text-ink-500">
+                    <span>{item.eventCode}</span>
+                    <span aria-hidden="true">|</span>
+                    <span>{getOriginLabel(item.attemptOrigin)}</span>
+                    <span aria-hidden="true">|</span>
+                    <span>{getFailureKindLabel(item.failureKind)}</span>
+                  </div>
+                </td>
+                <td
+                  className="max-w-[240px] truncate px-4 py-4 align-top text-ink-650"
+                  title={item.recipient}
+                >
+                  {item.recipient}
+                </td>
+                <td className="px-4 py-4 align-top text-ink-650">
+                  {getChannelLabel(item.channel)}
+                </td>
+                <td className="px-4 py-4 align-top">
+                  <Badge tone={getOutcomeTone(item.outcome)}>
+                    {getOutcomeLabel(item.outcome)}
+                  </Badge>
+                </td>
+                <td className="px-4 py-4 align-top text-ink-650">{item.retryCount}</td>
+                <td className="whitespace-nowrap px-4 py-4 align-top text-ink-500">
+                  {formatDateTime(item.createdAt)}
+                </td>
+                <td className="max-w-[280px] px-4 py-4 align-top">
+                  {item.errorMessage ? (
+                    <span
+                      className="line-clamp-2 text-sm text-red-700"
+                      title={item.errorMessage}
+                    >
+                      {item.errorMessage}
+                    </span>
+                  ) : (
+                    <span className="text-ink-400">-</span>
+                  )}
+                </td>
+                <td className="px-4 py-4 align-top">
+                  {item.canRetry ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      disabled={isRetrying}
+                      onClick={() => onRetryAttempt(item)}
+                    >
+                      {isRetrying ? 'Ponawiam...' : 'Ponow'}
+                    </Button>
+                  ) : (
+                    <span className="text-xs text-ink-500">
+                      {getInternalNotificationRetryBlockedReasonLabel(
+                        item.retryBlockedReasonCode,
+                      )}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export function InternalNotificationAttemptsPage() {
+  const [items, setItems] = useState<GlobalInternalNotificationAttemptItemDto[]>([])
+  const [total, setTotal] = useState(0)
+  const [offset, setOffset] = useState(0)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [retryingAttemptIds, setRetryingAttemptIds] = useState<string[]>([])
+  const [retrySuccessMessage, setRetrySuccessMessage] = useState<string | null>(null)
+  const [retryErrorMessage, setRetryErrorMessage] = useState<string | null>(null)
+
+  const loadAttempts = useCallback(async (showLoading = true) => {
+    if (showLoading) {
+      setIsLoading(true)
+    }
+    setError(null)
+
+    try {
+      const result = await getGlobalInternalNotificationAttempts({
+        limit: PAGE_SIZE,
+        offset,
+      })
+      setItems(result.items)
+      setTotal(result.total)
+    } catch {
+      setError('Nie udalo sie pobrac globalnej listy prob notyfikacji.')
+    } finally {
+      if (showLoading) {
+        setIsLoading(false)
+      }
+    }
+  }, [offset])
+
+  useEffect(() => {
+    void loadAttempts()
+  }, [loadAttempts])
+
+  const hasPreviousPage = offset > 0
+  const hasNextPage = offset + PAGE_SIZE < total
+  const currentPage = Math.floor(offset / PAGE_SIZE) + 1
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+
+  async function handleRetryAttempt(item: GlobalInternalNotificationAttemptItemDto) {
+    if (retryingAttemptIds.includes(item.attemptId)) {
+      return
+    }
+
+    setRetryingAttemptIds((current) => [...current, item.attemptId])
+    setRetrySuccessMessage(null)
+    setRetryErrorMessage(null)
+
+    try {
+      const result = await retryInternalNotificationAttempt(item.requestId, item.attemptId)
+      setRetrySuccessMessage(
+        getInternalNotificationRetrySuccessMessage(result.retryAttempt.outcome),
+      )
+      await loadAttempts(false)
+    } catch (errorValue) {
+      setRetryErrorMessage(getInternalNotificationRetryErrorMessage(errorValue))
+    } finally {
+      setRetryingAttemptIds((current) => current.filter((id) => id !== item.attemptId))
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+        <div className="min-w-0">
+          <p className="text-xs font-semibold uppercase text-brand-700">Notyfikacje wewnetrzne</p>
+          <h1 className="mt-1 text-3xl font-semibold text-ink-900">
+            Globalna lista prob dostarczenia
+          </h1>
+          <p className="mt-2 max-w-3xl text-sm leading-6 text-ink-500">
+            Read-only ledger internal notification attempts dla zespolu operacyjnego.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <MetricCard
+          title="Wszystkie proby"
+          value={isLoading ? '--' : total}
+          detail="Liczba rekordow zwrocona przez backend"
+        />
+        <MetricCard
+          title="Na stronie"
+          value={isLoading ? '--' : items.length}
+          detail={isLoading ? 'Ladowanie danych' : getVisibleRange(offset, items.length, total)}
+        />
+        <MetricCard
+          title="Tryb widoku"
+          value="Read-only"
+          detail="Ledger z akcja ponowienia dla uprawnionego operatora"
+        />
+      </div>
+
+      {retrySuccessMessage && (
+        <div className="rounded-ui border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+          {retrySuccessMessage}
+        </div>
+      )}
+
+      {retryErrorMessage && (
+        <div className="rounded-ui border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {retryErrorMessage}
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-panel border border-line bg-surface shadow-soft">
+        <AttemptsTable
+          items={items}
+          isLoading={isLoading}
+          error={error}
+          retryingAttemptIds={retryingAttemptIds}
+          onRetryAttempt={(item) => void handleRetryAttempt(item)}
+        />
+      </div>
+
+      {!isLoading && !error && total > PAGE_SIZE && (
+        <div className="flex items-center justify-between text-sm text-ink-600">
+          <Button
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+            disabled={!hasPreviousPage}
+            size="sm"
+            variant="ghost"
+          >
+            Poprzednia
+          </Button>
+          <span className="text-xs text-ink-500">
+            Strona {currentPage} z {totalPages}
+          </span>
+          <Button
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+            disabled={!hasNextPage}
+            size="sm"
+            variant="ghost"
+          >
+            Nastepna
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -18,6 +18,7 @@ import { AdminUsersPage } from '@/pages/Admin/AdminUsersPage'
 import { SystemModeSettingsPage } from '@/pages/Admin/SystemModeSettingsPage'
 import { PortingNotificationSettingsPage } from '@/pages/Admin/PortingNotificationSettingsPage'
 import { NotificationFallbackSettingsPage } from '@/pages/Admin/NotificationFallbackSettingsPage'
+import { InternalNotificationAttemptsPage } from '@/pages/Notifications/InternalNotificationAttemptsPage'
 import { NotificationFailureQueuePage } from '@/pages/Notifications/NotificationFailureQueuePage'
 import {
   getDefaultAuthenticatedRoute,
@@ -177,6 +178,10 @@ export const router = createBrowserRouter([
       {
         path: ROUTES.REQUEST_DETAIL,
         element: <RequestDetailPage />,
+      },
+      {
+        path: ROUTES.NOTIFICATION_ATTEMPTS,
+        element: <InternalNotificationAttemptsPage />,
       },
       {
         path: ROUTES.NOTIFICATION_FAILURES,

--- a/apps/frontend/src/services/internalNotificationAttempts.api.test.ts
+++ b/apps/frontend/src/services/internalNotificationAttempts.api.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+}))
+
+vi.mock('./api.client', () => ({
+  apiClient: {
+    get: (...args: unknown[]) => getMock(...args),
+  },
+}))
+
+import { getGlobalInternalNotificationAttempts } from './internalNotificationAttempts.api'
+
+describe('internalNotificationAttempts.api', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getMock.mockResolvedValue({ data: { data: { items: [], total: 0 } } })
+  })
+
+  it('loads global internal notification attempts without query params by default', async () => {
+    const result = await getGlobalInternalNotificationAttempts()
+
+    expect(getMock).toHaveBeenCalledWith('/internal-notification-attempts')
+    expect(result).toEqual({ items: [], total: 0 })
+  })
+
+  it('adds existing paging params when provided', async () => {
+    await getGlobalInternalNotificationAttempts({ limit: 50, offset: 100 })
+
+    expect(getMock).toHaveBeenCalledWith('/internal-notification-attempts?limit=50&offset=100')
+  })
+
+  it('keeps offset=0 in the query string when provided explicitly', async () => {
+    await getGlobalInternalNotificationAttempts({ limit: 50, offset: 0 })
+
+    expect(getMock).toHaveBeenCalledWith('/internal-notification-attempts?limit=50&offset=0')
+  })
+})

--- a/apps/frontend/src/services/internalNotificationAttempts.api.ts
+++ b/apps/frontend/src/services/internalNotificationAttempts.api.ts
@@ -1,0 +1,23 @@
+import type { GlobalInternalNotificationAttemptsResultDto } from '@np-manager/shared'
+import { apiClient } from './api.client'
+
+export interface GetGlobalInternalNotificationAttemptsParams {
+  limit?: number
+  offset?: number
+}
+
+export async function getGlobalInternalNotificationAttempts(
+  params: GetGlobalInternalNotificationAttemptsParams = {},
+): Promise<GlobalInternalNotificationAttemptsResultDto> {
+  const query = new URLSearchParams()
+  if (params.limit) query.set('limit', String(params.limit))
+  if (params.offset !== undefined) query.set('offset', String(params.offset))
+
+  const suffix = query.toString()
+  const response = await apiClient.get<{
+    success: true
+    data: GlobalInternalNotificationAttemptsResultDto
+  }>(suffix ? `/internal-notification-attempts?${suffix}` : '/internal-notification-attempts')
+
+  return response.data.data
+}


### PR DESCRIPTION
## Zakres
Frontendowy widok globalnej listy internal notification attempts z retry z poziomu tabeli.

## Co wchodzi
- nowa strona `/notifications/attempts`
- API client dla `GET /api/internal-notification-attempts`
- tabela attempts
- stany loading / empty / error
- link do canonical detail route `/requests/:caseNumber`
- prosta paginacja oparta o istniejące `limit/offset`
- retry action z poziomu globalnej listy
- per-row loading state
- success / error feedback
- refresh listy po sukcesie
- testy API i strony

## Założenia architektoniczne
- frontend only
- brak zmian backend/shared/prisma
- backend pozostaje source of truth dla `canRetry` i `retryBlockedReasonCode`
- retry używa istniejącego endpointu i istniejących helperów komunikatów
- brak bulk retry
- brak nowych filtrów backendowych
- brak nowych zależności

## Follow-up poza zakresem
- ewentualne dopracowanie copy nagłówka strony
- filtry operacyjne po outcome/channel
- dalsza paginacja / cursor pagination przy większej skali