### PR TITLE
feat(requests): operacyjna edycja 4 pol sprawy na RequestDetailPage (PR57)

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.details-edit.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.details-edit.service.test.ts
@@ -1,0 +1,345 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockPortingRequestFindUnique,
+  mockTransaction,
+  mockUpdate,
+  mockEventCreate,
+  mockLogAuditEvent,
+  mockGetPortingCommunicationHistoryItems,
+} = vi.hoisted(() => ({
+  mockPortingRequestFindUnique: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockEventCreate: vi.fn(),
+  mockLogAuditEvent: vi.fn(),
+  mockGetPortingCommunicationHistoryItems: vi.fn(),
+}))
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    portingRequest: {
+      findUnique: (...args: unknown[]) => mockPortingRequestFindUnique(...args),
+    },
+    $transaction: (...args: unknown[]) => mockTransaction(...args),
+  },
+}))
+
+vi.mock('../../../shared/audit/audit.service', () => ({
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
+}))
+
+vi.mock('../../pli-cbd/pli-cbd.adapter', () => ({
+  PLI_CBD_TRIGGER_SELECT: {},
+  portingRequestPliCbdAdapter: {},
+}))
+
+vi.mock('../../pli-cbd/pli-cbd.integration-tracker', () => ({
+  createFailedIntegrationAttempt: vi.fn(),
+  getPliCbdIntegrationEvents: vi.fn(),
+  withPliCbdIntegrationTracking: vi.fn(),
+}))
+
+vi.mock('../porting-request-communication.service', async () => {
+  const actual = await vi.importActual<typeof import('../porting-request-communication.service')>(
+    '../porting-request-communication.service',
+  )
+
+  return {
+    ...actual,
+    getPortingCommunicationHistoryItems: (...args: unknown[]) =>
+      mockGetPortingCommunicationHistoryItems(...args),
+  }
+})
+
+import { updatePortingRequestDetails } from '../porting-requests.service'
+
+function makeCurrent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'req-1',
+    caseNumber: 'FNP-20260101-ABCDEF',
+    statusInternal: 'SUBMITTED',
+    correspondenceAddress: 'Testowa 1, 00-001 Warszawa',
+    contactChannel: 'EMAIL',
+    internalNotes: null,
+    requestDocumentNumber: 'DOC-1',
+    ...overrides,
+  }
+}
+
+function makeDetailRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'req-1',
+    caseNumber: 'FNP-20260101-ABCDEF',
+    clientId: 'client-1',
+    numberType: 'FIXED_LINE',
+    numberRangeKind: 'SINGLE',
+    primaryNumber: '221234567',
+    rangeStart: null,
+    rangeEnd: null,
+    requestDocumentNumber: 'DOC-1',
+    donorRoutingNumber: '2600',
+    recipientRoutingNumber: '2700',
+    sentToExternalSystemAt: null,
+    portingMode: 'DAY',
+    requestedPortDate: null,
+    requestedPortTime: null,
+    earliestAcceptablePortDate: null,
+    confirmedPortDate: null,
+    donorAssignedPortDate: null,
+    donorAssignedPortTime: null,
+    statusInternal: 'SUBMITTED',
+    statusPliCbd: null,
+    pliCbdCaseId: null,
+    pliCbdCaseNumber: null,
+    pliCbdPackageId: null,
+    pliCbdExportStatus: 'NOT_EXPORTED',
+    pliCbdLastSyncAt: null,
+    lastExxReceived: null,
+    lastPliCbdStatusCode: null,
+    lastPliCbdStatusDescription: null,
+    rejectionCode: null,
+    rejectionReason: null,
+    subscriberKind: 'INDIVIDUAL',
+    subscriberFirstName: 'Jan',
+    subscriberLastName: 'Kowalski',
+    subscriberCompanyName: null,
+    identityType: 'PESEL',
+    identityValue: '90010112345',
+    correspondenceAddress: 'Testowa 1, 00-001 Warszawa',
+    hasPowerOfAttorney: true,
+    linkedWholesaleServiceOnRecipientSide: false,
+    contactChannel: 'EMAIL',
+    internalNotes: null,
+    createdByUserId: 'creator-1',
+    assignedAt: null,
+    assignedByUserId: null,
+    commercialOwnerUserId: null,
+    createdAt: new Date('2026-01-01T10:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T10:00:00.000Z'),
+    client: {
+      id: 'client-1',
+      clientType: 'INDIVIDUAL',
+      firstName: 'Jan',
+      lastName: 'Kowalski',
+      companyName: null,
+      email: 'jan.kowalski@example.com',
+      addressStreet: 'Testowa 1',
+      addressCity: 'Warszawa',
+      addressZip: '00-001',
+    },
+    donorOperator: {
+      id: 'op-1',
+      name: 'Donor',
+      shortName: 'DNR',
+      routingNumber: '2600',
+      isActive: true,
+    },
+    recipientOperator: {
+      id: 'op-2',
+      name: 'Recipient',
+      shortName: 'RCP',
+      routingNumber: '2700',
+      isActive: true,
+    },
+    infrastructureOperator: null,
+    assignedUser: null,
+    commercialOwner: null,
+    events: [],
+    ...overrides,
+  }
+}
+
+describe('updatePortingRequestDetails', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLogAuditEvent.mockResolvedValue(undefined)
+    mockGetPortingCommunicationHistoryItems.mockResolvedValue([])
+    mockTransaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+      cb({
+        portingRequest: { update: (...a: unknown[]) => mockUpdate(...a) },
+        portingRequestEvent: { create: (...a: unknown[]) => mockEventCreate(...a) },
+      }),
+    )
+    mockUpdate.mockResolvedValue({})
+    mockEventCreate.mockResolvedValue({})
+  })
+
+  it('updates allowed fields, writes per-field audit and creates [DetailsEdit] NOTE', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce(makeCurrent())
+    mockPortingRequestFindUnique.mockResolvedValueOnce(
+      makeDetailRow({
+        correspondenceAddress: 'Nowa 2, 00-002 Warszawa',
+        contactChannel: 'SMS',
+        internalNotes: 'Oddzwonic jutro',
+        requestDocumentNumber: 'DOC-2',
+      }),
+    )
+
+    const result = await updatePortingRequestDetails(
+      'req-1',
+      {
+        correspondenceAddress: 'Nowa 2, 00-002 Warszawa',
+        contactChannel: 'SMS',
+        internalNotes: 'Oddzwonic jutro',
+        requestDocumentNumber: 'DOC-2',
+      },
+      'actor-1',
+      'BOK_CONSULTANT',
+      '127.0.0.1',
+      'jest',
+    )
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'req-1' },
+      data: {
+        correspondenceAddress: 'Nowa 2, 00-002 Warszawa',
+        contactChannel: 'SMS',
+        internalNotes: 'Oddzwonic jutro',
+        requestDocumentNumber: 'DOC-2',
+      },
+    })
+
+    expect(mockEventCreate).toHaveBeenCalledTimes(1)
+    const eventArg = mockEventCreate.mock.calls[0]![0] as {
+      data: { title: string; description: string; eventType: string }
+    }
+    expect(eventArg.data.eventType).toBe('NOTE')
+    expect(eventArg.data.title.startsWith('[DetailsEdit] ')).toBe(true)
+    expect(eventArg.data.description).toContain('Adres korespondencyjny')
+    expect(eventArg.data.description).toContain('Kanal kontaktu')
+    expect(eventArg.data.description).toContain('Notatki wewnetrzne')
+    expect(eventArg.data.description).toContain('Numer dokumentu')
+
+    expect(mockLogAuditEvent).toHaveBeenCalledTimes(4)
+    const auditFields = (mockLogAuditEvent.mock.calls as Array<[{ fieldName: string }]>).map(
+      (call) => call[0].fieldName,
+    )
+    expect(auditFields.sort()).toEqual(
+      [
+        'contactChannel',
+        'correspondenceAddress',
+        'internalNotes',
+        'requestDocumentNumber',
+      ].sort(),
+    )
+
+    expect(result.caseNumber).toBe('FNP-20260101-ABCDEF')
+  })
+
+  it('updates only changed fields and skips unchanged ones', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce(makeCurrent())
+    mockPortingRequestFindUnique.mockResolvedValueOnce(
+      makeDetailRow({ internalNotes: 'Tylko notatka' }),
+    )
+
+    await updatePortingRequestDetails(
+      'req-1',
+      {
+        correspondenceAddress: 'Testowa 1, 00-001 Warszawa', // same as current
+        contactChannel: 'EMAIL', // same
+        internalNotes: 'Tylko notatka', // changed
+      },
+      'actor-1',
+      'BOK_CONSULTANT',
+    )
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'req-1' },
+      data: { internalNotes: 'Tylko notatka' },
+    })
+    expect(mockLogAuditEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogAuditEvent.mock.calls[0]![0]).toMatchObject({
+      fieldName: 'internalNotes',
+      oldValue: 'BRAK',
+      newValue: 'Tylko notatka',
+    })
+  })
+
+  it('returns current detail without side effects when there are no changes', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce(makeCurrent())
+    mockPortingRequestFindUnique.mockResolvedValueOnce(makeDetailRow())
+
+    await updatePortingRequestDetails(
+      'req-1',
+      {
+        correspondenceAddress: 'Testowa 1, 00-001 Warszawa',
+      },
+      'actor-1',
+      'ADMIN',
+    )
+
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(mockEventCreate).not.toHaveBeenCalled()
+    expect(mockLogAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('throws 404 when request does not exist', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce(null)
+
+    await expect(
+      updatePortingRequestDetails(
+        'missing',
+        { contactChannel: 'SMS' },
+        'actor-1',
+        'ADMIN',
+      ),
+    ).rejects.toMatchObject({ statusCode: 404 })
+
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(mockLogAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it.each(['REJECTED', 'CANCELLED', 'PORTED'] as const)(
+    'rejects edits when request is in terminal status %s',
+    async (statusInternal) => {
+      mockPortingRequestFindUnique.mockResolvedValueOnce(makeCurrent({ statusInternal }))
+
+      await expect(
+        updatePortingRequestDetails(
+          'req-1',
+          { contactChannel: 'SMS' },
+          'actor-1',
+          'BOK_CONSULTANT',
+        ),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'REQUEST_CLOSED_EDIT_FORBIDDEN',
+      })
+
+      expect(mockUpdate).not.toHaveBeenCalled()
+      expect(mockLogAuditEvent).not.toHaveBeenCalled()
+    },
+  )
+
+  it('allows clearing optional fields (null values mapped through)', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce(
+      makeCurrent({ internalNotes: 'stare', requestDocumentNumber: 'OLD' }),
+    )
+    mockPortingRequestFindUnique.mockResolvedValueOnce(
+      makeDetailRow({ internalNotes: null, requestDocumentNumber: null }),
+    )
+
+    await updatePortingRequestDetails(
+      'req-1',
+      { internalNotes: null, requestDocumentNumber: null },
+      'actor-1',
+      'ADMIN',
+    )
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'req-1' },
+      data: { internalNotes: null, requestDocumentNumber: null },
+    })
+
+    const auditCalls = mockLogAuditEvent.mock.calls as Array<
+      [{ fieldName: string; oldValue: string; newValue: string }]
+    >
+    expect(
+      auditCalls.find((call) => call[0].fieldName === 'internalNotes'),
+    ).toBeDefined()
+    expect(
+      auditCalls.find((call) => call[0].fieldName === 'internalNotes')?.[0].newValue,
+    ).toBe('BRAK')
+  })
+})

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -13,6 +13,7 @@ import {
   retryInternalNotificationAttemptSchema,
   updatePortingRequestAssignmentSchema,
   updatePortingRequestCommercialOwnerSchema,
+  updatePortingRequestDetailsSchema,
   updatePortingRequestStatusSchema,
 } from './porting-requests.schema'
 import {
@@ -31,6 +32,7 @@ import {
   syncPortingRequestFromPliCbd,
   updatePortingRequestAssignment,
   updateCommercialOwner,
+  updatePortingRequestDetails,
   updatePortingRequestStatus,
 } from './porting-requests.service'
 import {
@@ -420,6 +422,24 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
 
     return reply.status(201).send({ success: true, data: { request: portingRequest } })
   })
+
+  app.patch<{ Params: { id: string } }>(
+    '/:id/details',
+    { preHandler: [authenticate, authorize(writeRoles)] },
+    async (request, reply) => {
+      const body = updatePortingRequestDetailsSchema.parse(request.body)
+      const portingRequest = await updatePortingRequestDetails(
+        request.params.id,
+        body,
+        request.user.id,
+        request.user.role as UserRole,
+        request.ip,
+        request.headers['user-agent'],
+      )
+
+      return reply.status(200).send({ success: true, data: { request: portingRequest } })
+    },
+  )
 
   app.patch<{ Params: { id: string } }>(
     '/:id/status',

--- a/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
@@ -349,6 +349,39 @@ export const updatePortingRequestStatusSchema = z.object({
 
 export type UpdatePortingRequestStatusBody = z.infer<typeof updatePortingRequestStatusSchema>
 
+// ============================================================
+// OPERATIONAL DETAILS EDIT v1
+// ============================================================
+
+const nullableTrimmedString = (max: number) =>
+  z.preprocess(
+    (value) => (value === '' ? null : value),
+    z.union([z.string().max(max).trim(), z.null()]),
+  )
+
+export const updatePortingRequestDetailsSchema = z
+  .object({
+    correspondenceAddress: z
+      .string()
+      .min(1, 'Adres korespondencyjny nie moze byc pusty.')
+      .max(1000)
+      .trim()
+      .optional(),
+    contactChannel: z.enum(['EMAIL', 'SMS', 'LETTER']).optional(),
+    internalNotes: nullableTrimmedString(5000).optional(),
+    requestDocumentNumber: nullableTrimmedString(100).optional(),
+  })
+  .refine(
+    (data) =>
+      data.correspondenceAddress !== undefined ||
+      data.contactChannel !== undefined ||
+      data.internalNotes !== undefined ||
+      data.requestDocumentNumber !== undefined,
+    { message: 'Podaj przynajmniej jedno pole do zmiany.' },
+  )
+
+export type UpdatePortingRequestDetailsBody = z.infer<typeof updatePortingRequestDetailsSchema>
+
 export const portingRequestListQuerySchema = z.object({
   search: z.string().trim().max(200).optional(),
   status: statusEnum.optional(),

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -31,6 +31,7 @@ import type {
   PortingRequestSummaryQuery,
   UpdatePortingRequestAssignmentBody,
   UpdatePortingRequestCommercialOwnerBody,
+  UpdatePortingRequestDetailsBody,
   UpdatePortingRequestStatusBody,
 } from './porting-requests.schema'
 import { dispatchPortingNotification } from './porting-notification.service'
@@ -1528,6 +1529,155 @@ export async function updateCommercialOwner(
   }).catch(() => {})
 
   return updated
+}
+
+type DetailsEditableField =
+  | 'correspondenceAddress'
+  | 'contactChannel'
+  | 'internalNotes'
+  | 'requestDocumentNumber'
+
+const DETAILS_EDIT_FIELD_LABELS: Record<DetailsEditableField, string> = {
+  correspondenceAddress: 'Adres korespondencyjny',
+  contactChannel: 'Kanal kontaktu',
+  internalNotes: 'Notatki wewnetrzne',
+  requestDocumentNumber: 'Numer dokumentu',
+}
+
+function formatDetailsAuditValue(value: string | null | undefined): string {
+  if (value === null || value === undefined || value === '') return 'BRAK'
+  return value.length > 200 ? `${value.slice(0, 197)}...` : value
+}
+
+export async function updatePortingRequestDetails(
+  requestId: string,
+  body: UpdatePortingRequestDetailsBody,
+  userId: string,
+  userRole: UserRole,
+  ipAddress?: string,
+  userAgent?: string,
+): Promise<PortingRequestDetailDto> {
+  const current = await prisma.portingRequest.findUnique({
+    where: { id: requestId },
+    select: {
+      id: true,
+      caseNumber: true,
+      statusInternal: true,
+      correspondenceAddress: true,
+      contactChannel: true,
+      internalNotes: true,
+      requestDocumentNumber: true,
+    },
+  })
+
+  if (!current) {
+    throw AppError.notFound('Sprawa portowania nie zostala znaleziona.')
+  }
+
+  if (CLOSED_STATUSES.includes(current.statusInternal)) {
+    throw AppError.badRequest(
+      'Nie mozna edytowac danych sprawy w statusie koncowym.',
+      'REQUEST_CLOSED_EDIT_FORBIDDEN',
+    )
+  }
+
+  const changes: Array<{
+    field: DetailsEditableField
+    oldValue: string | null
+    newValue: string | null
+  }> = []
+  const updateData: Prisma.PortingRequestUpdateInput = {}
+
+  if (body.correspondenceAddress !== undefined && body.correspondenceAddress !== current.correspondenceAddress) {
+    changes.push({
+      field: 'correspondenceAddress',
+      oldValue: current.correspondenceAddress,
+      newValue: body.correspondenceAddress,
+    })
+    updateData.correspondenceAddress = body.correspondenceAddress
+  }
+
+  if (body.contactChannel !== undefined && body.contactChannel !== current.contactChannel) {
+    changes.push({
+      field: 'contactChannel',
+      oldValue: current.contactChannel,
+      newValue: body.contactChannel,
+    })
+    updateData.contactChannel = body.contactChannel
+  }
+
+  if (body.internalNotes !== undefined) {
+    const normalizedNext = body.internalNotes === '' ? null : body.internalNotes
+    if (normalizedNext !== current.internalNotes) {
+      changes.push({
+        field: 'internalNotes',
+        oldValue: current.internalNotes,
+        newValue: normalizedNext,
+      })
+      updateData.internalNotes = normalizedNext
+    }
+  }
+
+  if (body.requestDocumentNumber !== undefined) {
+    const normalizedNext = body.requestDocumentNumber === '' ? null : body.requestDocumentNumber
+    if (normalizedNext !== current.requestDocumentNumber) {
+      changes.push({
+        field: 'requestDocumentNumber',
+        oldValue: current.requestDocumentNumber,
+        newValue: normalizedNext,
+      })
+      updateData.requestDocumentNumber = normalizedNext
+    }
+  }
+
+  if (changes.length === 0) {
+    return getPortingRequest(requestId, userRole)
+  }
+
+  const changedFieldLabels = changes.map((c) => DETAILS_EDIT_FIELD_LABELS[c.field]).join(', ')
+  const eventDescription = changes
+    .map((c) => {
+      const fieldLabel = DETAILS_EDIT_FIELD_LABELS[c.field]
+      const before = formatDetailsAuditValue(c.oldValue)
+      const after = formatDetailsAuditValue(c.newValue)
+      return `${fieldLabel}: ${before} -> ${after}`
+    })
+    .join(' | ')
+
+  await prisma.$transaction(async (tx) => {
+    await tx.portingRequest.update({
+      where: { id: requestId },
+      data: updateData,
+    })
+
+    await tx.portingRequestEvent.create({
+      data: {
+        request: { connect: { id: requestId } },
+        eventSource: 'INTERNAL',
+        eventType: 'NOTE',
+        title: `[DetailsEdit] Edycja danych sprawy: ${changedFieldLabels}`,
+        description: eventDescription,
+        createdBy: { connect: { id: userId } },
+      },
+    })
+  })
+
+  for (const change of changes) {
+    await logAuditEvent({
+      action: 'UPDATE',
+      userId,
+      entityType: 'porting_request',
+      entityId: requestId,
+      requestId,
+      fieldName: change.field,
+      oldValue: formatDetailsAuditValue(change.oldValue),
+      newValue: formatDetailsAuditValue(change.newValue),
+      ipAddress,
+      userAgent,
+    })
+  }
+
+  return getPortingRequest(requestId, userRole)
 }
 
 export async function listCommercialOwnerCandidates(): Promise<CommercialOwnerCandidatesResultDto> {

--- a/apps/frontend/src/components/RequestOperationalDetailsPanel/RequestOperationalDetailsPanel.tsx
+++ b/apps/frontend/src/components/RequestOperationalDetailsPanel/RequestOperationalDetailsPanel.tsx
@@ -1,0 +1,302 @@
+import { useState } from 'react'
+import {
+  CONTACT_CHANNEL_LABELS,
+  type ContactChannel,
+  type UpdatePortingRequestDetailsDto,
+} from '@np-manager/shared'
+
+export interface RequestOperationalDetailsPanelProps {
+  correspondenceAddress: string
+  contactChannel: ContactChannel
+  internalNotes: string | null
+  requestDocumentNumber: string | null
+  canEdit: boolean
+  disabledReason?: string | null
+  onSave: (payload: UpdatePortingRequestDetailsDto) => Promise<void>
+}
+
+const CONTACT_CHANNEL_OPTIONS: ContactChannel[] = ['EMAIL', 'SMS', 'LETTER']
+
+const MAX_LENGTHS = {
+  correspondenceAddress: 1000,
+  internalNotes: 5000,
+  requestDocumentNumber: 100,
+} as const
+
+function diffPayload(
+  initial: {
+    correspondenceAddress: string
+    contactChannel: ContactChannel
+    internalNotes: string | null
+    requestDocumentNumber: string | null
+  },
+  next: {
+    correspondenceAddress: string
+    contactChannel: ContactChannel
+    internalNotes: string
+    requestDocumentNumber: string
+  },
+): UpdatePortingRequestDetailsDto {
+  const payload: UpdatePortingRequestDetailsDto = {}
+
+  if (next.correspondenceAddress.trim() !== initial.correspondenceAddress) {
+    payload.correspondenceAddress = next.correspondenceAddress.trim()
+  }
+
+  if (next.contactChannel !== initial.contactChannel) {
+    payload.contactChannel = next.contactChannel
+  }
+
+  const nextNotes = next.internalNotes.trim() === '' ? null : next.internalNotes.trim()
+  if (nextNotes !== initial.internalNotes) {
+    payload.internalNotes = nextNotes
+  }
+
+  const nextDoc =
+    next.requestDocumentNumber.trim() === '' ? null : next.requestDocumentNumber.trim()
+  if (nextDoc !== initial.requestDocumentNumber) {
+    payload.requestDocumentNumber = nextDoc
+  }
+
+  return payload
+}
+
+export function RequestOperationalDetailsPanel({
+  correspondenceAddress,
+  contactChannel,
+  internalNotes,
+  requestDocumentNumber,
+  canEdit,
+  disabledReason,
+  onSave,
+}: RequestOperationalDetailsPanelProps) {
+  const [mode, setMode] = useState<'view' | 'edit'>('view')
+  const [formCorrespondenceAddress, setFormCorrespondenceAddress] = useState(correspondenceAddress)
+  const [formContactChannel, setFormContactChannel] = useState<ContactChannel>(contactChannel)
+  const [formInternalNotes, setFormInternalNotes] = useState(internalNotes ?? '')
+  const [formRequestDocumentNumber, setFormRequestDocumentNumber] = useState(
+    requestDocumentNumber ?? '',
+  )
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  function enterEditMode() {
+    setFormCorrespondenceAddress(correspondenceAddress)
+    setFormContactChannel(contactChannel)
+    setFormInternalNotes(internalNotes ?? '')
+    setFormRequestDocumentNumber(requestDocumentNumber ?? '')
+    setError(null)
+    setSuccess(null)
+    setMode('edit')
+  }
+
+  function cancelEdit() {
+    setMode('view')
+    setError(null)
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+
+    const payload = diffPayload(
+      { correspondenceAddress, contactChannel, internalNotes, requestDocumentNumber },
+      {
+        correspondenceAddress: formCorrespondenceAddress,
+        contactChannel: formContactChannel,
+        internalNotes: formInternalNotes,
+        requestDocumentNumber: formRequestDocumentNumber,
+      },
+    )
+
+    if (Object.keys(payload).length === 0) {
+      setError('Nie wprowadzono zmian.')
+      return
+    }
+
+    if (
+      payload.correspondenceAddress !== undefined &&
+      payload.correspondenceAddress.trim() === ''
+    ) {
+      setError('Adres korespondencyjny nie moze byc pusty.')
+      return
+    }
+
+    setError(null)
+    setSuccess(null)
+    setIsSaving(true)
+
+    try {
+      await onSave(payload)
+      setSuccess('Dane sprawy zostaly zaktualizowane.')
+      setMode('view')
+    } catch (saveError) {
+      const message =
+        saveError instanceof Error && saveError.message
+          ? saveError.message
+          : 'Nie udalo sie zapisac zmian.'
+      setError(message)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <div data-testid="request-operational-details-panel" className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm text-ink-500">
+          Waska edycja operacyjna. Zmieniasz dane kontaktowe i notatki bez przebudowy sprawy.
+        </p>
+        {mode === 'view' && (
+          <button
+            type="button"
+            onClick={enterEditMode}
+            disabled={!canEdit}
+            title={!canEdit ? disabledReason ?? undefined : undefined}
+            className="btn-secondary"
+          >
+            Edytuj
+          </button>
+        )}
+      </div>
+
+      {mode === 'view' && !canEdit && disabledReason && (
+        <div className="rounded-panel border border-line bg-ink-50 px-3 py-2 text-xs text-ink-500">
+          {disabledReason}
+        </div>
+      )}
+
+      {mode === 'view' && success && (
+        <div
+          role="status"
+          className="rounded-panel border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+        >
+          {success}
+        </div>
+      )}
+
+      {mode === 'view' ? (
+        <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <dt className="mb-1 text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">
+              Numer dokumentu
+            </dt>
+            <dd className="text-sm font-mono font-medium text-ink-800">
+              {requestDocumentNumber ?? <span className="font-sans font-normal text-ink-400">-</span>}
+            </dd>
+          </div>
+          <div>
+            <dt className="mb-1 text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">
+              Kanal kontaktu
+            </dt>
+            <dd className="text-sm font-medium text-ink-800">
+              {CONTACT_CHANNEL_LABELS[contactChannel]}
+            </dd>
+          </div>
+          <div className="sm:col-span-2">
+            <dt className="mb-1 text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">
+              Adres korespondencyjny
+            </dt>
+            <dd className="whitespace-pre-wrap break-words text-sm font-medium text-ink-800">
+              {correspondenceAddress}
+            </dd>
+          </div>
+          <div className="sm:col-span-2">
+            <dt className="mb-1 text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">
+              Notatki wewnetrzne
+            </dt>
+            <dd className="whitespace-pre-wrap break-words text-sm font-medium text-ink-800">
+              {internalNotes ?? <span className="font-normal text-ink-400">-</span>}
+            </dd>
+          </div>
+        </dl>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
+                Numer dokumentu
+              </span>
+              <input
+                type="text"
+                value={formRequestDocumentNumber}
+                onChange={(event) => setFormRequestDocumentNumber(event.target.value)}
+                maxLength={MAX_LENGTHS.requestDocumentNumber}
+                className="input-field"
+                placeholder="np. DOC-2026-001"
+              />
+            </label>
+
+            <label className="block">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
+                Kanal kontaktu
+              </span>
+              <select
+                value={formContactChannel}
+                onChange={(event) => setFormContactChannel(event.target.value as ContactChannel)}
+                className="input-field"
+              >
+                {CONTACT_CHANNEL_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {CONTACT_CHANNEL_LABELS[option]}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block sm:col-span-2">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
+                Adres korespondencyjny
+              </span>
+              <textarea
+                value={formCorrespondenceAddress}
+                onChange={(event) => setFormCorrespondenceAddress(event.target.value)}
+                maxLength={MAX_LENGTHS.correspondenceAddress}
+                rows={3}
+                className="input-field"
+                placeholder="Ulica, kod, miejscowosc"
+              />
+            </label>
+
+            <label className="block sm:col-span-2">
+              <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
+                Notatki wewnetrzne
+              </span>
+              <textarea
+                value={formInternalNotes}
+                onChange={(event) => setFormInternalNotes(event.target.value)}
+                maxLength={MAX_LENGTHS.internalNotes}
+                rows={4}
+                className="input-field"
+                placeholder="Opcjonalne notatki operacyjne"
+              />
+            </label>
+          </div>
+
+          {error && (
+            <div
+              role="alert"
+              className="rounded-panel border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <button type="submit" className="btn-primary" disabled={isSaving}>
+              {isSaving ? 'Zapis...' : 'Zapisz zmiany'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelEdit}
+              className="btn-secondary"
+              disabled={isSaving}
+            >
+              Anuluj
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -38,6 +38,7 @@ import {
   syncPortingRequest,
   updatePortingRequestAssignment,
   updatePortingRequestCommercialOwner,
+  updatePortingRequestDetails,
   updatePortingRequestStatus,
   listCommercialOwnerCandidates,
 } from '@/services/portingRequests.api'
@@ -75,6 +76,7 @@ import {
   type CommercialOwnerCandidateDto,
   type NotificationFailureHistoryItemDto,
   type NotificationHealthDiagnosticsDto,
+  type UpdatePortingRequestDetailsDto,
 } from '@np-manager/shared'
 import { PortingAssignmentPanel } from '@/components/PortingAssignmentPanel/PortingAssignmentPanel'
 import { PortingCaseHistory } from '@/components/PortingCaseHistory/PortingCaseHistory'
@@ -88,6 +90,7 @@ import { PliCbdProcessSnapshot } from '@/components/PliCbdProcessSnapshot/PliCbd
 import { PliCbdTechnicalPayloadPreview } from '@/components/PliCbdTechnicalPayloadPreview/PliCbdTechnicalPayloadPreview'
 import { PliCbdXmlPreview } from '@/components/PliCbdXmlPreview/PliCbdXmlPreview'
 import { PortingInternalNotificationsPanel } from '@/components/PortingInternalNotificationsPanel/PortingInternalNotificationsPanel'
+import { RequestOperationalDetailsPanel } from '@/components/RequestOperationalDetailsPanel/RequestOperationalDetailsPanel'
 import { WhatsNextPanel } from '@/components/WhatsNextPanel/WhatsNextPanel'
 import { InternalNotificationAttemptsPanel } from '@/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel'
 import { NotificationFailureHistoryPanel } from '@/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel'
@@ -609,6 +612,16 @@ export function RequestDetailPage() {
     () => ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER'].includes(user?.role ?? ''),
     [user?.role],
   )
+  const canEditDetailsRole = canManageStatus
+  const isRequestClosed = request
+    ? TERMINAL_CLOSED_STATUSES.includes(request.statusInternal)
+    : false
+  const canEditOperationalDetails = canEditDetailsRole && !isRequestClosed
+  const operationalDetailsDisabledReason = !canEditDetailsRole
+    ? 'Twoja rola nie ma uprawnien do edycji danych sprawy.'
+    : isRequestClosed
+      ? 'Sprawa w statusie koncowym — edycja zablokowana.'
+      : null
   const isAdmin = useMemo(() => user?.role === 'ADMIN', [user?.role])
   const canUseInternalNotificationDiagnostics = isAdmin
   const canRetryInternalNotificationAttempts = isAdmin
@@ -1338,6 +1351,28 @@ export function RequestDetailPage() {
     }
   }
 
+  const handleUpdateOperationalDetails = useCallback(
+    async (payload: UpdatePortingRequestDetailsDto) => {
+      if (!id) {
+        throw new Error('Brak identyfikatora sprawy.')
+      }
+
+      try {
+        const updatedRequest = await updatePortingRequestDetails(id, payload)
+        setRequest(updatedRequest)
+        void loadCaseHistory()
+      } catch (err) {
+        if (axios.isAxiosError(err)) {
+          const apiError = err.response?.data as { error?: { message?: string } } | undefined
+          const message = apiError?.error?.message
+          throw new Error(message ?? 'Nie udalo sie zapisac zmian.')
+        }
+        throw err instanceof Error ? err : new Error('Nie udalo sie zapisac zmian.')
+      }
+    },
+    [id, loadCaseHistory],
+  )
+
   const handlePreviewCommunicationDraft = async (
     actionType: PortingRequestCommunicationActionType,
   ) => {
@@ -1856,15 +1891,28 @@ export function RequestDetailPage() {
             </dl>
           </SectionCard>
 
-          <SectionCard title="Dane klienta i kontakt" description="Tozsamosc abonenta, kontakt i notatki operacyjne.">
+          <SectionCard title="Dane klienta i kontakt" description="Tozsamosc abonenta i powiazania operatorskie.">
             <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <Field label="Typ identyfikatora" value={SUBSCRIBER_IDENTITY_TYPE_LABELS[request.identityType]} />
               <Field label="Wartosc identyfikatora" value={request.identityValue} mono />
               <Field label="Usluga hurtowa po stronie biorcy" value={request.linkedWholesaleServiceOnRecipientSide ? 'Tak' : 'Nie'} />
               <Field label="Operator infrastrukturalny" value={request.infrastructureOperator?.name} />
-              <WideField label="Adres korespondencyjny" value={request.correspondenceAddress} />
-              <WideField label="Notatki wewnetrzne" value={request.internalNotes} />
             </dl>
+          </SectionCard>
+
+          <SectionCard
+            title="Dane kontaktowe i operacyjne"
+            description="Edycja operacyjna v1: adres, kanal kontaktu, notatki, numer dokumentu."
+          >
+            <RequestOperationalDetailsPanel
+              correspondenceAddress={request.correspondenceAddress}
+              contactChannel={request.contactChannel}
+              internalNotes={request.internalNotes}
+              requestDocumentNumber={request.requestDocumentNumber}
+              canEdit={canEditOperationalDetails}
+              disabledReason={operationalDetailsDisabledReason}
+              onSave={handleUpdateOperationalDetails}
+            />
           </SectionCard>
 
           <div id="communication-panel" className="scroll-mt-6">

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -3,6 +3,7 @@ import type {
   GlobalNotificationFailureQueueResultDto,
   CommercialOwnerCandidatesResultDto,
   UpdatePortingRequestCommercialOwnerDto,
+  UpdatePortingRequestDetailsDto,
   CommunicationDeliveryAttemptsResultDto,
   CreatePortingRequestDto,
   ExecutePortingRequestExternalActionDto,
@@ -49,6 +50,7 @@ export type PliCbdTechnicalPayloadApiMessageType = 'e03' | 'e12' | 'e18' | 'e23'
 export type PreparePortingCommunicationDraftPayload = PreparePortingCommunicationDraftDto
 export type ExecutePortingRequestExternalActionPayload = ExecutePortingRequestExternalActionDto
 export type UpdatePortingRequestCommercialOwnerPayload = UpdatePortingRequestCommercialOwnerDto
+export type UpdatePortingRequestDetailsPayload = UpdatePortingRequestDetailsDto
 
 function appendListFiltersToQuery(
   query: URLSearchParams,
@@ -523,6 +525,18 @@ export async function listCommercialOwnerCandidates(): Promise<CommercialOwnerCa
   }>('/porting-requests/commercial-owner-candidates')
 
   return response.data.data
+}
+
+export async function updatePortingRequestDetails(
+  id: string,
+  data: UpdatePortingRequestDetailsPayload,
+): Promise<PortingRequestDetailDto> {
+  const response = await apiClient.patch<{
+    success: true
+    data: { request: PortingRequestDetailDto }
+  }>(`/porting-requests/${id}/details`, data)
+
+  return response.data.data.request
 }
 
 export async function updatePortingRequestCommercialOwner(

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -50,6 +50,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR54 | Operacyjny hint v1 w wierszu listy spraw | DONE |
 | PR55 | Ownership signal (Moja / Nieprzypisana) w wierszu listy spraw | DONE |
 | PR56 | Backend test/runtime foundation: vitest config + @fastify/cors alignment | DONE |
+| PR57 | Operational edit v1 w `RequestDetailPage` (correspondenceAddress, contactChannel, internalNotes, requestDocumentNumber) | DONE |
 
 ---
 
@@ -770,6 +771,27 @@ apps/frontend/src/
 6. Commit prefix: `feat(prXXy): opis`
 
 ---
+
+## PR57 — Operational edit v1 (2026-04-23)
+
+Waski zakres edycji 4 pol operacyjnych na `RequestDetailPage`:
+- `correspondenceAddress` (max 1000), `contactChannel` (enum EMAIL/SMS/LETTER), `internalNotes` (max 5000, nullable), `requestDocumentNumber` (max 100, nullable).
+
+Backend:
+- `PATCH /api/porting-requests/:id/details` — Zod schema wymaga >=1 pola, RBAC przez `writeRoles` (ADMIN/BOK_CONSULTANT/BACK_OFFICE/MANAGER).
+- Status gate: `CLOSED_STATUSES` (REJECTED/CANCELLED/PORTED) -> 400 `REQUEST_CLOSED_EDIT_FORBIDDEN`.
+- Per-pole diff: jesli brak zmian, zwraca aktualny detail bez side effects.
+- Audit: per-field `AuditLog` (null/empty -> `BRAK`, truncate >200) + pojedynczy `PortingRequestEvent` NOTE z prefiksem `[DetailsEdit]` (spojne z `[Dispatch]`/`[ErrorFallback]`). Nie rozszerzamy `PortingRequestCaseHistoryEventType`.
+
+Frontend:
+- Nowy komponent `RequestOperationalDetailsPanel` (view/edit toggle, client-side walidacja "no changes" i pustego adresu, maxLength z `MAX_LENGTHS`).
+- Sekcja w `RequestDetailPage`: przeniesione `correspondenceAddress`/`internalNotes` z karty "Dane klienta" do nowej karty "Dane kontaktowe i operacyjne".
+- `canEdit = writeRole && !isClosed`; disabled reason pokazany w tooltipie i inline.
+
+Testy/walidacje:
+- Backend vitest: 8 testow (pelny update + NOTE + 4 audity, partial, no-op, 404, 3x status gate, null clear) — PASS.
+- Backend tsc: clean. Frontend tsc: clean.
+- Frontend vitest/RTL: brak infrastruktury w repo; nie konfigurujemy w tej iteracji (out of v1 scope). Core logika pokryta backendem + client-side diff jest prosty.
 
 ## Kolejne kroki
 

--- a/packages/shared/src/dto/porting-requests.dto.ts
+++ b/packages/shared/src/dto/porting-requests.dto.ts
@@ -190,6 +190,18 @@ export interface UpdatePortingRequestStatusDto {
   comment?: string
 }
 
+/**
+ * Operacyjna edycja danych sprawy v1.
+ * Dozwolony waski zestaw pol kontaktowo/operacyjnych.
+ * Wszystkie pola opcjonalne, przynajmniej jedno musi byc obecne w request.
+ */
+export interface UpdatePortingRequestDetailsDto {
+  correspondenceAddress?: string
+  contactChannel?: ContactChannel
+  internalNotes?: string | null
+  requestDocumentNumber?: string | null
+}
+
 export interface PortingRequestStatusActionDto {
   actionId: PortingRequestStatusActionId
   label: string


### PR DESCRIPTION
## Summary
- Dodaje `PATCH /api/porting-requests/:id/details` (4 pola: correspondenceAddress, contactChannel, internalNotes, requestDocumentNumber) z RBAC `writeRoles` i status gate dla `REJECTED/CANCELLED/PORTED`.
- Per-pole `AuditLog` + pojedynczy `PortingRequestEvent NOTE [DetailsEdit]` (spojne z `[Dispatch]`/`[ErrorFallback]`); brak zmian = brak side effects.
- Frontend: nowy `RequestOperationalDetailsPanel` (view/edit toggle) wpiety w `RequestDetailPage`, `correspondenceAddress`/`internalNotes` przeniesione z karty "Dane klienta" do sekcji "Dane kontaktowe i operacyjne".

## Architektura
- Re-uzycie generycznego audit + NOTE zamiast rozszerzania `PortingRequestCaseHistoryEventType` (brak migracji).
- Fail-closed: status gate i RBAC w backendzie; frontend dodatkowo ukrywa/disabluje Edit z disabled reason.
- Null-normalizacja: pusty string -> null dla pol nullable; diff tylko faktycznie zmienionych pol.
- Limity: correspondenceAddress 1000, internalNotes 5000, requestDocumentNumber 100; audit oldValue/newValue truncate do 200.

## Testy
- Backend vitest (nowy plik `porting-requests.details-edit.service.test.ts`): **8/8 pass** — happy path + per-field audit + `[DetailsEdit]` NOTE, partial update, no-op, 404, `it.each` dla 3 CLOSED_STATUSES, null clear.
- Backend tsc: clean. Frontend tsc: clean.
- Pelne vitest backend: 423 pass; 14 import-time fail w `env.ts` **pre-existing** (niezwiazane z PR57).
- Frontend vitest/RTL: brak infrastruktury w repo — nie konfigurujemy w tej iteracji (poza zakresem v1).

## Test plan
- [ ] Jako BOK_CONSULTANT otworz `RequestDetailPage`, kliknij "Edytuj" w nowej sekcji, zmien 1-4 pola, zapisz. Zweryfikuj historia sprawy: wpis NOTE `[DetailsEdit]` + 1-4 wpisy w audit logu.
- [ ] Zapis bez zmian: klient pokazuje "Nie wprowadzono zmian."; brak requestu do API.
- [ ] Pusty `correspondenceAddress`: klient blokuje; backend Zod rowniez (min(1)).
- [ ] Sprawa w statusie `REJECTED/CANCELLED/PORTED`: Edit disabled z reason; bezposredni PATCH -> 400 `REQUEST_CLOSED_EDIT_FORBIDDEN`.
- [ ] Rola bez uprawnien (np. SALES): Edit disabled z reason; PATCH -> 403.
- [ ] Ustawienie `internalNotes`/`requestDocumentNumber` na pusty input -> audit pokazuje newValue `BRAK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)