### PR TITLE
feat(request-detail): panel "Co dalej ze sprawa?" w RequestDetailPage

### DIFF
--- a/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.test.tsx
+++ b/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.test.tsx
@@ -1,0 +1,217 @@
+import { isValidElement, type ReactElement, type ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  NotificationHealthDiagnosticsDto,
+  PortingCaseStatus,
+  PortingRequestAssigneeSummaryDto,
+  PortingRequestCommunicationActionDto,
+  PortingRequestStatusActionDto,
+} from '@np-manager/shared'
+import { WhatsNextPanel, type WhatsNextPanelProps } from './WhatsNextPanel'
+
+function collectElements(node: ReactNode): ReactElement[] {
+  const elements: ReactElement[] = []
+  const visit = (value: ReactNode) => {
+    if (Array.isArray(value)) {
+      value.forEach(visit)
+      return
+    }
+    if (!isValidElement(value)) return
+    elements.push(value)
+    visit((value.props as { children?: ReactNode }).children)
+  }
+  visit(node)
+  return elements
+}
+
+function getTextContent(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(getTextContent).join('')
+  if (!isValidElement(node)) return ''
+  return getTextContent((node.props as { children?: ReactNode }).children)
+}
+
+function findAllButtons(tree: ReactNode): ReactElement[] {
+  return collectElements(tree).filter((el) => el.type === 'button')
+}
+
+function findByTestId(tree: ReactNode, testId: string): ReactElement | undefined {
+  return collectElements(tree).find(
+    (el) => (el.props as { 'data-testid'?: string })['data-testid'] === testId,
+  )
+}
+
+const HEALTHY_NOTIFICATIONS: NotificationHealthDiagnosticsDto = {
+  status: 'OK',
+  failureCount: 0,
+  failedCount: 0,
+  misconfiguredCount: 0,
+  lastFailureAt: null,
+  lastFailureOutcome: null,
+}
+
+const ASSIGNEE: PortingRequestAssigneeSummaryDto = {
+  id: 'u1',
+  email: 'a@x',
+  displayName: 'Anna BOK',
+  role: 'BOK_CONSULTANT',
+}
+
+const STATUS_ACTION: PortingRequestStatusActionDto = {
+  actionId: 'CONFIRM',
+  label: 'Potwierdź portowanie',
+  targetStatus: 'CONFIRMED',
+  requiresReason: false,
+  requiresComment: false,
+  reasonLabel: null,
+  commentLabel: null,
+  description: 'Potwierdza sprawę.',
+}
+
+const COMM_ACTION: PortingRequestCommunicationActionDto = {
+  type: 'CLIENT_CONFIRMATION',
+  label: 'Wyślij notyfikację',
+  description: 'Notyfikacja do klienta.',
+  canPreview: true,
+  canCreateDraft: true,
+  canMarkSent: false,
+  disabled: false,
+  disabledReason: null,
+  existingDraftId: null,
+  existingDraftInfo: null,
+  allowsMultipleDrafts: false,
+}
+
+function makeProps(overrides: Partial<WhatsNextPanelProps> = {}): WhatsNextPanelProps {
+  return {
+    status: 'SUBMITTED',
+    availableStatusActions: [STATUS_ACTION],
+    availableCommunicationActions: [],
+    assignedUser: ASSIGNEE,
+    notificationHealth: HEALTHY_NOTIFICATIONS,
+    canManageStatus: true,
+    canManageAssignment: true,
+    onScrollToStatusActions: vi.fn(),
+    onScrollToCommunication: vi.fn(),
+    onScrollToAssignment: vi.fn(),
+    onScrollToNotifications: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe('WhatsNextPanel', () => {
+  it('renders header, current state in plain language, and next step', () => {
+    const tree = WhatsNextPanel(makeProps({ status: 'SUBMITTED' }))
+    const text = getTextContent(tree)
+    expect(text).toContain('Co dalej ze sprawą?')
+    expect(text).toContain('Sprawa: Złożona')
+    expect(text).toContain('Najbliższy krok')
+    expect(text).toContain('potwierdź')
+  })
+
+  it('shows prioritized status action as primary button, wires scroll callback', () => {
+    const onScrollToStatusActions = vi.fn()
+    const tree = WhatsNextPanel(
+      makeProps({ onScrollToStatusActions, availableCommunicationActions: [COMM_ACTION] }),
+    )
+    const buttons = findAllButtons(tree)
+    const statusButton = buttons.find((b) =>
+      getTextContent((b.props as { children?: ReactNode }).children).includes(
+        'Potwierdź portowanie',
+      ),
+    )
+    expect(statusButton).toBeDefined()
+    expect((statusButton!.props as { className?: string }).className).toContain('btn-primary')
+    ;(statusButton!.props as { onClick?: () => void }).onClick?.()
+    expect(onScrollToStatusActions).toHaveBeenCalledTimes(1)
+  })
+
+  it('offers a communication action when status actions are absent', () => {
+    const onScrollToCommunication = vi.fn()
+    const tree = WhatsNextPanel(
+      makeProps({
+        availableStatusActions: [],
+        availableCommunicationActions: [COMM_ACTION],
+        onScrollToCommunication,
+      }),
+    )
+    const buttons = findAllButtons(tree)
+    const commButton = buttons.find((b) =>
+      getTextContent((b.props as { children?: ReactNode }).children).includes(
+        'Wyślij notyfikację',
+      ),
+    )
+    expect(commButton).toBeDefined()
+    ;(commButton!.props as { onClick?: () => void }).onClick?.()
+    expect(onScrollToCommunication).toHaveBeenCalledTimes(1)
+  })
+
+  it('filters out disabled communication actions', () => {
+    const tree = WhatsNextPanel(
+      makeProps({
+        availableStatusActions: [],
+        availableCommunicationActions: [
+          { ...COMM_ACTION, disabled: true, disabledReason: 'Brak uprawnień' },
+        ],
+      }),
+    )
+    const actionsBox = findByTestId(tree, 'whats-next-actions')
+    expect(actionsBox).toBeUndefined()
+  })
+
+  it('shows assignment blocker when request is unassigned', () => {
+    const onScrollToAssignment = vi.fn()
+    const tree = WhatsNextPanel(
+      makeProps({ assignedUser: null, onScrollToAssignment }),
+    )
+    const blocker = findByTestId(tree, 'whats-next-blocker')
+    expect(blocker).toBeDefined()
+    expect(getTextContent(blocker)).toContain('nie ma przypisanego operatora BOK')
+    const blockerButton = findAllButtons(blocker).find((b) =>
+      getTextContent((b.props as { children?: ReactNode }).children).includes(
+        'Przypisz operatora',
+      ),
+    )
+    expect(blockerButton).toBeDefined()
+    ;(blockerButton!.props as { onClick?: () => void }).onClick?.()
+    expect(onScrollToAssignment).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows notification blocker when health is degraded', () => {
+    const tree = WhatsNextPanel(
+      makeProps({
+        notificationHealth: {
+          status: 'FAILED',
+          failureCount: 2,
+          failedCount: 2,
+          misconfiguredCount: 0,
+          lastFailureAt: '2026-04-20T10:00:00Z',
+          lastFailureOutcome: 'FAILED',
+        },
+      }),
+    )
+    const blocker = findByTestId(tree, 'whats-next-blocker')
+    expect(blocker).toBeDefined()
+    expect(getTextContent(blocker)).toContain('notyfikacji')
+  })
+
+  it('hides next step and actions for terminal statuses', () => {
+    const tree = WhatsNextPanel(
+      makeProps({ status: 'PORTED' as PortingCaseStatus, availableStatusActions: [] }),
+    )
+    const text = getTextContent(tree)
+    expect(text).toContain('Numer został przeniesiony')
+    expect(text).not.toContain('Najbliższy krok')
+    expect(findByTestId(tree, 'whats-next-actions')).toBeUndefined()
+    expect(findByTestId(tree, 'whats-next-blocker')).toBeUndefined()
+  })
+
+  it('shows view-only note when user cannot manage status', () => {
+    const tree = WhatsNextPanel(
+      makeProps({ canManageStatus: false, availableStatusActions: [] }),
+    )
+    const blocker = findByTestId(tree, 'whats-next-blocker')
+    expect(blocker).toBeDefined()
+    expect(getTextContent(blocker)).toContain('podgląd')
+  })
+})

--- a/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.test.tsx
+++ b/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.test.tsx
@@ -214,4 +214,33 @@ describe('WhatsNextPanel', () => {
     expect(blocker).toBeDefined()
     expect(getTextContent(blocker)).toContain('podgląd')
   })
+
+  it('does not attribute missing ERROR actions to user role', () => {
+    // Backend workflow defines no transitions from ERROR for any role, so the
+    // panel must not mislead operators into thinking it is a permissions gap.
+    const tree = WhatsNextPanel(
+      makeProps({
+        status: 'ERROR' as PortingCaseStatus,
+        availableStatusActions: [],
+        canManageStatus: true,
+      }),
+    )
+    const blocker = findByTestId(tree, 'whats-next-blocker')
+    expect(blocker).toBeUndefined()
+    const text = getTextContent(tree)
+    expect(text).not.toContain('dla Twojej roli')
+    expect(text).toContain('błędu')
+  })
+
+  it('does not show role-gap blocker while waiting on donor', () => {
+    const tree = WhatsNextPanel(
+      makeProps({
+        status: 'PENDING_DONOR' as PortingCaseStatus,
+        availableStatusActions: [],
+        canManageStatus: true,
+      }),
+    )
+    const blocker = findByTestId(tree, 'whats-next-blocker')
+    expect(blocker).toBeUndefined()
+  })
 })

--- a/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx
+++ b/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx
@@ -1,0 +1,322 @@
+import type {
+  NotificationHealthDiagnosticsDto,
+  PortingCaseStatus,
+  PortingRequestAssigneeSummaryDto,
+  PortingRequestCommunicationActionDto,
+  PortingRequestStatusActionDto,
+} from '@np-manager/shared'
+import { cx } from '@/components/ui'
+import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
+
+export interface WhatsNextPanelProps {
+  status: PortingCaseStatus
+  availableStatusActions: PortingRequestStatusActionDto[]
+  availableCommunicationActions: PortingRequestCommunicationActionDto[]
+  assignedUser: PortingRequestAssigneeSummaryDto | null
+  notificationHealth: NotificationHealthDiagnosticsDto
+  canManageStatus: boolean
+  canManageAssignment: boolean
+  onScrollToStatusActions: () => void
+  onScrollToCommunication: () => void
+  onScrollToAssignment: () => void
+  onScrollToNotifications: () => void
+}
+
+type PanelTone = 'success' | 'danger' | 'warning' | 'info' | 'neutral'
+
+interface PrimaryAction {
+  key: string
+  label: string
+  tone: 'primary' | 'secondary'
+  onClick: () => void
+}
+
+const TERMINAL_STATUSES: PortingCaseStatus[] = ['REJECTED', 'CANCELLED', 'PORTED']
+
+const TERMINAL_COPY: Partial<Record<PortingCaseStatus, { headline: string; body: string }>> = {
+  PORTED: {
+    headline: 'Numer został przeniesiony.',
+    body: 'Sprawa zakończona pomyślnie — żadne dalsze kroki nie są wymagane.',
+  },
+  REJECTED: {
+    headline: 'Sprawa została odrzucona.',
+    body: 'Żadne akcje nie są dostępne. Jeśli potrzebujesz kontynuować, utwórz nową sprawę.',
+  },
+  CANCELLED: {
+    headline: 'Sprawa została anulowana.',
+    body: 'Żadne akcje nie są dostępne.',
+  },
+}
+
+const STATUS_SUMMARY: Record<PortingCaseStatus, string> = {
+  DRAFT: 'Sprawa jest w przygotowaniu — zanim ruszy dalej, trzeba ją złożyć.',
+  SUBMITTED: 'Sprawa czeka na weryfikację przez obsługę.',
+  PENDING_DONOR: 'Sprawa czeka na odpowiedź operatora oddającego.',
+  CONFIRMED: 'Sprawa jest potwierdzona — czeka na dzień przeniesienia.',
+  REJECTED: 'Sprawa odrzucona.',
+  CANCELLED: 'Sprawa anulowana.',
+  PORTED: 'Numer został przeniesiony.',
+  ERROR: 'Sprawa jest w stanie błędu — wymaga interwencji.',
+}
+
+const NEXT_STEP_COPY: Partial<Record<PortingCaseStatus, string>> = {
+  DRAFT: 'Złóż sprawę, aby przekazać ją do dalszej obsługi, lub anuluj szkic.',
+  SUBMITTED: 'Zweryfikuj dane i przekaż sprawę do dawcy, potwierdź lub odrzuć.',
+  PENDING_DONOR:
+    'Poczekaj na odpowiedź dawcy. Gdy nadejdzie — potwierdź termin lub odrzuć sprawę.',
+  CONFIRMED: 'Po realizacji portowania oznacz sprawę jako przeniesioną.',
+  ERROR: 'Sprawdź przyczynę błędu i wybierz dalsze działanie lub skontaktuj się z przełożonym.',
+}
+
+const TONE_STYLES: Record<PanelTone, string> = {
+  success: 'border-emerald-200 bg-emerald-50',
+  danger: 'border-red-200 bg-red-50',
+  warning: 'border-amber-200 bg-amber-50',
+  info: 'border-brand-200 bg-brand-50',
+  neutral: 'border-line bg-surface',
+}
+
+const TONE_LABEL_STYLES: Record<PanelTone, string> = {
+  success: 'text-emerald-700',
+  danger: 'text-red-700',
+  warning: 'text-amber-700',
+  info: 'text-brand-700',
+  neutral: 'text-ink-500',
+}
+
+const TONE_HEADLINE_STYLES: Record<PanelTone, string> = {
+  success: 'text-emerald-900',
+  danger: 'text-red-900',
+  warning: 'text-amber-900',
+  info: 'text-ink-900',
+  neutral: 'text-ink-900',
+}
+
+const TONE_BODY_STYLES: Record<PanelTone, string> = {
+  success: 'text-emerald-800',
+  danger: 'text-red-800',
+  warning: 'text-amber-800',
+  info: 'text-ink-700',
+  neutral: 'text-ink-600',
+}
+
+function pickTone(status: PortingCaseStatus, hasBlocker: boolean): PanelTone {
+  if (status === 'PORTED') return 'success'
+  if (status === 'ERROR' || status === 'REJECTED') return 'danger'
+  if (status === 'CANCELLED') return 'neutral'
+  if (hasBlocker) return 'warning'
+  return 'info'
+}
+
+function buildPrimaryActions({
+  statusActions,
+  communicationActions,
+  canManageStatus,
+  onScrollToStatusActions,
+  onScrollToCommunication,
+}: {
+  statusActions: PortingRequestStatusActionDto[]
+  communicationActions: PortingRequestCommunicationActionDto[]
+  canManageStatus: boolean
+  onScrollToStatusActions: () => void
+  onScrollToCommunication: () => void
+}): PrimaryAction[] {
+  const actions: PrimaryAction[] = []
+
+  if (canManageStatus) {
+    for (const action of statusActions.slice(0, 2)) {
+      actions.push({
+        key: `status-${action.actionId}-${action.targetStatus}`,
+        label: action.label,
+        tone: actions.length === 0 ? 'primary' : 'secondary',
+        onClick: onScrollToStatusActions,
+      })
+    }
+  }
+
+  const firstCommunication = communicationActions.find((action) => !action.disabled)
+  if (firstCommunication && actions.length < 3) {
+    actions.push({
+      key: `communication-${firstCommunication.type}`,
+      label: firstCommunication.label,
+      tone: actions.length === 0 ? 'primary' : 'secondary',
+      onClick: onScrollToCommunication,
+    })
+  }
+
+  return actions.slice(0, 3)
+}
+
+function buildBlocker({
+  status,
+  canManageStatus,
+  availableStatusActions,
+  assignedUser,
+  canManageAssignment,
+  notificationHealth,
+  onScrollToAssignment,
+  onScrollToNotifications,
+}: {
+  status: PortingCaseStatus
+  canManageStatus: boolean
+  availableStatusActions: PortingRequestStatusActionDto[]
+  assignedUser: PortingRequestAssigneeSummaryDto | null
+  canManageAssignment: boolean
+  notificationHealth: NotificationHealthDiagnosticsDto
+  onScrollToAssignment: () => void
+  onScrollToNotifications: () => void
+}): { text: string; ctaLabel?: string; onClick?: () => void } | null {
+  if (TERMINAL_STATUSES.includes(status)) {
+    return null
+  }
+
+  if (notificationHealth.status !== 'OK' && notificationHealth.failureCount > 0) {
+    return {
+      text: `Zgłoszono ${notificationHealth.failureCount} błąd(ów) notyfikacji wewnętrznych — sprawdź zanim ruszysz dalej.`,
+      ctaLabel: 'Sprawdź notyfikacje',
+      onClick: onScrollToNotifications,
+    }
+  }
+
+  if (!assignedUser) {
+    return {
+      text: 'Sprawa nie ma przypisanego operatora BOK.',
+      ctaLabel: canManageAssignment ? 'Przypisz operatora' : 'Zobacz przypisanie',
+      onClick: onScrollToAssignment,
+    }
+  }
+
+  if (canManageStatus && availableStatusActions.length === 0 && status !== 'PENDING_DONOR') {
+    return {
+      text: 'Brak dostępnych akcji statusowych dla Twojej roli — sprawa czeka na uprawnionego operatora.',
+    }
+  }
+
+  if (!canManageStatus) {
+    return {
+      text: 'Twoja rola pozwala tylko na podgląd sprawy — akcje statusowe są niedostępne.',
+    }
+  }
+
+  return null
+}
+
+export function WhatsNextPanel({
+  status,
+  availableStatusActions,
+  availableCommunicationActions,
+  assignedUser,
+  notificationHealth,
+  canManageStatus,
+  canManageAssignment,
+  onScrollToStatusActions,
+  onScrollToCommunication,
+  onScrollToAssignment,
+  onScrollToNotifications,
+}: WhatsNextPanelProps) {
+  const statusMeta = getPortingStatusMeta(status)
+  const isTerminal = TERMINAL_STATUSES.includes(status)
+  const terminalCopy = TERMINAL_COPY[status]
+
+  const blocker = buildBlocker({
+    status,
+    canManageStatus,
+    availableStatusActions,
+    assignedUser,
+    canManageAssignment,
+    notificationHealth,
+    onScrollToAssignment,
+    onScrollToNotifications,
+  })
+
+  const tone = pickTone(status, blocker !== null)
+
+  const actions = isTerminal
+    ? []
+    : buildPrimaryActions({
+        statusActions: availableStatusActions,
+        communicationActions: availableCommunicationActions,
+        canManageStatus,
+        onScrollToStatusActions,
+        onScrollToCommunication,
+      })
+
+  const headline = isTerminal
+    ? terminalCopy?.headline ?? `Sprawa: ${statusMeta.label}`
+    : `Sprawa: ${statusMeta.label}`
+
+  const summary = isTerminal
+    ? terminalCopy?.body ?? STATUS_SUMMARY[status]
+    : STATUS_SUMMARY[status]
+
+  const nextStep = isTerminal ? null : NEXT_STEP_COPY[status] ?? null
+
+  return (
+    <section
+      aria-label="Co dalej ze sprawą?"
+      className={cx('rounded-panel border px-5 py-4 shadow-sm', TONE_STYLES[tone])}
+    >
+      <p
+        className={cx(
+          'text-xs font-semibold uppercase tracking-[0.1em]',
+          TONE_LABEL_STYLES[tone],
+        )}
+      >
+        Co dalej ze sprawą?
+      </p>
+      <p className={cx('mt-2 text-base font-semibold', TONE_HEADLINE_STYLES[tone])}>
+        {headline}
+      </p>
+      <p className={cx('mt-1 text-sm leading-6', TONE_BODY_STYLES[tone])}>{summary}</p>
+
+      {nextStep && (
+        <div className="mt-3 rounded-ui border border-white/60 bg-white/70 px-3 py-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-ink-500">
+            Najbliższy krok
+          </p>
+          <p className="mt-1 text-sm font-medium text-ink-800">{nextStep}</p>
+        </div>
+      )}
+
+      {actions.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2" data-testid="whats-next-actions">
+          {actions.map((action) => (
+            <button
+              key={action.key}
+              type="button"
+              onClick={action.onClick}
+              className={
+                action.tone === 'primary'
+                  ? 'btn-primary'
+                  : 'btn-secondary'
+              }
+            >
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {blocker && (
+        <div
+          className="mt-3 rounded-ui border border-amber-200 bg-amber-50 px-3 py-2"
+          data-testid="whats-next-blocker"
+        >
+          <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">
+            Blokada
+          </p>
+          <p className="mt-1 text-sm font-medium text-amber-900">{blocker.text}</p>
+          {blocker.ctaLabel && blocker.onClick && (
+            <button
+              type="button"
+              onClick={blocker.onClick}
+              className="mt-2 rounded-ui px-2 py-1 text-xs font-semibold text-amber-900 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500"
+            >
+              {blocker.ctaLabel} →
+            </button>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx
+++ b/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx
@@ -33,6 +33,12 @@ interface PrimaryAction {
 
 const TERMINAL_STATUSES: PortingCaseStatus[] = ['REJECTED', 'CANCELLED', 'PORTED']
 
+// Statuses where a missing status action can be truthfully attributed to the
+// current user's role — i.e. some role in the workflow has a transition from
+// this status. Excludes PENDING_DONOR (waiting on donor) and ERROR (backend
+// workflow defines no transitions from ERROR for any role).
+const ROLE_GATED_STATUSES: PortingCaseStatus[] = ['DRAFT', 'SUBMITTED', 'CONFIRMED']
+
 const TERMINAL_COPY: Partial<Record<PortingCaseStatus, { headline: string; body: string }>> = {
   PORTED: {
     headline: 'Numer został przeniesiony.',
@@ -186,15 +192,15 @@ function buildBlocker({
     }
   }
 
-  if (canManageStatus && availableStatusActions.length === 0 && status !== 'PENDING_DONOR') {
-    return {
-      text: 'Brak dostępnych akcji statusowych dla Twojej roli — sprawa czeka na uprawnionego operatora.',
-    }
-  }
-
   if (!canManageStatus) {
     return {
       text: 'Twoja rola pozwala tylko na podgląd sprawy — akcje statusowe są niedostępne.',
+    }
+  }
+
+  if (availableStatusActions.length === 0 && ROLE_GATED_STATUSES.includes(status)) {
+    return {
+      text: 'Brak dostępnych akcji statusowych dla Twojej roli — sprawa czeka na uprawnionego operatora.',
     }
   }
 

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -88,6 +88,7 @@ import { PliCbdProcessSnapshot } from '@/components/PliCbdProcessSnapshot/PliCbd
 import { PliCbdTechnicalPayloadPreview } from '@/components/PliCbdTechnicalPayloadPreview/PliCbdTechnicalPayloadPreview'
 import { PliCbdXmlPreview } from '@/components/PliCbdXmlPreview/PliCbdXmlPreview'
 import { PortingInternalNotificationsPanel } from '@/components/PortingInternalNotificationsPanel/PortingInternalNotificationsPanel'
+import { WhatsNextPanel } from '@/components/WhatsNextPanel/WhatsNextPanel'
 import { InternalNotificationAttemptsPanel } from '@/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel'
 import { NotificationFailureHistoryPanel } from '@/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel'
 import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
@@ -348,126 +349,6 @@ function scrollToSection(sectionId: string) {
 }
 
 const TERMINAL_CLOSED_STATUSES: PortingCaseStatus[] = ['REJECTED', 'CANCELLED', 'PORTED']
-
-const TERMINAL_CLOSED_LABELS: Partial<Record<PortingCaseStatus, string>> = {
-  PORTED: 'Numer przeniesiony pomyślnie.',
-  REJECTED: 'Sprawa odrzucona.',
-  CANCELLED: 'Sprawa anulowana.',
-}
-
-const STATUS_NEXT_STEP_DESCRIPTION: Partial<Record<PortingCaseStatus, string>> = {
-  DRAFT: 'Złóż sprawę do dalszej obsługi lub anuluj szkic.',
-  SUBMITTED: 'Sprawa oczekuje na weryfikację — potwierdź, odeślij do dawcy lub odrzuć.',
-  PENDING_DONOR: 'Oczekiwanie na odpowiedź operatora oddającego — po odpowiedzi potwierdź lub odrzuć.',
-  CONFIRMED: 'Sprawa potwierdzona — po realizacji portowania oznacz jako przeniesioną.',
-  ERROR: 'Zidentyfikuj przyczynę błędu i podjej działanie — anuluj lub skontaktuj się z przełożonym.',
-}
-
-function NextStepBanner({
-  status,
-  availableStatusActions,
-  canManageStatus,
-  onScrollToActions,
-}: {
-  status: PortingCaseStatus
-  availableStatusActions: PortingRequestStatusActionDto[]
-  canManageStatus: boolean
-  onScrollToActions: () => void
-}) {
-  const isTerminal = TERMINAL_CLOSED_STATUSES.includes(status)
-  const isError = status === 'ERROR'
-  const hasActions = availableStatusActions.length > 0
-
-  if (isTerminal) {
-    const tone = status === 'PORTED' ? 'emerald' : status === 'REJECTED' ? 'red' : 'neutral'
-    const colorClass =
-      tone === 'emerald'
-        ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
-        : tone === 'red'
-          ? 'border-red-200 bg-red-50 text-red-800'
-          : 'border-line bg-ink-50 text-ink-600'
-
-    return (
-      <div className={cx('rounded-panel border px-4 py-3', colorClass)}>
-        <p className="text-xs font-semibold uppercase tracking-wide opacity-70">Stan sprawy</p>
-        <p className="mt-1 text-sm font-semibold">
-          {TERMINAL_CLOSED_LABELS[status] ?? 'Sprawa zakończona — brak dalszych kroków.'}
-        </p>
-        <p className="mt-0.5 text-xs opacity-70">Żadne akcje statusowe nie są dostępne.</p>
-      </div>
-    )
-  }
-
-  if (isError) {
-    return (
-      <div className="rounded-panel border border-red-200 bg-red-50 px-4 py-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-red-600">Wymaga interwencji</p>
-        <p className="mt-1 text-sm font-semibold text-red-800">Sprawa ma status Błąd.</p>
-        <p className="mt-0.5 text-xs text-red-700">
-          {STATUS_NEXT_STEP_DESCRIPTION.ERROR}
-        </p>
-        {canManageStatus && hasActions && (
-          <button
-            type="button"
-            onClick={onScrollToActions}
-            className="mt-2 rounded-ui px-2 py-1 text-xs font-semibold text-red-800 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
-          >
-            Przejdź do akcji →
-          </button>
-        )}
-      </div>
-    )
-  }
-
-  if (!canManageStatus) {
-    return (
-      <div className="rounded-panel border border-line bg-surface px-4 py-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-ink-400">Tryb podglądu</p>
-        <p className="mt-1 text-sm text-ink-600">
-          Twoja rola pozwala tylko na podgląd sprawy. Akcje statusowe są niedostępne.
-        </p>
-      </div>
-    )
-  }
-
-  if (hasActions) {
-    return (
-      <div className="rounded-panel border border-brand-200 bg-brand-50 px-4 py-3">
-        <p className="text-xs font-semibold uppercase tracking-wide text-brand-600">Następny krok</p>
-        <p className="mt-1 text-sm font-medium text-ink-800">
-          {STATUS_NEXT_STEP_DESCRIPTION[status] ?? 'Wykonaj dostępną akcję, aby kontynuować obsługę sprawy.'}
-        </p>
-        <div className="mt-2 flex flex-wrap gap-x-3 gap-y-0.5">
-          {availableStatusActions.slice(0, 3).map((action) => (
-            <span key={`${action.actionId}-${action.targetStatus}`} className="text-xs text-brand-700">
-              • {action.label}
-            </span>
-          ))}
-        </div>
-        <button
-          type="button"
-          onClick={onScrollToActions}
-          className="mt-2 rounded-ui px-2 py-1 text-xs font-semibold text-brand-800 underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
-        >
-          Przejdź do akcji →
-        </button>
-      </div>
-    )
-  }
-
-  // Active status, no actions available for this role
-  return (
-    <div className="rounded-panel border border-amber-200 bg-amber-50 px-4 py-3">
-      <p className="text-xs font-semibold uppercase tracking-wide text-amber-600">Oczekuje na działanie</p>
-      <p className="mt-1 text-sm font-medium text-amber-800">
-        Sprawa aktywna — żadna akcja nie jest dostępna dla Twojej roli w tym statusie.
-      </p>
-      <p className="mt-0.5 text-xs text-amber-700">
-        Sprawa oczekuje na działanie uprawnionego operatora.
-      </p>
-    </div>
-  )
-}
 
 function getStatusTone(status: ReturnType<typeof getPortingStatusMeta>['tone']): BadgeTone {
   const toneByStatus: Record<ReturnType<typeof getPortingStatusMeta>['tone'], BadgeTone> = {
@@ -2255,11 +2136,18 @@ export function RequestDetailPage() {
         </div>
 
         <div className="space-y-4">
-          <NextStepBanner
+          <WhatsNextPanel
             status={request.statusInternal}
             availableStatusActions={availableStatusActions}
+            availableCommunicationActions={availableCommunicationActions}
+            assignedUser={request.assignedUser}
+            notificationHealth={request.notificationHealth}
             canManageStatus={canManageStatus}
-            onScrollToActions={() => scrollToSection('workflow-actions')}
+            canManageAssignment={canManageAssignment}
+            onScrollToStatusActions={() => scrollToSection('workflow-actions')}
+            onScrollToCommunication={() => scrollToSection('communication-panel')}
+            onScrollToAssignment={() => scrollToSection('assignment-panel')}
+            onScrollToNotifications={() => scrollToSection('notification-panel')}
           />
 
           <div id="assignment-panel" className="scroll-mt-6">


### PR DESCRIPTION
## Summary
- Nowy komponent `WhatsNextPanel` zastępuje dotychczasowy `NextStepBanner` w prawej kolumnie `RequestDetailPage`.
- Panel odpowiada użytkownikowi na pytanie „co mam teraz zrobić?": plain-language stan sprawy, najbliższy krok, 2–3 priorytetyzowane akcje (statusowe > jedna komunikacyjna jeśli dostępna) oraz pojedynczy blocker (notyfikacje / brak przypisania / tryb podglądu).
- Zero nowej logiki biznesowej — używa wyłącznie istniejących pól `PortingRequestDetailDto` (`statusInternal`, `availableStatusActions`, `availableCommunicationActions`, `assignedUser`, `notificationHealth`) i dostępnych callbacków `scrollToSection`.

## Zakres
- `apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx` (nowy)
- `apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.test.tsx` (nowy, 8 testów)
- `apps/frontend/src/pages/Requests/RequestDetailPage.tsx` — import + podmiana `<NextStepBanner>` na `<WhatsNextPanel>`, usunięcie martwej funkcji `NextStepBanner` i dwóch osieroconych stałych (`TERMINAL_CLOSED_LABELS`, `STATUS_NEXT_STEP_DESCRIPTION`).

Brak zmian w `apps/backend/**`, `packages/shared/**`, `prisma/**`, `package.json`, lockfile.

## UX
- Nagłówek „Co dalej ze sprawą?" + jednozdaniowy stan.
- Sekcja „Najbliższy krok" tylko dla statusów nie-terminalnych.
- Max 3 akcje: pierwsza primary (najważniejsza), reszta secondary; komunikacyjne `disabled` są filtrowane.
- Blocker pojedynczy, wybierany wg priorytetu: notyfikacje → przypisanie → brak akcji dla roli → tryb podglądu.
- Dla statusów terminalnych (`PORTED`/`REJECTED`/`CANCELLED`) panel pokazuje tylko komunikat zakończenia — bez akcji ani blockera.

## Test plan
- [x] `npx tsc --noEmit` w `apps/frontend` — czysto
- [x] `npx vitest run src/components/WhatsNextPanel` — 8/8
- [x] `npx vitest run` (pełny frontend) — 221/221 w 40 plikach
- [ ] Smoke manualny: otwórz `RequestDetailPage` dla sprawy w różnych statusach (DRAFT, SUBMITTED, PENDING_DONOR, CONFIRMED, ERROR, PORTED) — panel w prawej kolumnie pokazuje adekwatny stan + akcję prowadzącą do właściwej sekcji
- [ ] Smoke manualny: sprawa bez `assignedUser` → widoczny blocker „Przypisz operatora" scrollujący do panelu przypisania
- [ ] Smoke manualny: sprawa z `notificationHealth.status !== 'OK'` → blocker notyfikacji ma priorytet nad brakiem przypisania

🤖 Generated with [Claude Code](https://claude.com/claude-code)