### PR TITLE
feat(requests): reczne uzupelnienie daty portowania w trybie manualnym (PR59)

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-request-details-history.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-request-details-history.service.test.ts
@@ -81,7 +81,7 @@ describe('getPortingRequestDetailsHistory', () => {
     })
   })
 
-  it('queries only the 4 details fields with correct filters', async () => {
+  it('queries the 5 editable fields with correct filters', async () => {
     mockPortingRequestFindUnique.mockResolvedValueOnce({ id: 'req-1' })
     mockAuditLogFindMany.mockResolvedValueOnce([])
 

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.port-date-edit.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.port-date-edit.service.test.ts
@@ -1,0 +1,236 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  mockPortingRequestFindUnique,
+  mockTransaction,
+  mockUpdate,
+  mockEventCreate,
+  mockLogAuditEvent,
+  mockGetPortingCommunicationHistoryItems,
+} = vi.hoisted(() => ({
+  mockPortingRequestFindUnique: vi.fn(),
+  mockTransaction: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockEventCreate: vi.fn(),
+  mockLogAuditEvent: vi.fn(),
+  mockGetPortingCommunicationHistoryItems: vi.fn(),
+}))
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    portingRequest: {
+      findUnique: (...args: unknown[]) => mockPortingRequestFindUnique(...args),
+    },
+    $transaction: (...args: unknown[]) => mockTransaction(...args),
+  },
+}))
+
+vi.mock('../../../shared/audit/audit.service', () => ({
+  logAuditEvent: (...args: unknown[]) => mockLogAuditEvent(...args),
+}))
+
+vi.mock('../../pli-cbd/pli-cbd.adapter', () => ({
+  PLI_CBD_TRIGGER_SELECT: {},
+  portingRequestPliCbdAdapter: {},
+}))
+
+vi.mock('../../pli-cbd/pli-cbd.integration-tracker', () => ({
+  createFailedIntegrationAttempt: vi.fn(),
+  getPliCbdIntegrationEvents: vi.fn(),
+  withPliCbdIntegrationTracking: vi.fn(),
+}))
+
+vi.mock('../porting-request-communication.service', async () => {
+  const actual = await vi.importActual<typeof import('../porting-request-communication.service')>(
+    '../porting-request-communication.service',
+  )
+
+  return {
+    ...actual,
+    getPortingCommunicationHistoryItems: (...args: unknown[]) =>
+      mockGetPortingCommunicationHistoryItems(...args),
+  }
+})
+
+import { updatePortingRequestPortDate } from '../porting-requests.service'
+
+function makeCurrent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'req-1',
+    statusInternal: 'SUBMITTED',
+    confirmedPortDate: null,
+    ...overrides,
+  }
+}
+
+function makeDetailRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'req-1',
+    caseNumber: 'FNP-20260101-ABCDEF',
+    clientId: 'client-1',
+    numberType: 'FIXED_LINE',
+    numberRangeKind: 'SINGLE',
+    primaryNumber: '221234567',
+    rangeStart: null,
+    rangeEnd: null,
+    requestDocumentNumber: null,
+    donorRoutingNumber: '2600',
+    recipientRoutingNumber: '2700',
+    sentToExternalSystemAt: null,
+    portingMode: 'DAY',
+    requestedPortDate: null,
+    requestedPortTime: null,
+    earliestAcceptablePortDate: null,
+    confirmedPortDate: null,
+    donorAssignedPortDate: null,
+    donorAssignedPortTime: null,
+    statusInternal: 'SUBMITTED',
+    statusPliCbd: null,
+    pliCbdCaseId: null,
+    pliCbdCaseNumber: null,
+    pliCbdPackageId: null,
+    pliCbdExportStatus: 'NOT_EXPORTED',
+    pliCbdLastSyncAt: null,
+    lastExxReceived: null,
+    lastPliCbdStatusCode: null,
+    lastPliCbdStatusDescription: null,
+    rejectionCode: null,
+    rejectionReason: null,
+    subscriberKind: 'INDIVIDUAL',
+    subscriberFirstName: 'Jan',
+    subscriberLastName: 'Kowalski',
+    subscriberCompanyName: null,
+    identityType: 'PESEL',
+    identityValue: '90010112345',
+    correspondenceAddress: 'Testowa 1, 00-001 Warszawa',
+    hasPowerOfAttorney: true,
+    linkedWholesaleServiceOnRecipientSide: false,
+    contactChannel: 'EMAIL',
+    internalNotes: null,
+    createdByUserId: 'creator-1',
+    assignedAt: null,
+    assignedByUserId: null,
+    commercialOwnerUserId: null,
+    createdAt: new Date('2026-01-01T10:00:00.000Z'),
+    updatedAt: new Date('2026-01-01T10:00:00.000Z'),
+    client: {
+      id: 'client-1',
+      clientType: 'INDIVIDUAL',
+      firstName: 'Jan',
+      lastName: 'Kowalski',
+      companyName: null,
+      email: 'jan.kowalski@example.com',
+      addressStreet: 'Testowa 1',
+      addressCity: 'Warszawa',
+      addressZip: '00-001',
+    },
+    donorOperator: { id: 'op-1', name: 'Donor', shortName: 'DNR', routingNumber: '2600', isActive: true },
+    recipientOperator: { id: 'op-2', name: 'Recipient', shortName: 'RCP', routingNumber: '2700', isActive: true },
+    infrastructureOperator: null,
+    assignedUser: null,
+    commercialOwner: null,
+    events: [],
+    ...overrides,
+  }
+}
+
+describe('updatePortingRequestPortDate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLogAuditEvent.mockResolvedValue(undefined)
+    mockGetPortingCommunicationHistoryItems.mockResolvedValue([])
+    mockTransaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+      cb({
+        portingRequest: { update: (...a: unknown[]) => mockUpdate(...a) },
+        portingRequestEvent: { create: (...a: unknown[]) => mockEventCreate(...a) },
+      }),
+    )
+    mockUpdate.mockResolvedValue({})
+    mockEventCreate.mockResolvedValue({})
+  })
+
+  it('sets confirmedPortDate, writes [PortDateEdit] NOTE and audit entry', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce(makeCurrent())
+    mockPortingRequestFindUnique.mockResolvedValueOnce(
+      makeDetailRow({ confirmedPortDate: new Date('2026-05-15') }),
+    )
+
+    await updatePortingRequestPortDate('req-1', '2026-05-15', 'actor-1', 'BOK_CONSULTANT', '127.0.0.1', 'test')
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'req-1' },
+      data: { confirmedPortDate: new Date('2026-05-15T00:00:00.000Z') },
+    })
+
+    expect(mockEventCreate).toHaveBeenCalledTimes(1)
+    const eventArg = mockEventCreate.mock.calls[0]![0] as { data: { title: string; description: string } }
+    expect(eventArg.data.title).toBe('[PortDateEdit] Reczna zmiana daty przeniesienia numeru')
+    expect(eventArg.data.description).toContain('BRAK -> 2026-05-15')
+
+    expect(mockLogAuditEvent).toHaveBeenCalledTimes(1)
+    expect(mockLogAuditEvent.mock.calls[0]![0]).toMatchObject({
+      fieldName: 'confirmedPortDate',
+      oldValue: 'BRAK',
+      newValue: '2026-05-15',
+    })
+  })
+
+  it('clears confirmedPortDate (null) and writes audit', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce(
+      makeCurrent({ confirmedPortDate: new Date('2026-05-15') }),
+    )
+    mockPortingRequestFindUnique.mockResolvedValueOnce(makeDetailRow())
+
+    await updatePortingRequestPortDate('req-1', null, 'actor-1', 'ADMIN')
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'req-1' },
+      data: { confirmedPortDate: null },
+    })
+
+    expect(mockLogAuditEvent.mock.calls[0]![0]).toMatchObject({
+      fieldName: 'confirmedPortDate',
+      oldValue: '2026-05-15',
+      newValue: 'BRAK',
+    })
+  })
+
+  it('returns current detail without side effects when date is unchanged', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce(
+      makeCurrent({ confirmedPortDate: new Date('2026-05-15') }),
+    )
+    mockPortingRequestFindUnique.mockResolvedValueOnce(makeDetailRow())
+
+    await updatePortingRequestPortDate('req-1', '2026-05-15', 'actor-1', 'ADMIN')
+
+    expect(mockUpdate).not.toHaveBeenCalled()
+    expect(mockEventCreate).not.toHaveBeenCalled()
+    expect(mockLogAuditEvent).not.toHaveBeenCalled()
+  })
+
+  it('throws 404 when request does not exist', async () => {
+    mockPortingRequestFindUnique.mockResolvedValueOnce(null)
+
+    await expect(
+      updatePortingRequestPortDate('missing', '2026-05-15', 'actor-1', 'ADMIN'),
+    ).rejects.toMatchObject({ statusCode: 404 })
+
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it.each(['REJECTED', 'CANCELLED', 'PORTED'] as const)(
+    'rejects edit in terminal status %s',
+    async (statusInternal) => {
+      mockPortingRequestFindUnique.mockResolvedValueOnce(makeCurrent({ statusInternal }))
+
+      await expect(
+        updatePortingRequestPortDate('req-1', '2026-05-15', 'actor-1', 'BOK_CONSULTANT'),
+      ).rejects.toMatchObject({
+        statusCode: 400,
+        code: 'REQUEST_CLOSED_EDIT_FORBIDDEN',
+      })
+
+      expect(mockUpdate).not.toHaveBeenCalled()
+    },
+  )
+})

--- a/apps/backend/src/modules/porting-requests/porting-request-details-history.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-request-details-history.service.ts
@@ -11,6 +11,7 @@ const DETAILS_HISTORY_FIELD_NAMES: DetailsHistoryFieldName[] = [
   'contactChannel',
   'internalNotes',
   'requestDocumentNumber',
+  'confirmedPortDate',
 ]
 
 const DEFAULT_LIMIT = 50

--- a/apps/backend/src/modules/porting-requests/porting-requests.router.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.router.ts
@@ -14,6 +14,7 @@ import {
   updatePortingRequestAssignmentSchema,
   updatePortingRequestCommercialOwnerSchema,
   updatePortingRequestDetailsSchema,
+  updatePortingRequestPortDateSchema,
   updatePortingRequestStatusSchema,
 } from './porting-requests.schema'
 import {
@@ -33,6 +34,7 @@ import {
   updatePortingRequestAssignment,
   updateCommercialOwner,
   updatePortingRequestDetails,
+  updatePortingRequestPortDate,
   updatePortingRequestStatus,
 } from './porting-requests.service'
 import {
@@ -441,6 +443,24 @@ export async function portingRequestsRouter(app: FastifyInstance): Promise<void>
       const portingRequest = await updatePortingRequestDetails(
         request.params.id,
         body,
+        request.user.id,
+        request.user.role as UserRole,
+        request.ip,
+        request.headers['user-agent'],
+      )
+
+      return reply.status(200).send({ success: true, data: { request: portingRequest } })
+    },
+  )
+
+  app.patch<{ Params: { id: string } }>(
+    '/:id/port-date',
+    { preHandler: [authenticate, authorize(writeRoles)] },
+    async (request, reply) => {
+      const body = updatePortingRequestPortDateSchema.parse(request.body)
+      const portingRequest = await updatePortingRequestPortDate(
+        request.params.id,
+        body.confirmedPortDate,
         request.user.id,
         request.user.role as UserRole,
         request.ip,

--- a/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
@@ -359,6 +359,26 @@ const nullableTrimmedString = (max: number) =>
     z.union([z.string().max(max).trim(), z.null()]),
   )
 
+// ============================================================
+// MANUAL PORT DATE EDIT
+// ============================================================
+
+export const updatePortingRequestPortDateSchema = z.object({
+  confirmedPortDate: z.preprocess(
+    (value) => (value === '' ? null : value),
+    z.union([
+      z.string().refine(isValidDateOnly, 'Data musi miec format RRRR-MM-DD'),
+      z.null(),
+    ]),
+  ),
+})
+
+export type UpdatePortingRequestPortDateBody = z.infer<typeof updatePortingRequestPortDateSchema>
+
+// ============================================================
+// OPERATIONAL DETAILS EDIT v1
+// ============================================================
+
 export const updatePortingRequestDetailsSchema = z
   .object({
     correspondenceAddress: z

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -1680,6 +1680,84 @@ export async function updatePortingRequestDetails(
   return getPortingRequest(requestId, userRole)
 }
 
+// ============================================================
+// MANUAL PORT DATE EDIT
+// ============================================================
+
+export async function updatePortingRequestPortDate(
+  requestId: string,
+  confirmedPortDate: string | null,
+  userId: string,
+  userRole: UserRole,
+  ipAddress?: string,
+  userAgent?: string,
+): Promise<PortingRequestDetailDto> {
+  const current = await prisma.portingRequest.findUnique({
+    where: { id: requestId },
+    select: {
+      id: true,
+      statusInternal: true,
+      confirmedPortDate: true,
+    },
+  })
+
+  if (!current) {
+    throw AppError.notFound('Sprawa portowania nie zostala znaleziona.')
+  }
+
+  if (CLOSED_STATUSES.includes(current.statusInternal)) {
+    throw AppError.badRequest(
+      'Nie mozna edytowac danych sprawy w statusie koncowym.',
+      'REQUEST_CLOSED_EDIT_FORBIDDEN',
+    )
+  }
+
+  const currentDateStr = toDateOnlyString(current.confirmedPortDate)
+  if (confirmedPortDate === currentDateStr) {
+    return getPortingRequest(requestId, userRole)
+  }
+
+  const newDateValue = confirmedPortDate ? toDateOnlyValue(confirmedPortDate) ?? null : null
+
+  const oldDisplay = currentDateStr ?? 'BRAK'
+  const newDisplay = confirmedPortDate ?? 'BRAK'
+
+  await prisma.$transaction(async (tx) => {
+    await tx.portingRequest.update({
+      where: { id: requestId },
+      data: { confirmedPortDate: newDateValue },
+    })
+
+    await tx.portingRequestEvent.create({
+      data: {
+        request: { connect: { id: requestId } },
+        eventSource: 'INTERNAL',
+        eventType: 'NOTE',
+        title: '[PortDateEdit] Reczna zmiana daty przeniesienia numeru',
+        description: `Data przeniesienia: ${oldDisplay} -> ${newDisplay}`,
+        statusBefore: current.statusInternal,
+        statusAfter: current.statusInternal,
+        createdBy: { connect: { id: userId } },
+      },
+    })
+  })
+
+  await logAuditEvent({
+    action: 'UPDATE',
+    userId,
+    entityType: 'porting_request',
+    entityId: requestId,
+    requestId,
+    fieldName: 'confirmedPortDate',
+    oldValue: oldDisplay,
+    newValue: newDisplay,
+    ipAddress,
+    userAgent,
+  })
+
+  return getPortingRequest(requestId, userRole)
+}
+
 export async function listCommercialOwnerCandidates(): Promise<CommercialOwnerCandidatesResultDto> {
   const rows = await prisma.user.findMany({
     where: { isActive: true, role: 'SALES' },

--- a/apps/frontend/src/components/RequestDetailsHistoryPanel/RequestDetailsHistoryPanel.tsx
+++ b/apps/frontend/src/components/RequestDetailsHistoryPanel/RequestDetailsHistoryPanel.tsx
@@ -5,6 +5,7 @@ const FIELD_LABELS: Record<DetailsHistoryFieldName, string> = {
   contactChannel: 'Kanal kontaktu',
   internalNotes: 'Notatki wewnetrzne',
   requestDocumentNumber: 'Numer dokumentu',
+  confirmedPortDate: 'Data przeniesienia numeru',
 }
 
 interface RequestDetailsHistoryPanelProps {
@@ -55,7 +56,7 @@ export function RequestDetailsHistoryPanel({
           Historia zmian danych sprawy
         </h2>
         <p className="mt-1 text-sm text-gray-500">
-          Zmiany pol: adres korespondencyjny, kanal kontaktu, notatki, numer dokumentu.
+          Zmiany pol: adres korespondencyjny, kanal kontaktu, notatki, numer dokumentu, data przeniesienia.
         </p>
       </div>
 

--- a/apps/frontend/src/components/RequestPortDatePanel/RequestPortDatePanel.tsx
+++ b/apps/frontend/src/components/RequestPortDatePanel/RequestPortDatePanel.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import type { UpdatePortingRequestPortDateDto } from '@np-manager/shared'
+
+export interface RequestPortDatePanelProps {
+  confirmedPortDate: string | null
+  canEdit: boolean
+  disabledReason?: string | null
+  onSave: (payload: UpdatePortingRequestPortDateDto) => Promise<void>
+}
+
+function todayString(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export function RequestPortDatePanel({
+  confirmedPortDate,
+  canEdit,
+  disabledReason,
+  onSave,
+}: RequestPortDatePanelProps) {
+  const [mode, setMode] = useState<'view' | 'edit'>('view')
+  const [formDate, setFormDate] = useState(confirmedPortDate ?? '')
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  function enterEditMode() {
+    setFormDate(confirmedPortDate ?? '')
+    setError(null)
+    setSuccess(null)
+    setMode('edit')
+  }
+
+  function cancelEdit() {
+    setMode('view')
+    setError(null)
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+
+    const newDate = formDate.trim() === '' ? null : formDate.trim()
+
+    if (newDate === confirmedPortDate) {
+      setError('Nie wprowadzono zmian.')
+      return
+    }
+
+    setError(null)
+    setSuccess(null)
+    setIsSaving(true)
+
+    try {
+      await onSave({ confirmedPortDate: newDate })
+      setSuccess('Data przeniesienia zostala zapisana.')
+      setMode('view')
+    } catch (saveError) {
+      const message =
+        saveError instanceof Error && saveError.message
+          ? saveError.message
+          : 'Nie udalo sie zapisac daty.'
+      setError(message)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <div data-testid="request-port-date-panel" className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm text-ink-500">
+          Wpisz date, ktora operator uzyskal z Adescom lub od dawcy numeru.
+        </p>
+        {mode === 'view' && (
+          <button
+            type="button"
+            onClick={enterEditMode}
+            disabled={!canEdit}
+            title={!canEdit ? (disabledReason ?? undefined) : undefined}
+            className="btn-secondary"
+          >
+            {confirmedPortDate ? 'Zmien' : 'Ustaw date'}
+          </button>
+        )}
+      </div>
+
+      {mode === 'view' && !canEdit && disabledReason && (
+        <div className="rounded-panel border border-line bg-ink-50 px-3 py-2 text-xs text-ink-500">
+          {disabledReason}
+        </div>
+      )}
+
+      {mode === 'view' && success && (
+        <div
+          role="status"
+          className="rounded-panel border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700"
+        >
+          {success}
+        </div>
+      )}
+
+      {mode === 'view' ? (
+        <div>
+          <dt className="mb-1 text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">
+            Wyznaczona data przeniesienia numeru
+          </dt>
+          <dd className="text-sm font-mono font-medium text-ink-800">
+            {confirmedPortDate ?? (
+              <span className="font-sans font-normal text-ink-400">Nie uzupelniono</span>
+            )}
+          </dd>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <label className="block">
+            <span className="mb-1 block text-xs font-semibold uppercase tracking-[0.08em] text-ink-500">
+              Wyznaczona data przeniesienia numeru
+            </span>
+            <input
+              type="date"
+              value={formDate}
+              onChange={(event) => setFormDate(event.target.value)}
+              min={todayString()}
+              className="input-field w-full sm:w-auto"
+            />
+            <p className="mt-1 text-xs text-ink-400">
+              Pozostaw puste, aby usunac date (sprawa bez daty portowania).
+            </p>
+          </label>
+
+          {error && (
+            <div
+              role="alert"
+              className="rounded-panel border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            <button type="submit" className="btn-primary" disabled={isSaving}>
+              {isSaving ? 'Zapis...' : 'Zapisz date'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelEdit}
+              className="btn-secondary"
+              disabled={isSaving}
+            >
+              Anuluj
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -40,6 +40,7 @@ import {
   updatePortingRequestAssignment,
   updatePortingRequestCommercialOwner,
   updatePortingRequestDetails,
+  updatePortingRequestPortDate,
   updatePortingRequestStatus,
   listCommercialOwnerCandidates,
 } from '@/services/portingRequests.api'
@@ -79,6 +80,7 @@ import {
   type PortingRequestDetailsHistoryItemDto,
   type NotificationHealthDiagnosticsDto,
   type UpdatePortingRequestDetailsDto,
+  type UpdatePortingRequestPortDateDto,
 } from '@np-manager/shared'
 import { PortingAssignmentPanel } from '@/components/PortingAssignmentPanel/PortingAssignmentPanel'
 import { PortingCaseHistory } from '@/components/PortingCaseHistory/PortingCaseHistory'
@@ -93,6 +95,7 @@ import { PliCbdTechnicalPayloadPreview } from '@/components/PliCbdTechnicalPaylo
 import { PliCbdXmlPreview } from '@/components/PliCbdXmlPreview/PliCbdXmlPreview'
 import { PortingInternalNotificationsPanel } from '@/components/PortingInternalNotificationsPanel/PortingInternalNotificationsPanel'
 import { RequestOperationalDetailsPanel } from '@/components/RequestOperationalDetailsPanel/RequestOperationalDetailsPanel'
+import { RequestPortDatePanel } from '@/components/RequestPortDatePanel/RequestPortDatePanel'
 import { RequestDetailsHistoryPanel } from '@/components/RequestDetailsHistoryPanel/RequestDetailsHistoryPanel'
 import { WhatsNextPanel } from '@/components/WhatsNextPanel/WhatsNextPanel'
 import { InternalNotificationAttemptsPanel } from '@/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel'
@@ -638,6 +641,8 @@ export function RequestDetailPage() {
   const canUsePliCbdExternalActions = systemCapabilities.pliCbd.capabilities.externalActions
   const canShowPliCbdSection =
     isAdmin && (canUsePliCbdDiagnostics || canUsePliCbdExport || canUsePliCbdSync)
+  const isManualMode = !systemCapabilities.pliCbd.active
+  const canEditPortDate = canEditDetailsRole && !isRequestClosed
   const canShowPliCbdDiagnostics = isAdmin && canUsePliCbdDiagnostics
   const canShowPliCbdOperationalMeta = shouldShowPliCbdOperationalMeta(systemCapabilities)
   const canManageAssignment = useMemo(() => canManagePortingOwnership(user?.role), [user?.role])
@@ -1398,6 +1403,29 @@ export function RequestDetailPage() {
     [id, loadCaseHistory],
   )
 
+  const handleUpdatePortDate = useCallback(
+    async (payload: UpdatePortingRequestPortDateDto) => {
+      if (!id) {
+        throw new Error('Brak identyfikatora sprawy.')
+      }
+
+      try {
+        const updatedRequest = await updatePortingRequestPortDate(id, payload)
+        setRequest(updatedRequest)
+        void loadCaseHistory()
+        void loadDetailsHistory()
+      } catch (err) {
+        if (axios.isAxiosError(err)) {
+          const apiError = err.response?.data as { error?: { message?: string } } | undefined
+          const message = apiError?.error?.message
+          throw new Error(message ?? 'Nie udalo sie zapisac daty.')
+        }
+        throw err instanceof Error ? err : new Error('Nie udalo sie zapisac daty.')
+      }
+    },
+    [id, loadCaseHistory],
+  )
+
   const handlePreviewCommunicationDraft = async (
     actionType: PortingRequestCommunicationActionType,
   ) => {
@@ -1915,6 +1943,20 @@ export function RequestDetailPage() {
               <Field label="Pelnomocnictwo" value={request.hasPowerOfAttorney ? 'Tak' : 'Nie'} />
             </dl>
           </SectionCard>
+
+          {isManualMode && (
+            <SectionCard
+              title="Dane portowania"
+              description="Reczne uzupelnienie wyznaczonej daty przeniesienia numeru (tryb manualny)."
+            >
+              <RequestPortDatePanel
+                confirmedPortDate={request.confirmedPortDate}
+                canEdit={canEditPortDate}
+                disabledReason={operationalDetailsDisabledReason}
+                onSave={handleUpdatePortDate}
+              />
+            </SectionCard>
+          )}
 
           <SectionCard title="Dane klienta i kontakt" description="Tozsamosc abonenta i powiazania operatorskie.">
             <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -4,6 +4,7 @@ import type {
   CommercialOwnerCandidatesResultDto,
   UpdatePortingRequestCommercialOwnerDto,
   UpdatePortingRequestDetailsDto,
+  UpdatePortingRequestPortDateDto,
   CommunicationDeliveryAttemptsResultDto,
   CreatePortingRequestDto,
   ExecutePortingRequestExternalActionDto,
@@ -52,6 +53,7 @@ export type PreparePortingCommunicationDraftPayload = PreparePortingCommunicatio
 export type ExecutePortingRequestExternalActionPayload = ExecutePortingRequestExternalActionDto
 export type UpdatePortingRequestCommercialOwnerPayload = UpdatePortingRequestCommercialOwnerDto
 export type UpdatePortingRequestDetailsPayload = UpdatePortingRequestDetailsDto
+export type UpdatePortingRequestPortDatePayload = UpdatePortingRequestPortDateDto
 
 function appendListFiltersToQuery(
   query: URLSearchParams,
@@ -547,6 +549,18 @@ export async function updatePortingRequestDetails(
     success: true
     data: { request: PortingRequestDetailDto }
   }>(`/porting-requests/${id}/details`, data)
+
+  return response.data.data.request
+}
+
+export async function updatePortingRequestPortDate(
+  id: string,
+  data: UpdatePortingRequestPortDatePayload,
+): Promise<PortingRequestDetailDto> {
+  const response = await apiClient.patch<{
+    success: true
+    data: { request: PortingRequestDetailDto }
+  }>(`/porting-requests/${id}/port-date`, data)
 
   return response.data.data.request
 }

--- a/docs/PROJECT_CONTINUITY.md
+++ b/docs/PROJECT_CONTINUITY.md
@@ -52,6 +52,7 @@ Dokument dla kolejnych sesji AI/deweloperskich. Opisuje stan, decyzje architekto
 | PR56 | Backend test/runtime foundation: vitest config + @fastify/cors alignment | DONE |
 | PR57 | Operational edit v1 w `RequestDetailPage` (correspondenceAddress, contactChannel, internalNotes, requestDocumentNumber) | DONE |
 | PR58 | Historia zmian danych sprawy v1 w `RequestDetailPage` (read path dla AuditLog tych 4 pol) | DONE |
+| PR59 | Reczne uzupelnienie confirmedPortDate w trybie manualnym (PATCH /port-date + RequestPortDatePanel) | DONE |
 
 ---
 
@@ -819,6 +820,45 @@ Testy/walidacje:
 - Backend: 6 nowych testow jednostkowych serwisu (mapowanie, filtr 4 pol, empty, 404, BRAK, null) — PASS.
 - Backend tsc: clean. Frontend tsc: clean.
 - Frontend vitest: 271/271 PASS (brak RTL dla nowego komponentu — prosta prezentacja, core logika pokryta backendem).
+
+## PR59 — Reczne uzupelnienie confirmedPortDate w trybie manualnym (2026-04-23)
+
+Waski pionowy slice: operator w trybie manualnym moze recznie uzupelnic wyznaczona date przeniesienia numeru uzyskana z Adescom / od dawcy.
+
+Architektura:
+- **Dedykowany endpoint**: `PATCH /api/porting-requests/:id/port-date`.
+  - Body: `{ confirmedPortDate: string | null }` (YYYY-MM-DD lub null).
+  - RBAC: `writeRoles` (ADMIN, BOK_CONSULTANT, BACK_OFFICE, MANAGER).
+  - Status gate: CLOSED_STATUSES blokuje edycje (`REQUEST_CLOSED_EDIT_FORBIDDEN`).
+  - No-op: jesli ta sama wartosc, zwraca aktualny detail bez side effects.
+  - Audit: `AuditLog` entry z `fieldName: 'confirmedPortDate'`.
+  - Historia: `PortingRequestEvent NOTE` z prefiksem `[PortDateEdit]`.
+
+Shared:
+- `UpdatePortingRequestPortDateDto` (nowy) — kontrakt body PATCH.
+- `DetailsHistoryFieldName` — dodano `confirmedPortDate` (5 pol zamiast 4).
+
+Backend:
+- `updatePortingRequestPortDateSchema` w `porting-requests.schema.ts`.
+- `updatePortingRequestPortDate()` w `porting-requests.service.ts`.
+- PATCH `/:id/port-date` w `porting-requests.router.ts`.
+- `confirmedPortDate` dodany do `DETAILS_HISTORY_FIELD_NAMES` w `porting-request-details-history.service.ts` — historia zmian dostepna przez istniejacy endpoint i panel `RequestDetailsHistoryPanel`.
+
+Frontend:
+- Nowy komponent `RequestPortDatePanel` (view/edit/save toggle, analogia do `RequestOperationalDetailsPanel`).
+- Nowa sekcja `Dane portowania` w `RequestDetailPage` — widoczna tylko gdy `!systemCapabilities.pliCbd.active` (tryb manualny/standalone).
+- `FIELD_LABELS['confirmedPortDate']` dodany w `RequestDetailsHistoryPanel` (label: `Data przeniesienia numeru`).
+- `updatePortingRequestPortDate()` w `portingRequests.api.ts`.
+
+Testy/walidacja:
+- Backend: nowy plik testowy `porting-requests.port-date-edit.service.test.ts` — 7 testow (set date, clear, no-op, 404, 3x status gate) — PASS.
+- Backend tsc: clean. Frontend tsc: clean.
+- Frontend vitest: 271/271 PASS (tyle samo co przed).
+
+Decyzje:
+- Endpoint dedykowany (nie przez /details) — inna semantyka domenowa.
+- Sekcja widoczna tylko w trybie manualnym (fail-closed zgodne z istniejacym wzorcem capabilities).
+- Historia `confirmedPortDate` trafia do istniejacego panelu `RequestDetailsHistoryPanel` bez nowych endpointow.
 
 ## Kolejne kroki
 

--- a/packages/shared/src/dto/porting-request-details-history.dto.ts
+++ b/packages/shared/src/dto/porting-request-details-history.dto.ts
@@ -5,6 +5,7 @@ export type DetailsHistoryFieldName =
   | 'contactChannel'
   | 'internalNotes'
   | 'requestDocumentNumber'
+  | 'confirmedPortDate'
 
 export interface PortingRequestDetailsHistoryItemDto {
   id: string

--- a/packages/shared/src/dto/porting-requests.dto.ts
+++ b/packages/shared/src/dto/porting-requests.dto.ts
@@ -202,6 +202,11 @@ export interface UpdatePortingRequestDetailsDto {
   requestDocumentNumber?: string | null
 }
 
+/** Ręczne uzupełnienie wyznaczonej daty przeniesienia numeru (tryb manualny). */
+export interface UpdatePortingRequestPortDateDto {
+  confirmedPortDate: string | null
+}
+
 export interface PortingRequestStatusActionDto {
   actionId: PortingRequestStatusActionId
   label: string


### PR DESCRIPTION
## Summary

- Dodano dedykowany endpoint `PATCH /api/porting-requests/:id/port-date` do ręcznego ustawiania `confirmedPortDate`
- Nowy komponent `RequestPortDatePanel` w `RequestDetailPage` — sekcja „Dane portowania" widoczna tylko w trybie manualnym (`!pliCbd.active`)
- Zmiana audytowalna: `AuditLog` (fieldName: `confirmedPortDate`) + `PortingRequestEvent NOTE` z prefiksem `[PortDateEdit]`
- Historia zmian daty widoczna w istniejącym `RequestDetailsHistoryPanel` (rozszerzono `DetailsHistoryFieldName` i `DETAILS_HISTORY_FIELD_NAMES`)

## Kontekst

W trybie STANDALONE operator poznaje wyznaczoną datę przeniesienia numeru bezpośrednio z Adescom / od dawcy. Dotąd nie było w aplikacji miejsca na jej zapisanie — ta sekcja wypełnia tę lukę operacyjną.

## Decyzje architektoniczne

- **Dedykowany endpoint** (`/port-date`) zamiast rozszerzania `/details` — inna semantyka domenowa (scheduling vs. dane kontaktowe)
- **Gate na capabilities**: sekcja UI widoczna tylko gdy `!systemCapabilities.pliCbd.active` — w trybie PLI CBD integrated data pochodzi z zewnętrznego systemu przez `SET_PORT_DATE`
- **Historia reużywa istniejącej infrastruktury**: `confirmedPortDate` dodany do `DETAILS_HISTORY_FIELD_NAMES` → brak nowego endpointu/panelu

## Zmienione pliki

| Warstwa | Plik |
|---------|------|
| Shared DTO | `porting-request-details-history.dto.ts`, `porting-requests.dto.ts` |
| Backend schema | `porting-requests.schema.ts` |
| Backend service | `porting-requests.service.ts` |
| Backend router | `porting-requests.router.ts` |
| Backend history | `porting-request-details-history.service.ts` |
| Backend tests (nowy) | `porting-requests.port-date-edit.service.test.ts` (7 testów) |
| Frontend API | `portingRequests.api.ts` |
| Frontend komponent (nowy) | `RequestPortDatePanel/RequestPortDatePanel.tsx` |
| Frontend page | `RequestDetailPage.tsx` |
| Frontend history panel | `RequestDetailsHistoryPanel.tsx` |
| Docs | `PROJECT_CONTINUITY.md` |

## Test plan

- [ ] Tryb manualny (STANDALONE): sekcja „Dane portowania" widoczna w detalu sprawy
- [ ] Tryb PLI CBD integrated: sekcja ukryta
- [ ] Ustaw datę: `2026-06-15` → zapis, powrót do widoku, data widoczna
- [ ] Zmień datę: inna data → zapis, data zaktualizowana
- [ ] Wyczyść datę: puste pole → zapis, `confirmedPortDate = null`, wyświetla „Nie uzupełniono"
- [ ] No-op: ta sama data → brak zapisu, brak eventu
- [ ] Status gate: sprawa PORTED/REJECTED/CANCELLED → przycisk disabled
- [ ] RBAC: rola SALES/AUDITOR → przycisk disabled
- [ ] Historia zmian: wpis `Data przeniesienia numeru` pojawia się w panelu historii
- [ ] Backend: 7/7 testów nowego pliku PASS, 436/436 istniejących PASS
- [ ] Frontend: 271/271 PASS, tsc clean obu apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)