### PR TITLE
feat(requests): ownership signal (Moja / Nieprzypisana) w wierszu listy spraw

### DIFF
--- a/apps/frontend/src/lib/portingOwnership.test.ts
+++ b/apps/frontend/src/lib/portingOwnership.test.ts
@@ -5,6 +5,7 @@ import {
   canSelectAnyAssignee,
   formatAssigneeLabel,
   formatAssignmentHistoryHeadline,
+  getOwnershipSignal,
   parseOwnershipFilter,
 } from './portingOwnership'
 
@@ -49,6 +50,29 @@ describe('portingOwnership helpers', () => {
     expect(formatAssignmentHistoryHeadline(historyItem)).toBe(
       'Zmieniono przypisanie z Anna Admin na Jan Kowalski.',
     )
+  })
+
+  describe('getOwnershipSignal', () => {
+    const assignee = {
+      id: 'user-1',
+      email: 'user-1@np-manager.local',
+      displayName: 'Jan Kowalski',
+      role: 'BOK_CONSULTANT' as const,
+    }
+
+    it('returns Nieprzypisana when no assignee', () => {
+      expect(getOwnershipSignal(null, 'user-1')).toEqual({ label: 'Nieprzypisana', tone: 'amber' })
+      expect(getOwnershipSignal(null, null)).toEqual({ label: 'Nieprzypisana', tone: 'amber' })
+    })
+
+    it('returns Moja when assignee matches currentUserId', () => {
+      expect(getOwnershipSignal(assignee, 'user-1')).toEqual({ label: 'Moja', tone: 'emerald' })
+    })
+
+    it('returns null when assigned to someone else', () => {
+      expect(getOwnershipSignal(assignee, 'user-2')).toBeNull()
+      expect(getOwnershipSignal(assignee, null)).toBeNull()
+    })
   })
 
   it('parses ownership filter values and RBAC helper flags', () => {

--- a/apps/frontend/src/lib/portingOwnership.ts
+++ b/apps/frontend/src/lib/portingOwnership.ts
@@ -4,6 +4,25 @@ import type {
   UserRole,
 } from '@np-manager/shared'
 
+export type OwnershipSignal =
+  | { label: 'Moja'; tone: 'emerald' }
+  | { label: 'Nieprzypisana'; tone: 'amber' }
+
+export function getOwnershipSignal(
+  assignedUserSummary: PortingRequestAssigneeSummaryDto | null,
+  currentUserId: string | null,
+): OwnershipSignal | null {
+  if (!assignedUserSummary) {
+    return { label: 'Nieprzypisana', tone: 'amber' }
+  }
+
+  if (currentUserId && assignedUserSummary.id === currentUserId) {
+    return { label: 'Moja', tone: 'emerald' }
+  }
+
+  return null
+}
+
 export type OwnershipFilter = 'ALL' | 'MINE' | 'UNASSIGNED'
 
 export function parseOwnershipFilter(value: string | null): OwnershipFilter {

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -6,6 +6,7 @@ import { useOperators } from '@/hooks/useOperators'
 import {
   canManagePortingOwnership,
   formatAssigneeLabel,
+  getOwnershipSignal,
   parseOwnershipFilter,
   type OwnershipFilter,
 } from '@/lib/portingOwnership'
@@ -217,6 +218,7 @@ export function RequestRow({
 }) {
   const ownerLabel = formatCommercialOwnerLabel(request.commercialOwnerSummary)
   const assigneeLabel = formatAssigneeLabel(request.assignedUserSummary)
+  const ownershipSignal = getOwnershipSignal(request.assignedUserSummary, currentUserId)
   const isUnassigned = request.assignedUserSummary === null
   const canAssignToMe = canAssign && isUnassigned && currentUserId !== null
   const [isAssigning, setIsAssigning] = useState(false)
@@ -385,6 +387,14 @@ export function RequestRow({
         >
           {assigneeLabel}
         </div>
+        {ownershipSignal && (
+          <Badge
+            tone={ownershipSignal.tone}
+            className="mt-1 w-fit text-[11px] font-semibold uppercase tracking-[0.04em]"
+          >
+            {ownershipSignal.label}
+          </Badge>
+        )}
         <div className="mt-1 text-xs text-ink-400">BOK</div>
       </td>
       <td className="px-5 py-4 align-top">

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -48,6 +48,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR52 | Lekkie row actions na `RequestsPage` | DONE |
 | PR53 | Oznaczenie priorytetu pracy w wierszu listy spraw | DONE |
 | PR54 | Operacyjny hint v1 w wierszu listy spraw | DONE |
+| PR55 | Ownership signal (Moja / Nieprzypisana) w wierszu listy spraw | DONE |
 
 ---
 
@@ -95,6 +96,16 @@ Dispatch jest non-blocking (`.catch(() => {})`) i nie blokuje glownego flow API.
   - Admin ma strone `Ustawienia powiadomien portingowych` do konfiguracji fallback email/Teams.
   - Read-only diagnostyka env: `email adapter mode`, `SMTP configured`.
 - Zakres pozostaje wewnetrzny (operacyjny) - bez zmian w customer communication pipeline.
+
+### PR55 - ownership signal w wierszu listy spraw
+
+- Frontend-only. Brak zmian backendu, DTO, endpointów.
+- Nowy helper `getOwnershipSignal(assignedUserSummary, currentUserId)` w `portingOwnership.ts`:
+  - `null` assignee → `{ label: 'Nieprzypisana', tone: 'amber' }`
+  - `assignedUserSummary.id === currentUserId` → `{ label: 'Moja', tone: 'emerald' }`
+  - assigned to someone else → `null` (bez badge, nazwa już widoczna)
+- `RequestRow` renderuje mały Badge w kolumnie "Przypisanie" na podstawie signalu.
+- Weryfikacja: 261/261 frontend testów PASS, tsc clean.
 
 ### PR16 - diagnostyka zdrowia notyfikacji
 


### PR DESCRIPTION
## Co zmieniono

Dodano prosty ownership signal v1 w wierszu listy spraw na `RequestsPage`. Każdy wiersz pokazuje teraz, czy sprawa jest moja, nieprzypisana, czy należy do kogoś innego.

## Zakres zmian

- **`portingOwnership.ts`** — nowy helper `getOwnershipSignal(assignedUserSummary, currentUserId)`:
  - `null` assignee → `{ label: 'Nieprzypisana', tone: 'amber' }`
  - `assignedUserSummary.id === currentUserId` → `{ label: 'Moja', tone: 'emerald' }`
  - assigned to someone else → `null` (nazwa już widoczna w kolumnie)
- **`RequestsPage.tsx`** — `RequestRow` renderuje mały Badge w kolumnie "Przypisanie" na podstawie signalu
- **`portingOwnership.test.ts`** — 3 nowe testy jednostkowe

## Decyzje

- **Frontend-only** — `assignedUserSummary.id` i `currentUserId` już dostępne w `RequestRow`; backend nie tknięty
- Badge tylko dla "Moja" i "Nieprzypisana" — dla sprawy przypisanej do kogoś innego nazwa jest wystarczająca
- Helper w `portingOwnership.ts` — spójnie z pozostałymi helperami ownership

## Weryfikacja

- 261/261 frontend testów PASS (były 258)
- `npx tsc --noEmit` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)