### PR TITLE
fix(frontend): popraw polska odmiane licznika spraw na RequestsPage

### DIFF
--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -64,6 +64,7 @@ import {
   parseQuickWorkFilter,
   type RequestsQuickWorkFilter,
 } from './requestsOperational'
+import { pluralizeRequests } from './pluralizeRequests'
 
 const PAGE_SIZE = 20
 const PORTING_MODES: PortingMode[] = ['DAY', 'END', 'EOP']
@@ -158,10 +159,6 @@ function formatDate(iso: string): string {
     month: '2-digit',
     year: 'numeric',
   })
-}
-
-function pluralizeRequests(total: number): string {
-  return total === 1 ? 'sprawa' : total < 5 ? 'sprawy' : 'spraw'
 }
 
 function getSummaryCardTone(cardId: 'ALL' | 'WITH_OWNER' | 'WITHOUT_OWNER' | 'MINE' | 'HAS_FAILURES') {

--- a/apps/frontend/src/pages/Requests/pluralizeRequests.test.ts
+++ b/apps/frontend/src/pages/Requests/pluralizeRequests.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { pluralizeRequests } from './pluralizeRequests'
+
+describe('pluralizeRequests', () => {
+  it('uses "spraw" for 0', () => {
+    expect(pluralizeRequests(0)).toBe('spraw')
+  })
+
+  it('uses "sprawa" for 1', () => {
+    expect(pluralizeRequests(1)).toBe('sprawa')
+  })
+
+  it.each([2, 3, 4, 22, 23, 24, 102, 103, 104])('uses "sprawy" for %i', (n) => {
+    expect(pluralizeRequests(n)).toBe('sprawy')
+  })
+
+  it.each([5, 6, 10, 11, 12, 13, 14, 15, 20, 21, 25, 100, 101, 112, 113, 114])(
+    'uses "spraw" for %i',
+    (n) => {
+      expect(pluralizeRequests(n)).toBe('spraw')
+    },
+  )
+})

--- a/apps/frontend/src/pages/Requests/pluralizeRequests.ts
+++ b/apps/frontend/src/pages/Requests/pluralizeRequests.ts
@@ -1,0 +1,7 @@
+export function pluralizeRequests(total: number): string {
+  if (total === 1) return 'sprawa'
+  const mod10 = total % 10
+  const mod100 = total % 100
+  if (mod10 >= 2 && mod10 <= 4 && (mod100 < 12 || mod100 > 14)) return 'sprawy'
+  return 'spraw'
+}


### PR DESCRIPTION
## Summary
- `pluralizeRequests(0)` zwracal `"sprawy"` zamiast `"spraw"` — widoczne w `PageHeader.description` oraz w badge "Lista spraw" gdy lista pusta (np. search bez wynikow).
- Funkcja nie obslugiwala tez 12-14 (powinno byc `"spraw"`) ani 22-24 (powinno byc `"sprawy"`). Nowa implementacja stosuje pelne reguly polskiej pluralizacji (mod10 / mod100).
- Funkcja wyekstrahowana do `pluralizeRequests.ts`, dodane jednostkowe testy.

## Why
Manualny QA RequestsPage ujawnil, ze po wyszukiwaniu bez wynikow UI pokazuje "0 sprawy". Fix wypada drobny, ale regresja byla widoczna dla operatora przy kazdym pustym stanie.

## Zakres
- Brak zmian backend / DTO / routing / workflow / sortowania / paginacji / assignToMe.
- Zmiany tylko frontend: [pluralizeRequests.ts](apps/frontend/src/pages/Requests/pluralizeRequests.ts), [pluralizeRequests.test.ts](apps/frontend/src/pages/Requests/pluralizeRequests.test.ts), [RequestsPage.tsx](apps/frontend/src/pages/Requests/RequestsPage.tsx).

## Test plan
- [x] `tsc --noEmit` (apps/frontend)
- [x] `vitest run` — 310/310 passed (w tym 27 nowych testow `pluralizeRequests`)
- [x] `vite build`
- [ ] Manualna weryfikacja empty state listy (search bez wynikow) -> "0 spraw"

🤖 Generated with [Claude Code](https://claude.com/claude-code)