### PR TITLE
feat(pr20d): frontend filters for /notifications/attempts

### DIFF
--- a/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.test.tsx
+++ b/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { GlobalInternalNotificationAttemptItemDto } from '@np-manager/shared'
@@ -81,10 +81,11 @@ describe('InternalNotificationAttemptsPage', () => {
     const caseLink = await screen.findByRole('link', { name: 'FNP-20260411-ABC123' })
 
     expect(caseLink.getAttribute('href')).toBe('/requests/FNP-20260411-ABC123')
-    expect(screen.getByText('Zmiana statusu sprawy')).toBeTruthy()
-    expect(screen.getByText('bok@test.pl')).toBeTruthy()
-    expect(screen.getByText('Blad wysylki')).toBeTruthy()
-    expect(screen.getByText('SMTP unavailable')).toBeTruthy()
+    const table = screen.getByRole('table')
+    expect(within(table).getByText('Zmiana statusu sprawy')).toBeTruthy()
+    expect(within(table).getByText('bok@test.pl')).toBeTruthy()
+    expect(within(table).getByText('Blad wysylki')).toBeTruthy()
+    expect(within(table).getByText('SMTP unavailable')).toBeTruthy()
     expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenCalledWith({
       limit: 50,
       offset: 0,
@@ -188,6 +189,130 @@ describe('InternalNotificationAttemptsPage', () => {
       expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenCalledTimes(2)
     })
     expect(screen.getByText('Ponowienie wykonane: dostarczono.')).toBeTruthy()
+  })
+
+  it('sends outcome, channel and retryableOnly filters and resets offset to 0', async () => {
+    getGlobalInternalNotificationAttemptsMock.mockResolvedValue({
+      items: [makeAttempt()],
+      total: 120,
+    })
+
+    renderPage()
+
+    // first page initial call
+    await screen.findByRole('link', { name: 'FNP-20260411-ABC123' })
+
+    // navigate to second page
+    fireEvent.click(screen.getByRole('button', { name: 'Nastepna' }))
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
+        limit: 50,
+        offset: 50,
+        outcome: undefined,
+        channel: undefined,
+        retryableOnly: undefined,
+      })
+    })
+
+    // change outcome filter -> offset resets and filter is sent
+    fireEvent.change(screen.getByLabelText('Filtr wynik'), { target: { value: 'FAILED' } })
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
+        limit: 50,
+        offset: 0,
+        outcome: 'FAILED',
+        channel: undefined,
+        retryableOnly: undefined,
+      })
+    })
+
+    // change channel filter
+    fireEvent.change(screen.getByLabelText('Filtr kanal'), { target: { value: 'TEAMS' } })
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
+        limit: 50,
+        offset: 0,
+        outcome: 'FAILED',
+        channel: 'TEAMS',
+        retryableOnly: undefined,
+      })
+    })
+
+    // toggle retryableOnly
+    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko mozliwe do ponowienia/ }))
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
+        limit: 50,
+        offset: 0,
+        outcome: 'FAILED',
+        channel: 'TEAMS',
+        retryableOnly: true,
+      })
+    })
+  })
+
+  it('clears all filters via the reset button', async () => {
+    getGlobalInternalNotificationAttemptsMock.mockResolvedValue({
+      items: [makeAttempt()],
+      total: 1,
+    })
+
+    renderPage()
+    await screen.findByRole('link', { name: 'FNP-20260411-ABC123' })
+
+    fireEvent.change(screen.getByLabelText('Filtr wynik'), { target: { value: 'FAILED' } })
+    fireEvent.change(screen.getByLabelText('Filtr kanal'), { target: { value: 'EMAIL' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko mozliwe do ponowienia/ }))
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Wyczysc filtry' }))
+
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
+        limit: 50,
+        offset: 0,
+        outcome: undefined,
+        channel: undefined,
+        retryableOnly: undefined,
+      })
+    })
+
+    expect(screen.queryByRole('button', { name: 'Wyczysc filtry' })).toBeNull()
+  })
+
+  it('retry reloads data using currently active filters', async () => {
+    getGlobalInternalNotificationAttemptsMock.mockResolvedValue({
+      items: [makeAttempt()],
+      total: 1,
+    })
+
+    renderPage()
+    await screen.findByRole('link', { name: 'FNP-20260411-ABC123' })
+
+    fireEvent.change(screen.getByLabelText('Filtr wynik'), { target: { value: 'FAILED' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko mozliwe do ponowienia/ }))
+
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
+        limit: 50,
+        offset: 0,
+        outcome: 'FAILED',
+        channel: undefined,
+        retryableOnly: true,
+      })
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponow' }))
+
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
+        limit: 50,
+        offset: 0,
+        outcome: 'FAILED',
+        channel: undefined,
+        retryableOnly: true,
+      })
+    })
+    expect(retryInternalNotificationAttemptMock).toHaveBeenCalledWith('request-1', 'attempt-1')
   })
 
   it('shows retry error feedback without clearing loaded attempts', async () => {

--- a/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.test.tsx
+++ b/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.test.tsx
@@ -315,6 +315,65 @@ describe('InternalNotificationAttemptsPage', () => {
     expect(retryInternalNotificationAttemptMock).toHaveBeenCalledWith('request-1', 'attempt-1')
   })
 
+  it('clamps offset to last valid page when retryableOnly refresh shrinks total', async () => {
+    const pageTwoItem = makeAttempt({ attemptId: 'attempt-page-2' })
+
+    // initial page-1 load (will be triggered twice: first mount, then after clamp)
+    getGlobalInternalNotificationAttemptsMock
+      // mount (offset=0, no filters)
+      .mockResolvedValueOnce({ items: [makeAttempt()], total: 51 })
+      // after toggling retryableOnly -> offset=0, retryableOnly=true
+      .mockResolvedValueOnce({ items: [makeAttempt()], total: 51 })
+      // after clicking Nastepna -> offset=50, retryableOnly=true (only 1 retryable left)
+      .mockResolvedValueOnce({ items: [pageTwoItem], total: 51 })
+      // retry success refresh -> offset=50 but total shrank to 50 -> empty, triggers clamp
+      .mockResolvedValueOnce({ items: [], total: 50 })
+      // clamp-triggered refetch at offset=0
+      .mockResolvedValueOnce({ items: [makeAttempt()], total: 50 })
+
+    retryInternalNotificationAttemptMock.mockResolvedValueOnce({
+      retryAttempt: makeAttempt({ attemptId: 'attempt-retry-page-2', outcome: 'SENT' }),
+    })
+
+    renderPage()
+
+    await screen.findByRole('link', { name: 'FNP-20260411-ABC123' })
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko mozliwe do ponowienia/ }))
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
+        limit: 50,
+        offset: 0,
+        outcome: undefined,
+        channel: undefined,
+        retryableOnly: true,
+      })
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Nastepna' }))
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
+        limit: 50,
+        offset: 50,
+        outcome: undefined,
+        channel: undefined,
+        retryableOnly: true,
+      })
+    })
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponow' }))
+
+    await waitFor(() => {
+      expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
+        limit: 50,
+        offset: 0,
+        outcome: undefined,
+        channel: undefined,
+        retryableOnly: true,
+      })
+    })
+  })
+
   it('shows retry error feedback without clearing loaded attempts', async () => {
     retryInternalNotificationAttemptMock.mockRejectedValueOnce(new Error('API unavailable'))
 

--- a/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.tsx
+++ b/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.tsx
@@ -215,10 +215,24 @@ function AttemptsTable({
   )
 }
 
+const OUTCOME_FILTER_OPTIONS: InternalNotificationAttemptOutcomeDto[] = [
+  'SENT',
+  'STUBBED',
+  'DISABLED',
+  'MISCONFIGURED',
+  'FAILED',
+  'SKIPPED',
+]
+
+const CHANNEL_FILTER_OPTIONS: InternalNotificationAttemptChannelDto[] = ['EMAIL', 'TEAMS']
+
 export function InternalNotificationAttemptsPage() {
   const [items, setItems] = useState<GlobalInternalNotificationAttemptItemDto[]>([])
   const [total, setTotal] = useState(0)
   const [offset, setOffset] = useState(0)
+  const [outcomeFilter, setOutcomeFilter] = useState<InternalNotificationAttemptOutcomeDto | ''>('')
+  const [channelFilter, setChannelFilter] = useState<InternalNotificationAttemptChannelDto | ''>('')
+  const [retryableOnly, setRetryableOnly] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [retryingAttemptIds, setRetryingAttemptIds] = useState<string[]>([])
@@ -235,6 +249,9 @@ export function InternalNotificationAttemptsPage() {
       const result = await getGlobalInternalNotificationAttempts({
         limit: PAGE_SIZE,
         offset,
+        outcome: outcomeFilter || undefined,
+        channel: channelFilter || undefined,
+        retryableOnly: retryableOnly || undefined,
       })
       setItems(result.items)
       setTotal(result.total)
@@ -245,7 +262,7 @@ export function InternalNotificationAttemptsPage() {
         setIsLoading(false)
       }
     }
-  }, [offset])
+  }, [offset, outcomeFilter, channelFilter, retryableOnly])
 
   useEffect(() => {
     void loadAttempts()
@@ -255,6 +272,29 @@ export function InternalNotificationAttemptsPage() {
   const hasNextPage = offset + PAGE_SIZE < total
   const currentPage = Math.floor(offset / PAGE_SIZE) + 1
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE))
+  const hasActiveFilters = outcomeFilter !== '' || channelFilter !== '' || retryableOnly
+
+  function handleOutcomeChange(value: string) {
+    setOutcomeFilter((value as InternalNotificationAttemptOutcomeDto | '') ?? '')
+    setOffset(0)
+  }
+
+  function handleChannelChange(value: string) {
+    setChannelFilter((value as InternalNotificationAttemptChannelDto | '') ?? '')
+    setOffset(0)
+  }
+
+  function handleRetryableOnlyChange(value: boolean) {
+    setRetryableOnly(value)
+    setOffset(0)
+  }
+
+  function handleClearFilters() {
+    setOutcomeFilter('')
+    setChannelFilter('')
+    setRetryableOnly(false)
+    setOffset(0)
+  }
 
   async function handleRetryAttempt(item: GlobalInternalNotificationAttemptItemDto) {
     if (retryingAttemptIds.includes(item.attemptId)) {
@@ -308,6 +348,66 @@ export function InternalNotificationAttemptsPage() {
           value="Read-only"
           detail="Ledger z akcja ponowienia dla uprawnionego operatora"
         />
+      </div>
+
+      <div className="rounded-panel border border-line bg-surface p-4 shadow-soft">
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="flex flex-col gap-1 text-xs font-semibold uppercase text-ink-500">
+            Wynik
+            <select
+              value={outcomeFilter}
+              onChange={(event) => handleOutcomeChange(event.target.value)}
+              className="input-field h-10 min-w-[180px]"
+              aria-label="Filtr wynik"
+            >
+              <option value="">Wszystkie wyniki</option>
+              {OUTCOME_FILTER_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {getOutcomeLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-xs font-semibold uppercase text-ink-500">
+            Kanal
+            <select
+              value={channelFilter}
+              onChange={(event) => handleChannelChange(event.target.value)}
+              className="input-field h-10 min-w-[160px]"
+              aria-label="Filtr kanal"
+            >
+              <option value="">Wszystkie kanaly</option>
+              {CHANNEL_FILTER_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {getChannelLabel(value)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="flex h-10 items-center gap-2 pb-0 text-sm text-ink-700">
+            <input
+              type="checkbox"
+              className="h-4 w-4 rounded border-line text-brand-600 focus:ring-brand-500"
+              checked={retryableOnly}
+              onChange={(event) => handleRetryableOnlyChange(event.target.checked)}
+            />
+            Tylko mozliwe do ponowienia
+          </label>
+
+          {hasActiveFilters && (
+            <Button
+              type="button"
+              onClick={handleClearFilters}
+              variant="ghost"
+              size="sm"
+              className="h-10"
+            >
+              Wyczysc filtry
+            </Button>
+          )}
+        </div>
       </div>
 
       {retrySuccessMessage && (

--- a/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.tsx
+++ b/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.tsx
@@ -255,6 +255,11 @@ export function InternalNotificationAttemptsPage() {
       })
       setItems(result.items)
       setTotal(result.total)
+      if (offset > 0 && offset >= result.total) {
+        const lastPageOffset =
+          Math.max(0, Math.ceil(result.total / PAGE_SIZE) - 1) * PAGE_SIZE
+        setOffset(lastPageOffset)
+      }
     } catch {
       setError('Nie udalo sie pobrac globalnej listy prob notyfikacji.')
     } finally {

--- a/apps/frontend/src/services/internalNotificationAttempts.api.test.ts
+++ b/apps/frontend/src/services/internalNotificationAttempts.api.test.ts
@@ -36,4 +36,39 @@ describe('internalNotificationAttempts.api', () => {
 
     expect(getMock).toHaveBeenCalledWith('/internal-notification-attempts?limit=50&offset=0')
   })
+
+  it('adds outcome, channel and retryableOnly query params when provided', async () => {
+    await getGlobalInternalNotificationAttempts({
+      limit: 50,
+      offset: 0,
+      outcome: 'FAILED',
+      channel: 'EMAIL',
+      retryableOnly: true,
+    })
+
+    expect(getMock).toHaveBeenCalledWith(
+      '/internal-notification-attempts?limit=50&offset=0&outcome=FAILED&channel=EMAIL&retryableOnly=true',
+    )
+  })
+
+  it('omits retryableOnly param when false', async () => {
+    await getGlobalInternalNotificationAttempts({
+      limit: 50,
+      offset: 0,
+      retryableOnly: false,
+    })
+
+    expect(getMock).toHaveBeenCalledWith('/internal-notification-attempts?limit=50&offset=0')
+  })
+
+  it('omits filter params when outcome or channel are undefined', async () => {
+    await getGlobalInternalNotificationAttempts({
+      limit: 50,
+      offset: 0,
+      outcome: undefined,
+      channel: undefined,
+    })
+
+    expect(getMock).toHaveBeenCalledWith('/internal-notification-attempts?limit=50&offset=0')
+  })
 })

--- a/apps/frontend/src/services/internalNotificationAttempts.api.ts
+++ b/apps/frontend/src/services/internalNotificationAttempts.api.ts
@@ -1,9 +1,16 @@
-import type { GlobalInternalNotificationAttemptsResultDto } from '@np-manager/shared'
+import type {
+  GlobalInternalNotificationAttemptsResultDto,
+  InternalNotificationAttemptChannelDto,
+  InternalNotificationAttemptOutcomeDto,
+} from '@np-manager/shared'
 import { apiClient } from './api.client'
 
 export interface GetGlobalInternalNotificationAttemptsParams {
   limit?: number
   offset?: number
+  outcome?: InternalNotificationAttemptOutcomeDto
+  channel?: InternalNotificationAttemptChannelDto
+  retryableOnly?: boolean
 }
 
 export async function getGlobalInternalNotificationAttempts(
@@ -12,6 +19,9 @@ export async function getGlobalInternalNotificationAttempts(
   const query = new URLSearchParams()
   if (params.limit) query.set('limit', String(params.limit))
   if (params.offset !== undefined) query.set('offset', String(params.offset))
+  if (params.outcome) query.set('outcome', params.outcome)
+  if (params.channel) query.set('channel', params.channel)
+  if (params.retryableOnly) query.set('retryableOnly', 'true')
 
   const suffix = query.toString()
   const response = await apiClient.get<{


### PR DESCRIPTION
## Summary
- Dodaje operacyjne kontrolki filtrowania na stronie `/notifications/attempts`: select `outcome`, select `channel`, checkbox `retryableOnly` oraz przycisk `Wyczysc filtry` (widoczny tylko gdy filtr aktywny).
- Filtry spięte z istniejącym API `GET /api/internal-notification-attempts` z PR20C — puste wartości nie trafiają do query string, `retryableOnly=false` nie jest wysyłane.
- Zmiana dowolnego filtra resetuje paginację do offset=0; retry po sukcesie przeładowuje listę z aktualnie ustawionymi filtrami (dzięki `useCallback` deps na filtrach).

## Scope
Frontend-only. Bez zmian w `apps/backend/**`, `packages/shared/**`, `prisma/**`, `package.json`, lockfile. Bez nowych zależności.

Zmienione pliki:
- `apps/frontend/src/services/internalNotificationAttempts.api.ts`
- `apps/frontend/src/services/internalNotificationAttempts.api.test.ts`
- `apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.tsx`
- `apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.test.tsx`

## Test plan
- [x] `cd apps/frontend && npx tsc --noEmit` — brak błędów
- [x] `cd apps/frontend && npx vitest run` — 210/210 testów przechodzi (w tym 6 testów API client i 11 testów strony, z nowymi testami dla filtrów, resetu i retry z aktywnymi filtrami)
- [ ] Manualne kliknięcie filtrów w UI z backendem na :3001 i zalogowanym operatorem — nieprzeprowadzone w worktree (brak backendu + seed), kod jest pokryty unit testami

🤖 Generated with [Claude Code](https://claude.com/claude-code)