### PR TITLE
feat(requests): sort "Priorytet pracy" na liście spraw (PR50B)

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
@@ -371,6 +371,149 @@ describe('listPortingRequests - quick work filters', () => {
   })
 })
 
+describe('listPortingRequests - WORK_PRIORITY sort (PR50B)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    // Wed 2026-04-22 11:00 Warsaw
+    vi.setSystemTime(new Date('2026-04-22T09:00:00.000Z'))
+
+    mockPrismaTransaction.mockImplementation(async (arg: unknown) => {
+      if (Array.isArray(arg)) return Promise.all(arg)
+      return undefined
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  function makeCandidate(
+    id: string,
+    confirmedPortDate: Date | null,
+    createdAt: Date,
+  ): { id: string; confirmedPortDate: Date | null; createdAt: Date } {
+    return { id, confirmedPortDate, createdAt }
+  }
+
+  it('orders rows by work-priority bucket, then date asc, with NO_DATE between THIS_WEEK and LATER', async () => {
+    const overdue = makeCandidate(
+      'overdue',
+      new Date('2026-04-20T00:00:00.000Z'),
+      new Date('2026-04-01T10:00:00.000Z'),
+    )
+    const today = makeCandidate(
+      'today',
+      new Date('2026-04-22T00:00:00.000Z'),
+      new Date('2026-04-01T10:00:00.000Z'),
+    )
+    const tomorrow = makeCandidate(
+      'tomorrow',
+      new Date('2026-04-23T00:00:00.000Z'),
+      new Date('2026-04-01T10:00:00.000Z'),
+    )
+    const thisWeek = makeCandidate(
+      'this_week',
+      new Date('2026-04-26T00:00:00.000Z'),
+      new Date('2026-04-01T10:00:00.000Z'),
+    )
+    const noDateOld = makeCandidate(
+      'no_date_old',
+      null,
+      new Date('2026-03-01T10:00:00.000Z'),
+    )
+    const noDateNew = makeCandidate(
+      'no_date_new',
+      null,
+      new Date('2026-04-10T10:00:00.000Z'),
+    )
+    const later = makeCandidate(
+      'later',
+      new Date('2026-05-11T00:00:00.000Z'),
+      new Date('2026-04-01T10:00:00.000Z'),
+    )
+
+    const shuffled = [later, noDateNew, thisWeek, overdue, noDateOld, tomorrow, today]
+    // First findMany: candidates (id, confirmedPortDate, createdAt)
+    // Second findMany: full rows for page
+    mockPortingRequestFindMany.mockResolvedValueOnce(shuffled)
+    mockPortingRequestFindMany.mockResolvedValueOnce([
+      makeListRow({ id: 'overdue', confirmedPortDate: overdue.confirmedPortDate }),
+      makeListRow({ id: 'today', confirmedPortDate: today.confirmedPortDate }),
+      makeListRow({ id: 'tomorrow', confirmedPortDate: tomorrow.confirmedPortDate }),
+      makeListRow({ id: 'this_week', confirmedPortDate: thisWeek.confirmedPortDate }),
+      makeListRow({ id: 'no_date_old', confirmedPortDate: null }),
+      makeListRow({ id: 'no_date_new', confirmedPortDate: null }),
+      makeListRow({ id: 'later', confirmedPortDate: later.confirmedPortDate }),
+    ])
+
+    const result = await listPortingRequests(
+      { sort: 'WORK_PRIORITY', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    expect(result.pagination.total).toBe(7)
+    expect(result.items.map((i) => i.id)).toEqual([
+      'overdue',
+      'today',
+      'tomorrow',
+      'this_week',
+      'no_date_old',
+      'no_date_new',
+      'later',
+    ])
+
+    // Pagination-safe: second findMany queries only the target page ids
+    const secondCall = mockPortingRequestFindMany.mock.calls[1]?.[0] as {
+      where: { id: { in: string[] } }
+    }
+    expect(secondCall.where.id.in).toHaveLength(7)
+  })
+
+  it('respects pagination boundaries for WORK_PRIORITY sort', async () => {
+    const candidates = Array.from({ length: 5 }, (_, i) =>
+      makeCandidate(
+        `r-${i + 1}`,
+        new Date(`2026-04-${String(20 + i).padStart(2, '0')}T00:00:00.000Z`),
+        new Date('2026-04-01T10:00:00.000Z'),
+      ),
+    )
+
+    mockPortingRequestFindMany.mockResolvedValueOnce(candidates)
+    mockPortingRequestFindMany.mockResolvedValueOnce([
+      makeListRow({ id: 'r-3' }),
+      makeListRow({ id: 'r-4' }),
+    ])
+
+    const result = await listPortingRequests(
+      { sort: 'WORK_PRIORITY', page: 2, pageSize: 2 },
+      CURRENT_USER_ID,
+    )
+
+    const pageIds = (
+      mockPortingRequestFindMany.mock.calls[1]?.[0] as { where: { id: { in: string[] } } }
+    ).where.id.in
+    expect(pageIds).toEqual(['r-3', 'r-4'])
+    expect(result.pagination.total).toBe(5)
+    expect(result.pagination.totalPages).toBe(3)
+  })
+
+  it('composes with quickWorkFilter when sorting by WORK_PRIORITY', async () => {
+    mockPortingRequestFindMany.mockResolvedValueOnce([])
+    mockPortingRequestFindMany.mockResolvedValueOnce([])
+
+    await listPortingRequests(
+      { sort: 'WORK_PRIORITY', quickWorkFilter: 'NO_DATE', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    const candidatesCall = mockPortingRequestFindMany.mock.calls[0]?.[0] as {
+      where: Record<string, unknown>
+    }
+    expect(candidatesCall.where).toMatchObject({ confirmedPortDate: null })
+  })
+})
+
 describe('getPortingRequestsOperationalSummary', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
@@ -62,6 +62,7 @@ const ownershipFilterEnum = z.enum(['ALL', 'MINE', 'UNASSIGNED'])
 const commercialOwnerFilterEnum = z.enum(['ALL', 'WITH_OWNER', 'WITHOUT_OWNER', 'MINE'])
 const notificationHealthFilterEnum = z.enum(['ALL', 'HAS_FAILURES', 'NO_FAILURES'])
 const quickWorkFilterEnum = z.enum(['URGENT', 'NO_DATE', 'NEEDS_ACTION_TODAY'])
+const listSortEnum = z.enum(['CREATED_AT_DESC', 'WORK_PRIORITY'])
 
 function validateDeferredEarliestDate(
   value: string | undefined,
@@ -357,6 +358,7 @@ export const portingRequestListQuerySchema = z.object({
   quickWorkFilter: quickWorkFilterEnum.optional(),
   commercialOwnerFilter: commercialOwnerFilterEnum.optional().default('ALL'),
   notificationHealthFilter: notificationHealthFilterEnum.optional().default('ALL'),
+  sort: listSortEnum.optional().default('CREATED_AT_DESC'),
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(100).default(20),
 })
@@ -365,6 +367,7 @@ export type PortingRequestListQuery = z.input<typeof portingRequestListQuerySche
 
 export const portingRequestSummaryQuerySchema = portingRequestListQuerySchema.omit({
   quickWorkFilter: true,
+  sort: true,
   page: true,
   pageSize: true,
 })

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -21,6 +21,7 @@ import type {
 } from '@np-manager/shared'
 import {
   getPortingUrgencyDateBoundaries,
+  getPortingWorkPriorityRank,
   PORTING_CASE_STATUS_LABELS,
 } from '@np-manager/shared'
 import type {
@@ -925,7 +926,12 @@ export async function listPortingRequests(
 ): Promise<PortingRequestListResultDto> {
   const page = query.page ?? 1
   const pageSize = query.pageSize ?? 20
+  const sort = query.sort ?? 'CREATED_AT_DESC'
   const where = buildPortingRequestListWhere(query, currentUserId)
+
+  if (sort === 'WORK_PRIORITY') {
+    return listPortingRequestsByWorkPriority(where, page, pageSize)
+  }
 
   const [total, requests] = await prisma.$transaction([
     prisma.portingRequest.count({ where }),
@@ -947,6 +953,78 @@ export async function listPortingRequests(
       totalPages: Math.ceil(total / pageSize),
     },
   }
+}
+
+async function listPortingRequestsByWorkPriority(
+  where: Prisma.PortingRequestWhereInput,
+  page: number,
+  pageSize: number,
+): Promise<PortingRequestListResultDto> {
+  // Reuzywamy shared semantyki urgency do wyliczenia kubelka pracy dla kazdej
+  // sprawy, a nastepnie paginujemy po stronie serwera aby lista byla spojna
+  // miedzy stronami.
+  const candidates = await prisma.portingRequest.findMany({
+    where,
+    select: { id: true, confirmedPortDate: true, createdAt: true },
+  })
+
+  const now = new Date()
+  const ordered = [...candidates].sort((a, b) => compareWorkPriority(a, b, now))
+  const total = ordered.length
+  const pageIds = ordered.slice((page - 1) * pageSize, page * pageSize).map((r) => r.id)
+
+  const rows = pageIds.length
+    ? await prisma.portingRequest.findMany({
+        where: { id: { in: pageIds } },
+        select: LIST_SELECT,
+      })
+    : []
+
+  const byId = new Map(rows.map((row) => [row.id, row]))
+  const items: PortingRequestListItemDto[] = []
+  for (const id of pageIds) {
+    const row = byId.get(id)
+    if (row) items.push(toListItem(row))
+  }
+
+  return {
+    items,
+    pagination: {
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize) || 1,
+    },
+  }
+}
+
+interface WorkPriorityCandidate {
+  id: string
+  confirmedPortDate: Date | null
+  createdAt: Date
+}
+
+function compareWorkPriority(
+  a: WorkPriorityCandidate,
+  b: WorkPriorityCandidate,
+  now: Date,
+): number {
+  const aIso = toDateOnlyString(a.confirmedPortDate)
+  const bIso = toDateOnlyString(b.confirmedPortDate)
+  const aRank = getPortingWorkPriorityRank(aIso, now)
+  const bRank = getPortingWorkPriorityRank(bIso, now)
+  if (aRank !== bRank) return aRank - bRank
+
+  // Dla dat: rosnaco po confirmedPortDate. NO_DATE: oldest-first wg createdAt.
+  if (aIso && bIso) {
+    if (aIso !== bIso) return aIso < bIso ? -1 : 1
+  }
+
+  const aCreated = a.createdAt.getTime()
+  const bCreated = b.createdAt.getTime()
+  if (aCreated !== bCreated) return aCreated - bCreated
+
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
 }
 
 interface BuildListWhereOptions {

--- a/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
@@ -452,6 +452,34 @@ describe('RequestsPage quick work filters', () => {
     })
   })
 
+  it('selects "Priorytet pracy" sort, syncs to URL and survives refresh', async () => {
+    const { unmount } = renderPage()
+    await screen.findByText('Sprawy portowania')
+
+    fireEvent.change(screen.getByLabelText('Sortowanie listy'), {
+      target: { value: 'WORK_PRIORITY' },
+    })
+
+    await waitFor(() => {
+      const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
+      expect(lastListCall).toMatchObject({ sort: 'WORK_PRIORITY', page: 1 })
+    })
+
+    unmount()
+    cleanup()
+    getPortingRequestsMock.mockClear()
+
+    renderPage('/requests?sort=WORK_PRIORITY')
+
+    await waitFor(() => {
+      const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
+      expect(lastListCall).toMatchObject({ sort: 'WORK_PRIORITY' })
+    })
+
+    const sortSelect = screen.getByLabelText('Sortowanie listy') as HTMLSelectElement
+    expect(sortSelect.value).toBe('WORK_PRIORITY')
+  })
+
   it('clears the quick work filter when selecting "Wszystkie"', async () => {
     renderPage('/requests?quickWorkFilter=URGENT&page=2&status=SUBMITTED')
 

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -30,6 +30,7 @@ import type {
   PortingRequestAssigneeSummaryDto,
   PortingRequestListItemDto,
   PortingRequestListResultDto,
+  PortingRequestListSort,
   PortingRequestOperationalSummaryDto,
 } from '@np-manager/shared'
 import {
@@ -37,8 +38,10 @@ import {
   buildListQueryFromFilters,
   buildRequestsSummaryCards,
   buildSummaryQueryFromFilters,
+  DEFAULT_REQUESTS_SORT,
   hasActiveRequestsFilters,
   parseCommercialOwnerFilter,
+  parseListSort,
   parseNotificationHealthFilter,
   parseQuickWorkFilter,
   type RequestsQuickWorkFilter,
@@ -95,6 +98,11 @@ const notificationHealthFilterLabels: Record<NotificationHealthFilter, string> =
   HAS_FAILURES: 'Bledy notyfikacji',
   NO_FAILURES: 'Bez bledow',
 }
+
+const sortOptions: Array<{ id: PortingRequestListSort; label: string }> = [
+  { id: 'CREATED_AT_DESC', label: 'Najnowsze' },
+  { id: 'WORK_PRIORITY', label: 'Priorytet pracy' },
+]
 
 interface ActiveFilterChip {
   id: string
@@ -381,6 +389,7 @@ export function RequestsPage() {
   const notificationHealthFilter = parseNotificationHealthFilter(
     searchParams.get('notificationHealthFilter'),
   )
+  const sort = parseListSort(searchParams.get('sort'))
   const page = parsePage(searchParams.get('page'))
 
   const filters = useMemo(
@@ -393,6 +402,7 @@ export function RequestsPage() {
       quickWorkFilter,
       commercialOwnerFilter,
       notificationHealthFilter,
+      sort,
       page,
       pageSize: PAGE_SIZE,
     }),
@@ -402,6 +412,7 @@ export function RequestsPage() {
       notificationHealthFilter,
       ownershipFilter,
       quickWorkFilter,
+      sort,
       page,
       portingModeFilter,
       searchInput,
@@ -732,6 +743,25 @@ export function RequestsPage() {
               {notificationHealthOptions.map((option) => (
                 <option key={option.id} value={option.id}>
                   Notyfikacje: {option.label}
+                </option>
+              ))}
+            </select>
+
+            <select
+              aria-label="Sortowanie listy"
+              value={sort}
+              onChange={(event) => {
+                const next = event.target.value as PortingRequestListSort
+                setParam({
+                  sort: next === DEFAULT_REQUESTS_SORT ? null : next,
+                  page: null,
+                })
+              }}
+              className="input-field h-10 min-w-[180px] lg:max-w-[220px]"
+            >
+              {sortOptions.map((option) => (
+                <option key={option.id} value={option.id}>
+                  Sortuj: {option.label}
                 </option>
               ))}
             </select>

--- a/apps/frontend/src/pages/Requests/requestsOperational.test.ts
+++ b/apps/frontend/src/pages/Requests/requestsOperational.test.ts
@@ -7,6 +7,7 @@ import {
   buildSummaryQueryFromFilters,
   hasActiveRequestsFilters,
   parseCommercialOwnerFilter,
+  parseListSort,
   parseNotificationHealthFilter,
   parseQuickWorkFilter,
   type RequestsOperationalFilterState,
@@ -24,6 +25,7 @@ function makeFilters(
     quickWorkFilter: 'ALL',
     commercialOwnerFilter: 'ALL',
     notificationHealthFilter: 'ALL',
+    sort: 'CREATED_AT_DESC',
     page: 1,
     pageSize: 20,
     ...overrides,
@@ -73,6 +75,7 @@ describe('requestsOperational helpers', () => {
       quickWorkFilter: undefined,
       commercialOwnerFilter: 'WITHOUT_OWNER',
       notificationHealthFilter: 'HAS_FAILURES',
+      sort: undefined,
       page: 3,
       pageSize: 20,
     })
@@ -94,9 +97,22 @@ describe('requestsOperational helpers', () => {
       quickWorkFilter: 'URGENT',
       commercialOwnerFilter: undefined,
       notificationHealthFilter: undefined,
+      sort: undefined,
       page: 1,
       pageSize: 20,
     })
+  })
+
+  it('parses and round-trips the WORK_PRIORITY sort option', () => {
+    expect(parseListSort('WORK_PRIORITY')).toBe('WORK_PRIORITY')
+    expect(parseListSort('unknown')).toBe('CREATED_AT_DESC')
+    expect(parseListSort(null)).toBe('CREATED_AT_DESC')
+
+    const query = buildListQueryFromFilters(makeFilters({ sort: 'WORK_PRIORITY' }))
+    expect(query.sort).toBe('WORK_PRIORITY')
+
+    const defaultQuery = buildListQueryFromFilters(makeFilters({ sort: 'CREATED_AT_DESC' }))
+    expect(defaultQuery.sort).toBeUndefined()
   })
 
   it('builds summary query without date-based quick filter and operational cards filters', () => {

--- a/apps/frontend/src/pages/Requests/requestsOperational.ts
+++ b/apps/frontend/src/pages/Requests/requestsOperational.ts
@@ -4,6 +4,7 @@ import type {
   PortingCaseStatus,
   PortingMode,
   PortingRequestListQueryDto,
+  PortingRequestListSort,
   PortingRequestOperationalSummaryDto,
   PortingRequestQuickWorkFilter,
   PortingRequestSummaryQueryDto,
@@ -38,6 +39,9 @@ const QUICK_WORK_FILTERS: RequestsQuickWorkFilter[] = [
   'NEEDS_ACTION_TODAY',
 ]
 
+const LIST_SORTS: PortingRequestListSort[] = ['CREATED_AT_DESC', 'WORK_PRIORITY']
+export const DEFAULT_REQUESTS_SORT: PortingRequestListSort = 'CREATED_AT_DESC'
+
 export interface RequestsOperationalFilterState {
   searchInput: string
   statusFilter: PortingCaseStatus | null
@@ -47,6 +51,7 @@ export interface RequestsOperationalFilterState {
   quickWorkFilter: RequestsQuickWorkFilter
   commercialOwnerFilter: CommercialOwnerFilter
   notificationHealthFilter: NotificationHealthFilter
+  sort: PortingRequestListSort
   page: number
   pageSize: number
 }
@@ -65,6 +70,14 @@ export function parseCommercialOwnerFilter(value: string | null): CommercialOwne
   }
 
   return 'ALL'
+}
+
+export function parseListSort(value: string | null): PortingRequestListSort {
+  if (value && LIST_SORTS.includes(value as PortingRequestListSort)) {
+    return value as PortingRequestListSort
+  }
+
+  return DEFAULT_REQUESTS_SORT
 }
 
 export function parseNotificationHealthFilter(value: string | null): NotificationHealthFilter {
@@ -120,6 +133,7 @@ export function buildListQueryFromFilters(
       filters.notificationHealthFilter !== 'ALL'
         ? filters.notificationHealthFilter
         : undefined,
+    sort: filters.sort !== DEFAULT_REQUESTS_SORT ? filters.sort : undefined,
     page: filters.page,
     pageSize: filters.pageSize,
   }

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -87,6 +87,7 @@ export async function getPortingRequests(
 ): Promise<PortingRequestListResultDto> {
   const query = new URLSearchParams()
   appendListFiltersToQuery(query, params, { includeQuickWorkFilter: true })
+  if (params.sort && params.sort !== 'CREATED_AT_DESC') query.set('sort', params.sort)
   if (params.page) query.set('page', String(params.page))
   if (params.pageSize) query.set('pageSize', String(params.pageSize))
 

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -44,6 +44,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR48 | "Co dalej ze sprawa?" panel na `RequestDetailPage` | DONE |
 | PR49 | Markery pilnosci/dat na liscie i w detailu | DONE |
 | PR50A | Quick work filters na `RequestsPage` | DONE |
+| PR50B | Sort "Priorytet pracy" na `RequestsPage` | DONE |
 
 ---
 

--- a/packages/shared/src/dto/porting-requests.dto.ts
+++ b/packages/shared/src/dto/porting-requests.dto.ts
@@ -27,6 +27,7 @@ export type OwnershipFilter = 'ALL' | 'MINE' | 'UNASSIGNED'
 export type CommercialOwnerFilter = 'ALL' | 'WITH_OWNER' | 'WITHOUT_OWNER' | 'MINE'
 export type NotificationHealthFilter = 'ALL' | 'HAS_FAILURES' | 'NO_FAILURES'
 export type PortingRequestQuickWorkFilter = 'URGENT' | 'NO_DATE' | 'NEEDS_ACTION_TODAY'
+export type PortingRequestListSort = 'CREATED_AT_DESC' | 'WORK_PRIORITY'
 export type NotificationHealthStatus = 'OK' | 'FAILED' | 'MISCONFIGURED' | 'MIXED'
 
 export interface NotificationHealthDiagnosticsDto {
@@ -92,6 +93,7 @@ export interface PortingRequestListQueryDto {
   quickWorkFilter?: PortingRequestQuickWorkFilter
   commercialOwnerFilter?: CommercialOwnerFilter
   notificationHealthFilter?: NotificationHealthFilter
+  sort?: PortingRequestListSort
   page?: number
   pageSize?: number
 }

--- a/packages/shared/src/porting-urgency.test.ts
+++ b/packages/shared/src/porting-urgency.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getPortingWorkPriorityBucket,
+  getPortingWorkPriorityRank,
+  PORTING_WORK_PRIORITY_ORDER,
+} from './porting-urgency'
+
+const NOW = new Date('2026-04-22T09:00:00.000Z')
+
+describe('getPortingWorkPriorityBucket', () => {
+  it('maps urgency levels to buckets, treating NONE as NO_DATE', () => {
+    expect(getPortingWorkPriorityBucket(null, NOW)).toBe('NO_DATE')
+    expect(getPortingWorkPriorityBucket(undefined, NOW)).toBe('NO_DATE')
+    expect(getPortingWorkPriorityBucket('2026-04-20', NOW)).toBe('OVERDUE')
+    expect(getPortingWorkPriorityBucket('2026-04-22', NOW)).toBe('TODAY')
+    expect(getPortingWorkPriorityBucket('2026-04-23', NOW)).toBe('TOMORROW')
+    expect(getPortingWorkPriorityBucket('2026-04-26', NOW)).toBe('THIS_WEEK')
+    expect(getPortingWorkPriorityBucket('2026-05-04', NOW)).toBe('LATER')
+  })
+
+  it('orders buckets so that NO_DATE sits between THIS_WEEK and LATER', () => {
+    const order = PORTING_WORK_PRIORITY_ORDER
+    expect(order.OVERDUE).toBeLessThan(order.TODAY)
+    expect(order.TODAY).toBeLessThan(order.TOMORROW)
+    expect(order.TOMORROW).toBeLessThan(order.THIS_WEEK)
+    expect(order.THIS_WEEK).toBeLessThan(order.NO_DATE)
+    expect(order.NO_DATE).toBeLessThan(order.LATER)
+  })
+
+  it('getPortingWorkPriorityRank returns the numeric priority key', () => {
+    expect(getPortingWorkPriorityRank('2026-04-20', NOW)).toBe(1)
+    expect(getPortingWorkPriorityRank('2026-04-22', NOW)).toBe(2)
+    expect(getPortingWorkPriorityRank(null, NOW)).toBe(5)
+    expect(getPortingWorkPriorityRank('2026-06-01', NOW)).toBe(6)
+  })
+})

--- a/packages/shared/src/porting-urgency.ts
+++ b/packages/shared/src/porting-urgency.ts
@@ -127,3 +127,44 @@ export function getPortingUrgencyLevel(
 
   return 'LATER'
 }
+
+// ============================================================
+// WORK PRIORITY (PR50B)
+// ============================================================
+// Kolejnosc, w jakiej operator powinien pracowac nad sprawami.
+// Reuzywa shared semantyki urgency; NO_DATE jest miedzy THIS_WEEK
+// a pozniejszymi sprawami LATER.
+
+export type PortingWorkPriorityBucket =
+  | 'OVERDUE'
+  | 'TODAY'
+  | 'TOMORROW'
+  | 'THIS_WEEK'
+  | 'NO_DATE'
+  | 'LATER'
+
+export const PORTING_WORK_PRIORITY_ORDER: Record<PortingWorkPriorityBucket, number> = {
+  OVERDUE: 1,
+  TODAY: 2,
+  TOMORROW: 3,
+  THIS_WEEK: 4,
+  NO_DATE: 5,
+  LATER: 6,
+}
+
+export function getPortingWorkPriorityBucket(
+  portDateIso: string | null | undefined,
+  now: Date = new Date(),
+): PortingWorkPriorityBucket {
+  const level = getPortingUrgencyLevel(portDateIso, now)
+  if (level === 'NONE') return 'NO_DATE'
+  if (level === 'LATER') return 'LATER'
+  return level
+}
+
+export function getPortingWorkPriorityRank(
+  portDateIso: string | null | undefined,
+  now: Date = new Date(),
+): number {
+  return PORTING_WORK_PRIORITY_ORDER[getPortingWorkPriorityBucket(portDateIso, now)]
+}


### PR DESCRIPTION
## Summary
- Dodaje drugi tryb sortowania na `RequestsPage` obok domyślnego `CREATED_AT_DESC`.
- Porządek: OVERDUE → TODAY → TOMORROW → THIS_WEEK → NO_DATE → LATER, wewnątrz kubełka `confirmedPortDate` ASC, następnie `createdAt` ASC, `id` ASC.
- Reużywa istniejącego `getPortingUrgencyLevel` w `@np-manager/shared` — jedno źródło prawdy; dodany tylko cienki helper `getPortingWorkPriorityBucket/Rank` + stała `PORTING_WORK_PRIORITY_ORDER`.
- Paginacja pozostaje server-correct (backend sortuje kandydatów, slice'uje stronę, potem dobiera pełne wiersze po `id`).
- URL/query sync: `sort` zapisywany tylko gdy != default; odświeżenie strony zachowuje wybór.

## What changed
- `packages/shared/src/porting-urgency.ts` — nowe helpery bucket/rank; test.
- `packages/shared/src/dto/porting-requests.dto.ts` — `PortingRequestListSort`, `sort?` w list query.
- `apps/backend/.../porting-requests.schema.ts` — enum sortu, pominięty w summary schema.
- `apps/backend/.../porting-requests.service.ts` — gałąź `listPortingRequestsByWorkPriority`.
- `apps/frontend/.../requestsOperational.ts` — `parseListSort`, pole `sort`, emisja tylko gdy != default.
- `apps/frontend/.../RequestsPage.tsx` — `<select>` „Sortowanie listy" z opcją „Priorytet pracy".
- `apps/frontend/src/services/portingRequests.api.ts` — przekazanie `sort` do backendu.
- Testy: shared (3), backend (3 dla WORK_PRIORITY: kolejność, paginacja, kompozycja z `quickWorkFilter`), frontend (parsing + URL roundtrip).
- `docs/PROJECT_CONTINUITY.md` — wpis PR50B.

## Why
Operator listy potrzebuje układu „najpilniejsze wyżej" bez zmiany domyślnej kolejności. Układ pilności już istnieje w shared (używany w urgency badges / quickWorkFilter), więc wystarczyło dodać sort po tej samej semantyce.

## Non-goals
- Bez nowych endpointów, ekranów, saved views, liczników, akcji batchowych.
- Default `CREATED_AT_DESC` niezmieniony.

## Validation
- `packages/shared`: vitest 3/3
- `apps/frontend`: vitest 248/248, `tsc --noEmit` clean
- `apps/backend`: vitest 414 pass (14 pre-existujących failów z ładowania env w niepowiązanych modułach — nie dotyczą PR50B), `tsc --noEmit` clean
- root `npm run build` — zielony

## Test plan
- [ ] Otworzyć `RequestsPage`, zmienić sort na „Priorytet pracy", sprawdzić że URL dostaje `sort=WORK_PRIORITY`
- [ ] Odświeżyć stronę — sort się utrzymuje
- [ ] Zweryfikować, że kolejność na stronie to OVERDUE → TODAY → TOMORROW → THIS_WEEK → NO_DATE → LATER
- [ ] Sprawdzić, że paginacja działa (strona 2 kontynuuje globalny porządek)
- [ ] Sprawdzić kompozycję z `quickWorkFilter`, search, filtrami operatora/statusu

🤖 Generated with [Claude Code](https://claude.com/claude-code)