### PR TITLE
fix(backend): stabilize vitest config and @fastify/cors version alignment

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -21,7 +21,7 @@
     "db:reset": "prisma migrate reset --force && tsx prisma/seed.ts"
   },
   "dependencies": {
-    "@fastify/cors": "^9.0.1",
+    "@fastify/cors": "^10.0.0",
     "@fastify/jwt": "^10.0.0",
     "@fastify/multipart": "^8.3.0",
     "@np-manager/shared": "*",

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'node:path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@np-manager/shared': path.resolve(__dirname, '../../packages/shared/src/index.ts'),
+    },
+  },
+  test: {
+    include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'prisma/**/*.test.ts'],
+    exclude: ['node_modules', 'dist'],
+  },
+})

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -49,6 +49,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR53 | Oznaczenie priorytetu pracy w wierszu listy spraw | DONE |
 | PR54 | Operacyjny hint v1 w wierszu listy spraw | DONE |
 | PR55 | Ownership signal (Moja / Nieprzypisana) w wierszu listy spraw | DONE |
+| PR56 | Backend test/runtime foundation: vitest config + @fastify/cors alignment | DONE |
 
 ---
 
@@ -646,6 +647,26 @@ Waski frontend-only slice na `RequestsPage`: kazdy wiersz dostal drugi, lekki ba
   - `apps/backend`: `npx vitest run` FAIL poza zakresem tego slice'a:
     - Vitest podnosi rowniez `dist/**` skompilowane testy CommonJS (`Vitest cannot be imported in a CommonJS module using require()`),
     - czesc runtime suite wpada dodatkowo w problem wersji pluginu Fastify/CORS (`@fastify/cors - expected '4.x' fastify version, '5.8.5' is installed`).
+### PR56 - backend test/runtime foundation
+
+Waski fix-pack infrastrukturalny. Bez zmian domenowych.
+
+Root causes:
+- Brak `vitest.config.ts` → vitest (domyslny discovery) lapie `dist/**/*.test.js` (skompilowane CJS pliki TestScriptu).
+- Skompilowane pliki uzywaja `require('vitest')` → `Vitest cannot be imported in a CommonJS module using require()`.
+- `@fastify/cors: ^9.0.1` w package.json niespojne z faktycznie zainstalowanym `10.1.0` (lock mial `^10.0.0`).
+
+Zmiany:
+- Nowy `apps/backend/vitest.config.ts`:
+  - `include: ['src/**/*.test.ts', 'src/**/*.spec.ts', 'prisma/**/*.test.ts']` — pokrywa wszystkie 65 plikow testowych.
+  - `exclude: ['node_modules', 'dist']` — jawne wykluczenie artefaktow budowania.
+  - `resolve.alias` dla `@np-manager/shared` → bezposrednio ze zrodel TypeScript.
+- `apps/backend/package.json`: `@fastify/cors ^9.0.1` → `^10.0.0` (zgodnie z package-lock i zainstalowana wersja 10.1.0, ktora wspiera fastify 5.x).
+
+Wyniki walidacji:
+- `npx tsc --noEmit` (backend): PASS
+- `npx vitest run` (backend): 65/65 plikow, 488/488 testow, 0 bledow.
+
 #### Konfiguracja transportu email
 
 ```env


### PR DESCRIPTION
## Summary

- **New `apps/backend/vitest.config.ts`** — explicit `include` patterns (`src/**/*.test.ts`, `prisma/**/*.test.ts`) and `exclude: ['node_modules', 'dist']` to stop vitest from picking up compiled CJS output in `dist/`
- **`@fastify/cors` version bump** — `^9.0.1` → `^10.0.0` to match `package-lock.json` (installed `10.1.0`, which supports fastify 5.x; no runtime change)

## Root cause

Without a `vitest.config.ts`, vitest used default discovery and matched `dist/**/*.test.js` — compiled CJS test files. Those fail immediately with:

> `Vitest cannot be imported in a CommonJS module using require()`

This produced 63 fake failures on every test run, obscuring the real 488 passing tests.

The `@fastify/cors` mismatch (`^9.0.1` in package.json vs `10.1.0` installed) was a version-range incoherence left from a dependency update that updated the lock but not the manifest. Corrected to `^10.0.0`.

## Validation

- `npx tsc --noEmit` (backend): PASS
- `npx vitest run` (backend): **65/65 test files, 488/488 tests, 0 failures**

## Reviewer notes

No business logic changes. No schema changes. No frontend changes. Pure tooling/config fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)