### PR TITLE
[codex] add request detail command center

### DIFF
--- a/apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { NotificationHealthDiagnosticsDto } from '@np-manager/shared'
+import type { PortingUrgency } from '@/lib/portingUrgency'
+import { RequestAttentionStrip, RequestCaseHero } from './RequestCommandCenter'
+
+const HEALTH_OK: NotificationHealthDiagnosticsDto = {
+  status: 'OK',
+  failureCount: 0,
+  failedCount: 0,
+  misconfiguredCount: 0,
+  lastFailureAt: null,
+  lastFailureOutcome: null,
+}
+
+const HEALTH_FAILED: NotificationHealthDiagnosticsDto = {
+  status: 'FAILED',
+  failureCount: 2,
+  failedCount: 2,
+  misconfiguredCount: 0,
+  lastFailureAt: '2026-04-24T08:00:00.000Z',
+  lastFailureOutcome: 'FAILED',
+}
+
+const URGENCY: PortingUrgency = {
+  level: 'TODAY',
+  label: 'Dzis',
+  tone: 'red',
+  emphasized: true,
+  daysDiff: 0,
+}
+
+const BASE_REQUEST = {
+  caseNumber: 'NP-2026-0007',
+  client: {
+    id: 'client-1',
+    clientType: 'BUSINESS' as const,
+    displayName: 'Acme Sp. z o.o.',
+  },
+  numberDisplay: '500123456',
+  subscriberDisplayName: 'Acme Sp. z o.o.',
+  donorOperator: {
+    id: 'op-1',
+    name: 'Operator Dawca',
+    shortName: 'DAW',
+    routingNumber: '100',
+  },
+  recipientOperator: {
+    id: 'op-2',
+    name: 'Operator Biorca',
+    shortName: 'BIO',
+    routingNumber: '200',
+  },
+  portingMode: 'DAY' as const,
+  confirmedPortDate: '2026-04-24',
+  requestedPortDate: '2026-04-24',
+  donorAssignedPortDate: null,
+  donorAssignedPortTime: null,
+  statusInternal: 'SUBMITTED' as const,
+  assignedUser: {
+    id: 'user-1',
+    email: 'anna.bok@example.com',
+    displayName: 'Anna BOK',
+    role: 'BOK_CONSULTANT' as const,
+  },
+  commercialOwner: {
+    id: 'sales-1',
+    email: 'sales@example.com',
+    displayName: 'Jan Sales',
+    role: 'SALES' as const,
+  },
+  notificationHealth: HEALTH_OK,
+}
+
+describe('RequestCommandCenter', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders case hero with case number, client, number, routing and owners', () => {
+    render(
+      <MemoryRouter>
+        <RequestCaseHero
+          request={BASE_REQUEST}
+          urgency={URGENCY}
+          copyLinkDone={false}
+          onBackToList={vi.fn()}
+          onCopyLink={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('NP-2026-0007')).toBeDefined()
+    expect(screen.getAllByText('Acme Sp. z o.o.').length).toBeGreaterThan(0)
+    expect(screen.getByText('500123456')).toBeDefined()
+    expect(screen.getByText(/Operator Dawca/)).toBeDefined()
+    expect(screen.getByText('Anna BOK')).toBeDefined()
+    expect(screen.getByText('Jan Sales')).toBeDefined()
+  })
+
+  it('prioritizes the first three attention signals and wires alert actions', () => {
+    const onScrollToNotifications = vi.fn()
+
+    render(
+      <RequestAttentionStrip
+        request={{
+          ...BASE_REQUEST,
+          statusInternal: 'ERROR',
+          assignedUser: null,
+          confirmedPortDate: null,
+          notificationHealth: HEALTH_FAILED,
+        }}
+        canManageAssignment
+        canManageStatus
+        workflowErrorMessage="Sprawdz panel akcji statusu."
+        onScrollToAssignment={vi.fn()}
+        onScrollToNotifications={onScrollToNotifications}
+        onScrollToPortingDates={vi.fn()}
+        onScrollToStatusActions={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Sprawa jest w stanie bledu')).toBeDefined()
+    expect(screen.getByText('Problemy z notyfikacjami wewnetrznymi')).toBeDefined()
+    expect(screen.getByText('Brak przypisania BOK')).toBeDefined()
+    expect(screen.queryByText('Brak potwierdzonej daty przeniesienia')).toBeNull()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sprawdz notyfikacje' }))
+    expect(onScrollToNotifications).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/frontend/src/pages/Requests/RequestCommandCenter.tsx
+++ b/apps/frontend/src/pages/Requests/RequestCommandCenter.tsx
@@ -1,0 +1,416 @@
+import { AlertBanner, Badge, Button, ButtonLink, DataField, SectionCard, type BadgeTone, cx } from '@/components/ui'
+import { ROUTES } from '@/constants/routes'
+import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
+import type { PortingUrgency } from '@/lib/portingUrgency'
+import {
+  PORTING_CASE_STATUS_LABELS,
+  PORTING_MODE_LABELS,
+  type NotificationHealthDiagnosticsDto,
+  type PortingRequestDetailDto,
+} from '@np-manager/shared'
+
+type CommandCenterRequest = Pick<
+  PortingRequestDetailDto,
+  | 'caseNumber'
+  | 'client'
+  | 'numberDisplay'
+  | 'subscriberDisplayName'
+  | 'donorOperator'
+  | 'recipientOperator'
+  | 'portingMode'
+  | 'confirmedPortDate'
+  | 'requestedPortDate'
+  | 'donorAssignedPortDate'
+  | 'donorAssignedPortTime'
+  | 'statusInternal'
+  | 'assignedUser'
+  | 'commercialOwner'
+  | 'notificationHealth'
+>
+
+interface RequestCaseHeroProps {
+  request: CommandCenterRequest
+  urgency: PortingUrgency
+  copyLinkDone: boolean
+  onBackToList: () => void
+  onCopyLink: () => void
+}
+
+interface RequestAttentionStripProps {
+  request: Pick<
+    CommandCenterRequest,
+    'assignedUser' | 'confirmedPortDate' | 'notificationHealth' | 'statusInternal'
+  >
+  canManageAssignment: boolean
+  canManageStatus: boolean
+  workflowErrorMessage: string
+  onScrollToAssignment: () => void
+  onScrollToNotifications: () => void
+  onScrollToPortingDates: () => void
+  onScrollToStatusActions: () => void
+}
+
+interface RequestMetaGridProps {
+  request: CommandCenterRequest
+  urgency: PortingUrgency
+}
+
+type AttentionTone = 'warning' | 'danger' | 'neutral'
+
+interface AttentionItem {
+  key: string
+  tone: AttentionTone
+  title: string
+  description: string
+  actionLabel?: string
+  onAction?: () => void
+}
+
+const MAX_ATTENTION_ITEMS = 3
+
+function getStatusTone(status: ReturnType<typeof getPortingStatusMeta>['tone']): BadgeTone {
+  const toneByStatus: Record<ReturnType<typeof getPortingStatusMeta>['tone'], BadgeTone> = {
+    gray: 'neutral',
+    blue: 'brand',
+    amber: 'amber',
+    green: 'green',
+    red: 'red',
+    emerald: 'emerald',
+  }
+
+  return toneByStatus[status]
+}
+
+function getNotificationHealthBadge(health: NotificationHealthDiagnosticsDto): {
+  label: string
+  tone: BadgeTone
+} {
+  if (health.status === 'OK') {
+    return { label: 'OK', tone: 'emerald' }
+  }
+
+  const labelByStatus: Record<Exclude<NotificationHealthDiagnosticsDto['status'], 'OK'>, string> = {
+    FAILED: 'Blad wysylki',
+    MISCONFIGURED: 'Blad konfiguracji',
+    MIXED: 'Bledy mieszane',
+  }
+
+  return {
+    label: `${labelByStatus[health.status]} (${health.failureCount})`,
+    tone: health.status === 'MISCONFIGURED' ? 'amber' : 'red',
+  }
+}
+
+function buildAttentionItems({
+  canManageAssignment,
+  canManageStatus,
+  request,
+  workflowErrorMessage,
+  onScrollToAssignment,
+  onScrollToNotifications,
+  onScrollToPortingDates,
+  onScrollToStatusActions,
+}: RequestAttentionStripProps): AttentionItem[] {
+  const items: AttentionItem[] = []
+
+  if (request.statusInternal === 'ERROR') {
+    items.push({
+      key: 'status-error',
+      tone: 'danger',
+      title: 'Sprawa jest w stanie bledu',
+      description: workflowErrorMessage,
+      actionLabel: canManageStatus ? 'Przejdz do akcji' : undefined,
+      onAction: canManageStatus ? onScrollToStatusActions : undefined,
+    })
+  }
+
+  if (request.notificationHealth.status !== 'OK' && request.notificationHealth.failureCount > 0) {
+    items.push({
+      key: 'notification-health',
+      tone: request.notificationHealth.status === 'MISCONFIGURED' ? 'warning' : 'danger',
+      title: 'Problemy z notyfikacjami wewnetrznymi',
+      description: `Wykryto ${request.notificationHealth.failureCount} problemow transportu notyfikacji dla tej sprawy.`,
+      actionLabel: 'Sprawdz notyfikacje',
+      onAction: onScrollToNotifications,
+    })
+  }
+
+  if (!request.assignedUser) {
+    items.push({
+      key: 'unassigned',
+      tone: 'warning',
+      title: 'Brak przypisania BOK',
+      description: 'Sprawa nie ma aktualnie przypisanego operatora odpowiedzialnego za obsluge.',
+      actionLabel: canManageAssignment ? 'Przypisz operatora' : 'Zobacz przypisanie',
+      onAction: onScrollToAssignment,
+    })
+  }
+
+  if (!request.confirmedPortDate) {
+    items.push({
+      key: 'missing-port-date',
+      tone: 'warning',
+      title: 'Brak potwierdzonej daty przeniesienia',
+      description: 'Termin przeniesienia nie zostal jeszcze potwierdzony w danych sprawy.',
+      actionLabel: 'Zobacz terminy',
+      onAction: onScrollToPortingDates,
+    })
+  }
+
+  if (!canManageStatus) {
+    items.push({
+      key: 'read-only',
+      tone: 'neutral',
+      title: 'Tryb podgladu dla tej roli',
+      description: 'Akcje statusowe sa niedostepne dla Twoich aktualnych uprawnien.',
+    })
+  }
+
+  return items.slice(0, MAX_ATTENTION_ITEMS)
+}
+
+function OwnerValue({
+  email,
+  name,
+  fallback,
+  warning = false,
+}: {
+  email?: string
+  name: string | null | undefined
+  fallback: string
+  warning?: boolean
+}) {
+  if (!name) {
+    return <span className={warning ? 'text-amber-800' : 'text-ink-400'}>{fallback}</span>
+  }
+
+  return (
+    <span className="block space-y-0.5">
+      <span className="block font-semibold text-ink-900">{name}</span>
+      {email && <span className="block text-xs font-normal text-ink-500">{email}</span>}
+    </span>
+  )
+}
+
+export function RequestCaseHero({
+  copyLinkDone,
+  request,
+  urgency,
+  onBackToList,
+  onCopyLink,
+}: RequestCaseHeroProps) {
+  const statusMeta = getPortingStatusMeta(request.statusInternal)
+  const healthBadge = getNotificationHealthBadge(request.notificationHealth)
+
+  return (
+    <section className="overflow-hidden rounded-panel border border-line bg-surface shadow-sm">
+      <div className="border-b border-line px-5 py-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <Button onClick={onBackToList} variant="ghost" size="sm" className="-ml-2 self-start">
+            {'<-'} Sprawy portowania
+          </Button>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button onClick={onCopyLink} variant="ghost" size="sm">
+              {copyLinkDone ? 'Skopiowano' : 'Kopiuj link'}
+            </Button>
+            <ButtonLink to={ROUTES.REQUEST_NEW} variant="secondary" size="sm">
+              + Nowa sprawa
+            </ButtonLink>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-0 xl:grid-cols-[minmax(0,1.45fr)_minmax(360px,0.75fr)]">
+        <div className="px-5 py-5">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge tone={getStatusTone(statusMeta.tone)} leadingDot>
+              {statusMeta.label}
+            </Badge>
+            <Badge tone="brand">{PORTING_MODE_LABELS[request.portingMode]}</Badge>
+            <Badge
+              tone={urgency.tone}
+              className={urgency.emphasized ? 'ring-2' : undefined}
+              aria-label={`Pilnosc sprawy: ${urgency.label}`}
+            >
+              Pilnosc: {urgency.label}
+            </Badge>
+            <Badge tone={healthBadge.tone}>Notyfikacje: {healthBadge.label}</Badge>
+          </div>
+
+          <div className="mt-4 max-w-4xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-ink-400">
+              Sprawa
+            </p>
+            <h1 className="mt-1 break-words font-mono text-3xl font-semibold tracking-tight text-ink-950 md:text-4xl">
+              {request.caseNumber}
+            </h1>
+            <p className="mt-3 text-2xl font-semibold tracking-tight text-ink-900">
+              {request.client.displayName}
+            </p>
+            <p className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm font-medium text-ink-500">
+              <span className="font-mono text-ink-800">{request.numberDisplay}</span>
+              <span>{request.subscriberDisplayName}</span>
+              <span>
+                {request.donorOperator.name} {'->'} {request.recipientOperator.name}
+              </span>
+            </p>
+          </div>
+        </div>
+
+        <div className="border-t border-line bg-ink-50/70 px-5 py-5 xl:border-l xl:border-t-0">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-ink-400">
+            Sygnały operacyjne
+          </p>
+          <dl className="mt-4 divide-y divide-line">
+            <DataField
+              className="pb-3"
+              label="Data przeniesienia"
+              value={request.confirmedPortDate ?? request.donorAssignedPortDate}
+              emptyText="Brak daty"
+              mono
+              variant="compact"
+            />
+            <DataField
+              className="py-3"
+              label="Przypisanie BOK"
+              value={
+                <OwnerValue
+                  name={request.assignedUser?.displayName}
+                  email={request.assignedUser?.email}
+                  fallback="Nieprzypisana"
+                  warning
+                />
+              }
+              variant="compact"
+            />
+            <DataField
+              className="py-3"
+              label="Opiekun handlowy"
+              value={
+                <OwnerValue
+                  name={request.commercialOwner?.displayName}
+                  email={request.commercialOwner?.email}
+                  fallback="Brak opiekuna"
+                  warning
+                />
+              }
+              variant="compact"
+            />
+            <DataField
+              className="pt-3"
+              label="Status procesu"
+              value={PORTING_CASE_STATUS_LABELS[request.statusInternal]}
+              variant="compact"
+            />
+          </dl>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export function RequestAttentionStrip(props: RequestAttentionStripProps) {
+  const items = buildAttentionItems(props)
+
+  if (items.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className={cx(
+        'grid gap-3',
+        items.length === 2 && 'xl:grid-cols-2',
+        items.length >= 3 && 'xl:grid-cols-3',
+      )}
+    >
+      {items.map((item) => (
+        <AlertBanner
+          key={item.key}
+          tone={item.tone}
+          title={item.title}
+          description={item.description}
+          action={
+            item.actionLabel && item.onAction ? (
+              <Button onClick={item.onAction} variant="secondary" size="sm">
+                {item.actionLabel}
+              </Button>
+            ) : undefined
+          }
+        />
+      ))}
+    </div>
+  )
+}
+
+export function RequestMetaGrid({ request, urgency }: RequestMetaGridProps) {
+  const healthBadge = getNotificationHealthBadge(request.notificationHealth)
+
+  return (
+    <SectionCard
+      title="Operacyjny skrót"
+      description="Najważniejsze dane do szybkiej oceny sprawy."
+      padding="md"
+    >
+      <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <DataField
+          label="Status"
+          value={PORTING_CASE_STATUS_LABELS[request.statusInternal]}
+          variant="compact"
+        />
+        <DataField
+          label="Pilność"
+          value={
+            <Badge tone={urgency.tone} className={urgency.emphasized ? 'ring-2' : undefined}>
+              {urgency.label}
+            </Badge>
+          }
+          variant="compact"
+        />
+        <DataField
+          label="Potwierdzona data"
+          value={request.confirmedPortDate}
+          emptyText="Brak daty"
+          mono
+          variant="compact"
+        />
+        <DataField
+          label="Data od dawcy"
+          value={
+            request.donorAssignedPortDate
+              ? `${request.donorAssignedPortDate}${request.donorAssignedPortTime ? ` ${request.donorAssignedPortTime}` : ''}`
+              : null
+          }
+          emptyText="Brak"
+          mono
+          variant="compact"
+        />
+        <DataField
+          label="BOK"
+          value={request.assignedUser?.displayName ?? null}
+          emptyText="Nieprzypisana"
+          variant="compact"
+        />
+        <DataField
+          label="Handlowy"
+          value={request.commercialOwner?.displayName ?? null}
+          emptyText="Brak opiekuna"
+          variant="compact"
+        />
+        <DataField
+          label="Notyfikacje"
+          value={<Badge tone={healthBadge.tone}>{healthBadge.label}</Badge>}
+          variant="compact"
+        />
+        <DataField
+          label="Operatorzy"
+          value={`${request.donorOperator.shortName || request.donorOperator.name} -> ${
+            request.recipientOperator.shortName || request.recipientOperator.name
+          }`}
+          variant="compact"
+        />
+      </dl>
+    </SectionCard>
+  )
+}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -6,7 +6,7 @@ import { Bell, CalendarClock, ChevronDown, FileText, Info, TriangleAlert, Zap } 
 import { buildPath, ROUTES } from '@/constants/routes'
 import { useAuthStore } from '@/stores/auth.store'
 import { useSystemCapabilities } from '@/hooks/useSystemCapabilities'
-import { AppIcon, Badge, Button, ButtonLink, type BadgeTone, cx } from '@/components/ui'
+import { AppIcon, Badge, Button, type BadgeTone, cx } from '@/components/ui'
 import {
   assignPortingRequestToMe,
   cancelPortingCommunication,
@@ -53,7 +53,6 @@ import {
   PLI_CBD_EXPORT_STATUS_LABELS,
   PORTED_NUMBER_KIND_LABELS,
   PORTING_CASE_STATUS_LABELS,
-  PORTING_MODE_LABELS,
   SUBSCRIBER_IDENTITY_TYPE_LABELS,
   type CommunicationDeliveryAttemptsResultDto,
   type PliCbdAnyTechnicalPayloadBuildResultDto,
@@ -103,7 +102,6 @@ import { RequestDetailsHistoryPanel } from '@/components/RequestDetailsHistoryPa
 import { WhatsNextPanel } from '@/components/WhatsNextPanel/WhatsNextPanel'
 import { InternalNotificationAttemptsPanel } from '@/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel'
 import { NotificationFailureHistoryPanel } from '@/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel'
-import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
 import { getPortingUrgency } from '@/lib/portingUrgency'
 import {
   getInternalNotificationRetryErrorMessage,
@@ -119,6 +117,11 @@ import {
   getWorkflowErrorEmptyStateMessage,
   shouldShowPliCbdOperationalMeta,
 } from './requestDetailCapabilities'
+import {
+  RequestAttentionStrip,
+  RequestCaseHero,
+  RequestMetaGrid,
+} from './RequestCommandCenter'
 
 const TECHNICAL_PAYLOAD_MESSAGE_TYPES = ['E03', 'E12', 'E18', 'E23'] as const
 
@@ -354,56 +357,11 @@ function WideField({ label, value }: { label: string; value: string | null | und
   )
 }
 
-function DetailMetric({
-  label,
-  value,
-  tone = 'neutral',
-  actionLabel,
-  onAction,
-}: {
-  label: string
-  value: string
-  tone?: BadgeTone
-  actionLabel?: string
-  onAction?: () => void
-}) {
-  return (
-    <div className="rounded-panel border border-line bg-surface px-4 py-3">
-      <div className="text-xs font-semibold uppercase tracking-[0.1em] text-ink-400">{label}</div>
-      <div className="mt-2 flex flex-wrap items-center gap-3">
-        <Badge tone={tone}>{value}</Badge>
-        {actionLabel && onAction && (
-          <button
-            type="button"
-            onClick={onAction}
-            className="rounded-ui bg-brand-50/70 px-2 py-1 text-xs font-semibold text-brand-800 underline-offset-4 transition-colors hover:bg-brand-100 hover:text-brand-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
-          >
-            {actionLabel} {'>'}
-          </button>
-        )}
-      </div>
-    </div>
-  )
-}
-
 function scrollToSection(sectionId: string) {
   document.getElementById(sectionId)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
 const TERMINAL_CLOSED_STATUSES: PortingCaseStatus[] = ['REJECTED', 'CANCELLED', 'PORTED']
-
-function getStatusTone(status: ReturnType<typeof getPortingStatusMeta>['tone']): BadgeTone {
-  const toneByStatus: Record<ReturnType<typeof getPortingStatusMeta>['tone'], BadgeTone> = {
-    gray: 'neutral',
-    blue: 'brand',
-    amber: 'amber',
-    green: 'green',
-    red: 'red',
-    emerald: 'emerald',
-  }
-
-  return toneByStatus[status]
-}
 
 function formatDateTime(iso: string): string {
   return new Date(iso).toLocaleString('pl-PL', {
@@ -1890,7 +1848,6 @@ export function RequestDetailPage() {
     )
   }
 
-  const statusMeta = getPortingStatusMeta(request.statusInternal)
   const urgency = getPortingUrgency(request.confirmedPortDate)
   const assignedUserLabel = request.assignedUser
     ? `${request.assignedUser.displayName} (${request.assignedUser.email})`
@@ -1901,87 +1858,46 @@ export function RequestDetailPage() {
   const quickStatusActions = canManageStatus ? availableStatusActions.slice(0, 3) : []
   const hasQuickActions =
     quickStatusActions.length > 0 || canManageAssignment || availableCommunicationActions.length > 0
+  const workflowErrorMessage = getWorkflowErrorEmptyStateMessage(canUsePliCbdExternalActions)
 
   return (
     <div className="space-y-6">
-      <section className="panel overflow-hidden">
-        <div className="border-b border-line px-5 py-5">
-          <div className="flex flex-col gap-5 xl:flex-row xl:items-start xl:justify-between">
-            <div className="min-w-0">
-              <Button
-                onClick={backToList}
-                variant="ghost"
-                size="sm"
-                className="mb-3 -ml-2"
-              >
-                ← Sprawy portowania
-              </Button>
-              <div className="flex flex-wrap items-center gap-2">
-                <Badge tone="neutral">{request.caseNumber}</Badge>
-                <Badge tone={getStatusTone(statusMeta.tone)}>{statusMeta.label}</Badge>
-                <Badge tone="brand">{PORTING_MODE_LABELS[request.portingMode]}</Badge>
-                <Badge
-                  tone={urgency.tone}
-                  className={urgency.emphasized ? 'ring-2' : undefined}
-                  aria-label={`Pilnosc sprawy: ${urgency.label}`}
-                >
-                  Pilnosc: {urgency.label}
-                </Badge>
-              </div>
-              <h1 className="mt-3 text-3xl font-semibold tracking-tight text-ink-900">
-                {request.client.displayName}
-              </h1>
-              <p className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm font-medium text-ink-500">
-                <span className="font-mono text-ink-700">{request.numberDisplay}</span>
-                <span>{request.subscriberDisplayName}</span>
-                <span>
-                  {request.donorOperator.name} {'->'} {request.recipientOperator.name}
-                </span>
-              </p>
-            </div>
+      <RequestCaseHero
+        request={request}
+        urgency={urgency}
+        copyLinkDone={copyLinkDone}
+        onBackToList={backToList}
+        onCopyLink={handleCopyLink}
+      />
 
-            <div className="flex flex-wrap items-center gap-2">
-              <Button onClick={handleCopyLink} variant="ghost" size="sm">
-                {copyLinkDone ? '✓ Skopiowano' : 'Kopiuj link'}
-              </Button>
-              <ButtonLink to={ROUTES.REQUEST_NEW} variant="secondary">
-                + Nowa sprawa
-              </ButtonLink>
-            </div>
-          </div>
-        </div>
+      <RequestAttentionStrip
+        request={request}
+        canManageAssignment={canManageAssignment}
+        canManageStatus={canManageStatus}
+        workflowErrorMessage={workflowErrorMessage}
+        onScrollToAssignment={() => scrollToSection('assignment-panel')}
+        onScrollToNotifications={() => scrollToSection('notification-panel')}
+        onScrollToPortingDates={() => scrollToSection('porting-terms-panel')}
+        onScrollToStatusActions={() => scrollToSection('workflow-actions')}
+      />
 
-        <div className="grid gap-3 bg-ink-50/70 px-5 py-4 md:grid-cols-2 xl:grid-cols-4">
-          <DetailMetric
-            label="Status"
-            value={statusMeta.label}
-            tone={getStatusTone(statusMeta.tone)}
-            actionLabel={canManageStatus ? 'Akcje' : undefined}
-            onAction={canManageStatus ? () => scrollToSection('workflow-actions') : undefined}
-          />
-          <DetailMetric
-            label="Przypisanie BOK"
-            value={request.assignedUser ? request.assignedUser.displayName : 'Nieprzypisana'}
-            tone={request.assignedUser ? 'brand' : 'amber'}
-            actionLabel={canManageAssignment ? 'Zmien' : 'Szczegoly'}
-            onAction={() => scrollToSection('assignment-panel')}
-          />
-          <DetailMetric
-            label="Opiekun handlowy"
-            value={request.commercialOwner ? request.commercialOwner.displayName : 'Brak opiekuna'}
-            tone={request.commercialOwner ? 'emerald' : 'amber'}
-            actionLabel={canManageCommercialOwner ? 'Zmien' : 'Szczegoly'}
-            onAction={() => scrollToSection('commercial-owner-panel')}
-          />
-          <DetailMetric
-            label="Notyfikacje"
-            value={request.notificationHealth.status === 'OK' ? 'OK' : `${request.notificationHealth.failureCount} bledow`}
-            tone={request.notificationHealth.status === 'OK' ? 'emerald' : 'red'}
-            actionLabel={request.notificationHealth.failureCount > 0 ? 'Sprawdz' : 'Historia'}
-            onAction={() => scrollToSection('notification-panel')}
-          />
-        </div>
-      </section>
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.9fr)] xl:items-start">
+        <WhatsNextPanel
+          status={request.statusInternal}
+          availableStatusActions={availableStatusActions}
+          availableCommunicationActions={availableCommunicationActions}
+          assignedUser={request.assignedUser}
+          notificationHealth={request.notificationHealth}
+          canManageStatus={canManageStatus}
+          canManageAssignment={canManageAssignment}
+          onScrollToStatusActions={() => scrollToSection('workflow-actions')}
+          onScrollToCommunication={() => scrollToSection('communication-panel')}
+          onScrollToAssignment={() => scrollToSection('assignment-panel')}
+          onScrollToNotifications={() => scrollToSection('notification-panel')}
+        />
+
+        <RequestMetaGrid request={request} urgency={urgency} />
+      </div>
 
       {hasQuickActions && (
         <section className="panel p-4">
@@ -2032,25 +1948,7 @@ export function RequestDetailPage() {
       <div className="grid gap-5 xl:grid-cols-[minmax(0,1.6fr)_minmax(340px,0.9fr)]">
         <div className="space-y-5">
           <SectionCard
-            title="Najwazniejsze informacje"
-            description="Dane potrzebne od razu po wejsciu w sprawe."
-            icon={FileText}
-          >
-            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Field label="Klient" value={request.client.displayName} />
-              <Field label="Abonent" value={request.subscriberDisplayName} />
-              <Field label="Typ uslugi" value={NUMBER_TYPE_LABELS[request.numberType]} />
-              <Field label="Typ numeracji" value={PORTED_NUMBER_KIND_LABELS[request.numberRangeKind]} />
-              <Field label="Numer / zakres" value={request.numberDisplay} mono />
-              <Field label="Status sprawy" value={PORTING_CASE_STATUS_LABELS[request.statusInternal]} />
-              <Field label="Operator oddajacy" value={request.donorOperator.name} />
-              <Field label="Operator bioracy" value={request.recipientOperator.name} />
-              <Field label="Numer dokumentu" value={request.requestDocumentNumber} mono />
-              <Field label="Kanal kontaktu" value={CONTACT_CHANNEL_LABELS[request.contactChannel]} />
-            </dl>
-          </SectionCard>
-
-          <SectionCard
+            id="porting-terms-panel"
             title="Porting i terminy"
             description="Daty oraz parametry potrzebne do operacyjnej obslugi portowania."
             icon={CalendarClock}
@@ -2080,15 +1978,6 @@ export function RequestDetailPage() {
             </SectionCard>
           )}
 
-          <SectionCard title="Dane klienta i kontakt" description="Tozsamosc abonenta i powiazania operatorskie.">
-            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Field label="Typ identyfikatora" value={SUBSCRIBER_IDENTITY_TYPE_LABELS[request.identityType]} />
-              <Field label="Wartosc identyfikatora" value={request.identityValue} mono />
-              <Field label="Usluga hurtowa po stronie biorcy" value={request.linkedWholesaleServiceOnRecipientSide ? 'Tak' : 'Nie'} />
-              <Field label="Operator infrastrukturalny" value={request.infrastructureOperator?.name} />
-            </dl>
-          </SectionCard>
-
           <SectionCard
             title="Dane kontaktowe i operacyjne"
             description="Edycja operacyjna v1: adres, kanal kontaktu, notatki, numer dokumentu."
@@ -2103,12 +1992,6 @@ export function RequestDetailPage() {
               onSave={handleUpdateOperationalDetails}
             />
           </SectionCard>
-
-          <RequestDetailsHistoryPanel
-            items={detailsHistoryItems}
-            isLoading={isDetailsHistoryLoading}
-            error={detailsHistoryError}
-          />
 
           <div id="communication-panel" className="scroll-mt-6">
             <PortingCommunicationPanel
@@ -2137,6 +2020,32 @@ export function RequestDetailPage() {
               onLoadDeliveryAttempts={(communicationId) => void handleLoadDeliveryAttempts(communicationId)}
             />
           </div>
+
+          <SectionCard
+            title="Dane identyfikacyjne"
+            description="Dane sprawy, abonenta i operatorow bez akcji operacyjnych."
+            icon={FileText}
+          >
+            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <Field label="Klient" value={request.client.displayName} />
+              <Field label="Abonent" value={request.subscriberDisplayName} />
+              <Field label="Typ uslugi" value={NUMBER_TYPE_LABELS[request.numberType]} />
+              <Field label="Typ numeracji" value={PORTED_NUMBER_KIND_LABELS[request.numberRangeKind]} />
+              <Field label="Numer / zakres" value={request.numberDisplay} mono />
+              <Field label="Status sprawy" value={PORTING_CASE_STATUS_LABELS[request.statusInternal]} />
+              <Field label="Operator oddajacy" value={request.donorOperator.name} />
+              <Field label="Operator bioracy" value={request.recipientOperator.name} />
+              <Field label="Numer dokumentu" value={request.requestDocumentNumber} mono />
+              <Field label="Kanal kontaktu" value={CONTACT_CHANNEL_LABELS[request.contactChannel]} />
+              <Field label="Typ identyfikatora" value={SUBSCRIBER_IDENTITY_TYPE_LABELS[request.identityType]} />
+              <Field label="Wartosc identyfikatora" value={request.identityValue} mono />
+              <Field
+                label="Usluga hurtowa po stronie biorcy"
+                value={request.linkedWholesaleServiceOnRecipientSide ? 'Tak' : 'Nie'}
+              />
+              <Field label="Operator infrastrukturalny" value={request.infrastructureOperator?.name} />
+            </dl>
+          </SectionCard>
 
           <SectionCard
             id="notification-panel"
@@ -2178,6 +2087,12 @@ export function RequestDetailPage() {
               )}
             </div>
           </SectionCard>
+
+          <RequestDetailsHistoryPanel
+            items={detailsHistoryItems}
+            isLoading={isDetailsHistoryLoading}
+            error={detailsHistoryError}
+          />
 
           <SectionCard title="Historia operacyjna" description="Chronologia zmian statusu i zdarzen sprawy.">
             <PortingCaseHistory
@@ -2393,20 +2308,6 @@ export function RequestDetailPage() {
         </div>
 
         <div className="space-y-4">
-          <WhatsNextPanel
-            status={request.statusInternal}
-            availableStatusActions={availableStatusActions}
-            availableCommunicationActions={availableCommunicationActions}
-            assignedUser={request.assignedUser}
-            notificationHealth={request.notificationHealth}
-            canManageStatus={canManageStatus}
-            canManageAssignment={canManageAssignment}
-            onScrollToStatusActions={() => scrollToSection('workflow-actions')}
-            onScrollToCommunication={() => scrollToSection('communication-panel')}
-            onScrollToAssignment={() => scrollToSection('assignment-panel')}
-            onScrollToNotifications={() => scrollToSection('notification-panel')}
-          />
-
           <div id="assignment-panel" className="scroll-mt-6">
             <PortingAssignmentPanel
               assignedUser={request.assignedUser}


### PR DESCRIPTION
## Summary
- Add a RequestDetailPage command center at the top of the case detail view.
- Surface key operational context: case number, client, number, operators, status, mode, urgency/date, owners and notification health.
- Move WhatsNextPanel higher so the next operational step is visible earlier.
- Add a limited attention strip for the most important operational signals.

## Scope
- Frontend-only RequestDetailPage layout improvement.
- New RequestCommandCenter presentation component.
- No backend changes.
- No DTO changes.
- No routing changes.
- No workflow changes.
- No PLI CBD capability gate changes.
- No RequestDetailPage data-fetching changes.

## Preserved logic
- availableStatusActions unchanged.
- availableCommunicationActions unchanged.
- assignment handlers unchanged.
- commercial owner handlers unchanged.
- manual port date confirmation unchanged.
- PLI CBD capability gates unchanged.
- notification retry unchanged.
- routing by caseNumber unchanged.

## Validation
- npm run type-check --workspace apps/frontend ? PASS
- npm run test --workspace apps/frontend ? PASS, 45 files / 312 tests
- npm run build --workspace apps/frontend ? PASS

## Manual QA focus
- First viewport on desktop and mobile.
- Hero/command center with long client/operator names.
- Attention strip with multiple alerts.
- WhatsNextPanel placement.
- Status actions still work.
- Manual port date confirmation still works.
- Assignment and commercial owner panels still work.
- PLI CBD sections remain gated correctly.
- Notification retry remains unchanged.
