### PR TITLE
refactor(frontend): polish notification fallback settings

### DIFF
--- a/apps/frontend/src/pages/Admin/NotificationFallbackSettingsPage.test.tsx
+++ b/apps/frontend/src/pages/Admin/NotificationFallbackSettingsPage.test.tsx
@@ -1,16 +1,13 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  Badge,
   NotificationFallbackSettingsPage,
   computeReadiness,
+  shouldRequireEnableConfirmation,
+  validateFallbackForm,
 } from './NotificationFallbackSettingsPage'
 
-// ============================================================
-// Mocks
-// ============================================================
-
-const { authState, mockedUseAuthStore } = vi.hoisted(() => {
+const { authState, getSettingsMock, mockedUseAuthStore, updateSettingsMock } = vi.hoisted(() => {
   const state: {
     user: {
       id: string
@@ -37,7 +34,12 @@ const { authState, mockedUseAuthStore } = vi.hoisted(() => {
     getState: () => state,
   })
 
-  return { authState: state, mockedUseAuthStore: store }
+  return {
+    authState: state,
+    getSettingsMock: vi.fn(),
+    mockedUseAuthStore: store,
+    updateSettingsMock: vi.fn(),
+  }
 })
 
 vi.mock('@/stores/auth.store', () => ({
@@ -45,49 +47,53 @@ vi.mock('@/stores/auth.store', () => ({
 }))
 
 vi.mock('@/services/adminNotificationFallbackSettings.api', () => ({
-  getAdminNotificationFallbackSettings: vi.fn(),
-  updateAdminNotificationFallbackSettings: vi.fn(),
+  getAdminNotificationFallbackSettings: getSettingsMock,
+  updateAdminNotificationFallbackSettings: updateSettingsMock,
 }))
 
-// ============================================================
-// Testy strony (renderToStaticMarkup — synchroniczne, bez efektów)
-// ============================================================
-
-describe('NotificationFallbackSettingsPage', () => {
-  it('render — heading strony widoczny gdy user.role === ADMIN', () => {
-    authState.user = {
-      id: 'admin-1',
-      email: 'admin@np-manager.local',
-      firstName: 'Anna',
-      lastName: 'Admin',
-      role: 'ADMIN',
-      forcePasswordChange: false,
-    }
-
-    const html = renderToStaticMarkup(<NotificationFallbackSettingsPage />)
-
-    expect(html).toContain('Ustawienia fallback notyfikacji')
-    expect(html).toContain('Konfiguracja zapasowego odbiorcy dla nieudanych notyfikacji.')
-  })
-
-  it('loading — komunikat ladowania widoczny na wejsciu', () => {
-    authState.user = {
-      id: 'admin-1',
-      email: 'admin@np-manager.local',
-      firstName: 'Anna',
-      lastName: 'Admin',
-      role: 'ADMIN',
-      forcePasswordChange: false,
-    }
-
-    const html = renderToStaticMarkup(<NotificationFallbackSettingsPage />)
-
-    expect(html).toContain('Ladowanie ustawien...')
+beforeEach(() => {
+  authState.user = {
+    id: 'admin-1',
+    email: 'admin@np-manager.local',
+    firstName: 'Anna',
+    lastName: 'Admin',
+    role: 'ADMIN',
+    forcePasswordChange: false,
+  }
+  getSettingsMock.mockReset()
+  updateSettingsMock.mockReset()
+  getSettingsMock.mockResolvedValue({
+    fallbackEnabled: false,
+    fallbackRecipientEmail: '',
+    fallbackRecipientName: '',
+    applyToFailed: true,
+    applyToMisconfigured: true,
+    readiness: 'DISABLED',
   })
 })
 
-describe('NotificationFallbackSettingsPage — dostep', () => {
-  it('blokuje uzytkownika z rola BOK_CONSULTANT', () => {
+describe('NotificationFallbackSettingsPage', () => {
+  it('shows PageHeader and loading state for ADMIN user', () => {
+    authState.user = {
+      id: 'admin-1',
+      email: 'admin@np-manager.local',
+      firstName: 'Anna',
+      lastName: 'Admin',
+      role: 'ADMIN',
+      forcePasswordChange: false,
+    }
+
+    const html = renderToStaticMarkup(<NotificationFallbackSettingsPage />)
+
+    expect(html).toContain('Administracja')
+    expect(html).toContain('Fallback notyfikacji')
+    expect(html).toContain(
+      'Konfiguracja zapasowego odbiorcy dla błędów wysyłki wewnętrznych notyfikacji portingowych.',
+    )
+    expect(html).toContain('Ładowanie ustawień...')
+  })
+
+  it('blocks non-admin users with the DS empty state copy', () => {
     authState.user = {
       id: 'bok-1',
       email: 'bok@np-manager.local',
@@ -99,53 +105,14 @@ describe('NotificationFallbackSettingsPage — dostep', () => {
 
     const html = renderToStaticMarkup(<NotificationFallbackSettingsPage />)
 
-    expect(html).toContain('Brak dostepu do administracji')
-    expect(html).toContain('Ta sekcja jest dostepna tylko dla administratora systemu.')
+    expect(html).toContain('Brak dostępu do administracji')
+    expect(html).toContain('Ta sekcja jest dostępna tylko dla administratora systemu.')
   })
+
 })
-
-// ============================================================
-// Testy komponentu Badge (testy jednostkowe — renderToStaticMarkup)
-// ============================================================
-
-describe('Badge', () => {
-  it('badge DISABLED: renderuje etykiete "Fallback wylaczony" z tonem neutral', () => {
-    const html = renderToStaticMarkup(
-      <Badge tone="neutral">Fallback wyłączony</Badge>,
-    )
-
-    expect(html).toContain('Fallback wyłączony')
-    expect(html).toContain('bg-gray-100')
-    expect(html).toContain('text-gray-700')
-  })
-
-  it('badge READY: renderuje etykiete "Fallback aktywny" z tonem success', () => {
-    const html = renderToStaticMarkup(
-      <Badge tone="success">Fallback aktywny</Badge>,
-    )
-
-    expect(html).toContain('Fallback aktywny')
-    expect(html).toContain('bg-green-50')
-    expect(html).toContain('text-green-700')
-  })
-
-  it('badge INCOMPLETE: renderuje etykiete "Konfiguracja niekompletna" z tonem warning', () => {
-    const html = renderToStaticMarkup(
-      <Badge tone="warning">Konfiguracja niekompletna</Badge>,
-    )
-
-    expect(html).toContain('Konfiguracja niekompletna')
-    expect(html).toContain('bg-amber-50')
-    expect(html).toContain('text-amber-700')
-  })
-})
-
-// ============================================================
-// Testy computeReadiness (logika walidacji / stanu fallbacku)
-// ============================================================
 
 describe('computeReadiness', () => {
-  it('walidacja: fallbackEnabled=true i pusty email zwraca INCOMPLETE', () => {
+  it('returns INCOMPLETE when fallback is enabled without email', () => {
     const readiness = computeReadiness({
       fallbackEnabled: true,
       fallbackRecipientEmail: '',
@@ -157,7 +124,7 @@ describe('computeReadiness', () => {
     expect(readiness).toBe('INCOMPLETE')
   })
 
-  it('sukces: fallbackEnabled=true z wypelnionym emailem zwraca READY', () => {
+  it('returns READY when fallback is enabled with email', () => {
     const readiness = computeReadiness({
       fallbackEnabled: true,
       fallbackRecipientEmail: 'fallback@multiplay.pl',
@@ -169,15 +136,88 @@ describe('computeReadiness', () => {
     expect(readiness).toBe('READY')
   })
 
-  it('blad: fallbackEnabled=false zwraca DISABLED niezaleznie od emaila', () => {
+  it('returns DISABLED when fallback is off, regardless of email', () => {
     const readiness = computeReadiness({
       fallbackEnabled: false,
-      fallbackRecipientEmail: 'fallback@multiplay.pl',
+      fallbackRecipientEmail: 'not-an-email',
       fallbackRecipientName: '',
       applyToFailed: true,
       applyToMisconfigured: true,
     })
 
     expect(readiness).toBe('DISABLED')
+  })
+})
+
+describe('validateFallbackForm', () => {
+  it('does not block save for invalid email when fallback is off', () => {
+    const error = validateFallbackForm({
+      fallbackEnabled: false,
+      fallbackRecipientEmail: 'niepoprawny-email',
+      fallbackRecipientName: '',
+      applyToFailed: true,
+      applyToMisconfigured: true,
+    })
+
+    expect(error).toBeNull()
+  })
+
+  it('requires email when fallback is on', () => {
+    const error = validateFallbackForm({
+      fallbackEnabled: true,
+      fallbackRecipientEmail: '',
+      fallbackRecipientName: '',
+      applyToFailed: true,
+      applyToMisconfigured: true,
+    })
+
+    expect(error).toBe('Podaj adres e-mail odbiorcy fallbacku, gdy fallback jest włączony.')
+  })
+
+  it('requires valid email when fallback is on', () => {
+    const error = validateFallbackForm({
+      fallbackEnabled: true,
+      fallbackRecipientEmail: 'niepoprawny-email',
+      fallbackRecipientName: '',
+      applyToFailed: true,
+      applyToMisconfigured: true,
+    })
+
+    expect(error).toBe('Podaj poprawny adres e-mail.')
+  })
+})
+
+describe('shouldRequireEnableConfirmation', () => {
+  it('requires confirmation for OFF to ON transition', () => {
+    const saved = {
+      fallbackEnabled: false,
+      fallbackRecipientEmail: '',
+      fallbackRecipientName: '',
+      applyToFailed: true,
+      applyToMisconfigured: true,
+    }
+    const form = {
+      ...saved,
+      fallbackEnabled: true,
+      fallbackRecipientEmail: 'fallback@multiplay.pl',
+    }
+
+    expect(shouldRequireEnableConfirmation(saved, form)).toBe(true)
+  })
+
+  it('does not require confirmation when fallback was already enabled', () => {
+    const saved = {
+      fallbackEnabled: true,
+      fallbackRecipientEmail: 'fallback@multiplay.pl',
+      fallbackRecipientName: '',
+      applyToFailed: true,
+      applyToMisconfigured: true,
+    }
+    const form = {
+      ...saved,
+      fallbackRecipientEmail: 'nowy-fallback@multiplay.pl',
+    }
+
+    expect(shouldRequireEnableConfirmation(saved, form)).toBe(false)
   })
 })

--- a/apps/frontend/src/pages/Admin/NotificationFallbackSettingsPage.tsx
+++ b/apps/frontend/src/pages/Admin/NotificationFallbackSettingsPage.tsx
@@ -1,15 +1,21 @@
 import { useCallback, useEffect, useState } from 'react'
 import axios from 'axios'
 import type { NotificationFallbackReadiness } from '@np-manager/shared'
+import {
+  AlertBanner,
+  Badge,
+  Button,
+  DataField,
+  EmptyState,
+  PageHeader,
+  SectionCard,
+  type BadgeTone,
+} from '@/components/ui'
 import { useAuthStore } from '@/stores/auth.store'
 import {
   getAdminNotificationFallbackSettings,
   updateAdminNotificationFallbackSettings,
 } from '@/services/adminNotificationFallbackSettings.api'
-
-// ============================================================
-// Typy lokalne
-// ============================================================
 
 interface FallbackFormState {
   fallbackEnabled: boolean
@@ -19,40 +25,22 @@ interface FallbackFormState {
   applyToMisconfigured: boolean
 }
 
-// ============================================================
-// Komponenty pomocnicze — design system (wzorzec z AdminUserDetail)
-// ============================================================
-
-type BadgeTone = 'success' | 'neutral' | 'warning'
-
-export function Badge({ tone, children }: { tone: BadgeTone; children: React.ReactNode }) {
-  const toneClasses: Record<BadgeTone, string> = {
-    success: 'border-green-200 bg-green-50 text-green-700',
-    neutral: 'border-gray-200 bg-gray-100 text-gray-700',
-    warning: 'border-amber-200 bg-amber-50 text-amber-700',
-  }
-
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${toneClasses[tone]}`}
-    >
-      {children}
-    </span>
-  )
-}
-
 const READINESS_BADGE_CONFIG: Record<
   NotificationFallbackReadiness,
   { label: string; tone: BadgeTone }
 > = {
-  READY: { label: 'Fallback aktywny', tone: 'success' },
+  READY: { label: 'Fallback aktywny', tone: 'emerald' },
   DISABLED: { label: 'Fallback wyłączony', tone: 'neutral' },
-  INCOMPLETE: { label: 'Konfiguracja niekompletna', tone: 'warning' },
+  INCOMPLETE: { label: 'Konfiguracja niekompletna', tone: 'amber' },
 }
 
-// ============================================================
-// Helpery
-// ============================================================
+const EMPTY_FORM: FallbackFormState = {
+  fallbackEnabled: false,
+  fallbackRecipientEmail: '',
+  fallbackRecipientName: '',
+  applyToFailed: true,
+  applyToMisconfigured: true,
+}
 
 function getErrorMessage(error: unknown, fallback: string): string {
   if (!axios.isAxiosError(error)) {
@@ -66,20 +54,21 @@ function getErrorMessage(error: unknown, fallback: string): string {
 
 function getPreviewText(form: FallbackFormState, readiness: NotificationFallbackReadiness): string {
   if (readiness === 'DISABLED') {
-    return 'Fallback jest wyłączony — błędy notyfikacji nie są eskalowane.'
+    return 'Fallback jest wyłączony. Błędy notyfikacji nie będą eskalowane na zapasowy adres.'
   }
 
   if (readiness === 'INCOMPLETE') {
-    return 'Uzupełnij adres email, aby aktywować fallback.'
+    return 'Uzupełnij adres e-mail, aby fallback mógł eskalować błędy notyfikacji.'
   }
 
   const triggers: string[] = []
   if (form.applyToFailed) triggers.push('FAILED')
   if (form.applyToMisconfigured) triggers.push('MISCONFIGURED')
 
-  const triggerLabel = triggers.length === 2 ? 'obu' : triggers.join(', ')
+  const triggerLabel =
+    triggers.length === 2 ? 'FAILED oraz MISCONFIGURED' : triggers.join(', ') || 'brak zdarzeń'
 
-  return `Fallback zostanie użyty dla ${triggerLabel}, alert trafi do: ${form.fallbackRecipientEmail}`
+  return `Fallback zostanie użyty dla ${triggerLabel}. Alert trafi do: ${form.fallbackRecipientEmail.trim()}.`
 }
 
 export function computeReadiness(form: FallbackFormState): NotificationFallbackReadiness {
@@ -88,33 +77,48 @@ export function computeReadiness(form: FallbackFormState): NotificationFallbackR
   return 'READY'
 }
 
-// ============================================================
-// Stałe
-// ============================================================
+export function validateFallbackForm(form: FallbackFormState): string | null {
+  const email = form.fallbackRecipientEmail.trim()
 
-const EMPTY_FORM: FallbackFormState = {
-  fallbackEnabled: false,
-  fallbackRecipientEmail: '',
-  fallbackRecipientName: '',
-  applyToFailed: true,
-  applyToMisconfigured: true,
+  if (form.fallbackEnabled && !email) {
+    return 'Podaj adres e-mail odbiorcy fallbacku, gdy fallback jest włączony.'
+  }
+
+  if (form.fallbackEnabled && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+    return 'Podaj poprawny adres e-mail.'
+  }
+
+  return null
 }
 
-// ============================================================
-// Strona
-// ============================================================
+export function shouldRequireEnableConfirmation(
+  savedSettings: FallbackFormState | null,
+  form: FallbackFormState,
+): boolean {
+  return !savedSettings?.fallbackEnabled && form.fallbackEnabled
+}
+
+function ReadinessBadge({ readiness }: { readiness: NotificationFallbackReadiness }) {
+  const badgeCfg = READINESS_BADGE_CONFIG[readiness]
+  return (
+    <Badge tone={badgeCfg.tone} leadingDot>
+      {badgeCfg.label}
+    </Badge>
+  )
+}
 
 export function NotificationFallbackSettingsPage() {
   const { user } = useAuthStore()
   const isAdmin = user?.role === 'ADMIN'
 
   const [form, setForm] = useState<FallbackFormState>(EMPTY_FORM)
-  // serverReadiness: readiness z backendu — source of truth dla badge
+  const [savedSettings, setSavedSettings] = useState<FallbackFormState | null>(null)
   const [serverReadiness, setServerReadiness] = useState<NotificationFallbackReadiness>('DISABLED')
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
+  const [showEnableConfirmation, setShowEnableConfirmation] = useState(false)
 
   const loadSettings = useCallback(async () => {
     setIsLoading(true)
@@ -122,17 +126,21 @@ export function NotificationFallbackSettingsPage() {
 
     try {
       const result = await getAdminNotificationFallbackSettings()
-      setForm({
+      const nextSettings = {
         fallbackEnabled: result.fallbackEnabled,
         fallbackRecipientEmail: result.fallbackRecipientEmail,
         fallbackRecipientName: result.fallbackRecipientName,
         applyToFailed: result.applyToFailed,
         applyToMisconfigured: result.applyToMisconfigured,
-      })
+      }
+
+      setForm(nextSettings)
+      setSavedSettings(nextSettings)
       setServerReadiness(result.readiness)
     } catch (errorValue) {
-      setError(getErrorMessage(errorValue, 'Nie udalo sie zaladowac ustawien fallbacku.'))
+      setError(getErrorMessage(errorValue, 'Nie udało się załadować ustawień fallbacku.'))
       setForm(EMPTY_FORM)
+      setSavedSettings(null)
     } finally {
       setIsLoading(false)
     }
@@ -152,31 +160,16 @@ export function NotificationFallbackSettingsPage() {
     value: FallbackFormState[K],
   ) => {
     setForm((current) => ({ ...current, [field]: value }))
+    setShowEnableConfirmation(false)
     setError(null)
     setSuccess(null)
   }
 
-  const handleSave = async () => {
-    if (isSaving) return
-
-    if (form.fallbackEnabled && !form.fallbackRecipientEmail.trim()) {
-      setError('Podaj adres email odbiorcy fallback, gdy fallback jest wlaczony.')
-      setSuccess(null)
-      return
-    }
-
-    if (
-      form.fallbackRecipientEmail.trim() &&
-      !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.fallbackRecipientEmail.trim())
-    ) {
-      setError('Podaj poprawny adres e-mail.')
-      setSuccess(null)
-      return
-    }
-
+  const saveSettings = async () => {
     setIsSaving(true)
     setError(null)
     setSuccess(null)
+    setShowEnableConfirmation(false)
 
     try {
       const result = await updateAdminNotificationFallbackSettings({
@@ -186,160 +179,257 @@ export function NotificationFallbackSettingsPage() {
         applyToFailed: form.applyToFailed,
         applyToMisconfigured: form.applyToMisconfigured,
       })
-
-      setForm({
+      const nextSettings = {
         fallbackEnabled: result.fallbackEnabled,
         fallbackRecipientEmail: result.fallbackRecipientEmail,
         fallbackRecipientName: result.fallbackRecipientName,
         applyToFailed: result.applyToFailed,
         applyToMisconfigured: result.applyToMisconfigured,
-      })
+      }
+
+      setForm(nextSettings)
+      setSavedSettings(nextSettings)
       setServerReadiness(result.readiness)
       setSuccess('Ustawienia fallbacku zostały zapisane.')
     } catch (errorValue) {
-      setError(getErrorMessage(errorValue, 'Nie udalo sie zapisac ustawien fallbacku.'))
+      setError(getErrorMessage(errorValue, 'Nie udało się zapisać ustawień fallbacku.'))
     } finally {
       setIsSaving(false)
     }
   }
 
+  const handleSave = async () => {
+    if (isSaving) return
+
+    const validationError = validateFallbackForm(form)
+    if (validationError) {
+      setError(validationError)
+      setSuccess(null)
+      setShowEnableConfirmation(false)
+      return
+    }
+
+    if (shouldRequireEnableConfirmation(savedSettings, form)) {
+      setError(null)
+      setSuccess(null)
+      setShowEnableConfirmation(true)
+      return
+    }
+
+    await saveSettings()
+  }
+
+  const liveReadiness = computeReadiness(form)
+  const savedRecipientName = savedSettings?.fallbackRecipientName.trim()
+
   if (!isAdmin) {
     return (
       <div className="p-6">
-        <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-14 text-center">
-          <h1 className="text-2xl font-semibold text-gray-900">Brak dostepu do administracji</h1>
-          <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-gray-600">
-            Ta sekcja jest dostepna tylko dla administratora systemu.
-          </p>
+        <div className="mx-auto max-w-4xl space-y-5">
+          <PageHeader
+            eyebrow="Administracja"
+            title="Fallback notyfikacji"
+            description="Konfiguracja zapasowego odbiorcy dla błędów wysyłki wewnętrznych notyfikacji portingowych."
+          />
+          <EmptyState
+            title="Brak dostępu do administracji"
+            description="Ta sekcja jest dostępna tylko dla administratora systemu."
+          />
         </div>
       </div>
     )
   }
 
-  // liveReadiness: podgląd oparty na aktualnym stanie formularza (przed zapisem)
-  const liveReadiness = computeReadiness(form)
-  const badgeCfg = READINESS_BADGE_CONFIG[serverReadiness]
-
   return (
     <div className="p-6">
-      <div className="mx-auto max-w-4xl space-y-4">
-        <div className="card p-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-xl font-semibold text-gray-900">
-                Ustawienia fallback notyfikacji
-              </h1>
-              <p className="mt-1 text-sm text-gray-600">
-                Konfiguracja zapasowego odbiorcy dla nieudanych notyfikacji.
-              </p>
-            </div>
-            {!isLoading && <Badge tone={badgeCfg.tone}>{badgeCfg.label}</Badge>}
-          </div>
-        </div>
+      <div className="mx-auto max-w-5xl space-y-5">
+        <PageHeader
+          eyebrow="Administracja"
+          title="Fallback notyfikacji"
+          description="Konfiguracja zapasowego odbiorcy dla błędów wysyłki wewnętrznych notyfikacji portingowych."
+        />
 
-        <div className="card p-6">
-          {isLoading ? (
-            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
-              Ladowanie ustawien...
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <label className="inline-flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={form.fallbackEnabled}
-                  onChange={(event) => handleChange('fallbackEnabled', event.target.checked)}
+        {isLoading ? (
+          <SectionCard title="Ładowanie ustawień">
+            <AlertBanner
+              tone="neutral"
+              title="Ładowanie ustawień..."
+              description="Pobieram aktualną konfigurację fallbacku z serwera."
+            />
+          </SectionCard>
+        ) : (
+          <>
+            {success && <AlertBanner tone="success" title={success} />}
+            {error && <AlertBanner tone="danger" title={error} />}
+
+            <SectionCard
+              title="Aktualny stan"
+              description="Stan zapisany na serwerze. To on decyduje o realnym zachowaniu fallbacku do czasu kolejnego zapisu."
+              action={<ReadinessBadge readiness={serverReadiness} />}
+            >
+              <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <DataField
+                  label="Fallback"
+                  value={savedSettings?.fallbackEnabled ? 'Włączony' : 'Wyłączony'}
                 />
-                <span className="text-sm font-medium text-gray-700">
-                  Włącz fallback notyfikacji
-                </span>
-              </label>
-
-              <label className="block">
-                <span className="mb-1 block text-sm font-medium text-gray-700">
-                  Adres email odbiorcy fallback
-                  {form.fallbackEnabled && <span className="text-red-500"> *</span>}
-                </span>
-                <input
-                  type="email"
-                  value={form.fallbackRecipientEmail}
-                  onChange={(event) => handleChange('fallbackRecipientEmail', event.target.value)}
-                  className="input-field"
-                  placeholder="fallback@example.com"
+                <DataField
+                  label="Adres fallbacku"
+                  value={savedSettings?.fallbackRecipientEmail}
+                  emptyText="Nie ustawiono"
                 />
-              </label>
-
-              <label className="block">
-                <span className="mb-1 block text-sm font-medium text-gray-700">
-                  Nazwa odbiorcy
-                </span>
-                <input
-                  type="text"
-                  value={form.fallbackRecipientName}
-                  onChange={(event) => handleChange('fallbackRecipientName', event.target.value)}
-                  className="input-field"
-                  placeholder="np. Zespol BOK"
+                <DataField
+                  label="Odbiorca"
+                  value={savedRecipientName}
+                  emptyText="Brak nazwy"
                 />
-              </label>
+                <DataField label="Readiness" value={READINESS_BADGE_CONFIG[serverReadiness].label} />
+              </dl>
+            </SectionCard>
 
-              <fieldset className="space-y-2">
-                <legend className="text-sm font-medium text-gray-700">
-                  Zastosuj fallback do:
-                </legend>
-                <label className="inline-flex items-center gap-2">
+            <SectionCard
+              title="Konfiguracja fallbacku"
+              description="Edytowany formularz. Zmiany zaczną działać dopiero po zapisie."
+              action={<ReadinessBadge readiness={liveReadiness} />}
+            >
+              <div className="space-y-5">
+                <label className="flex items-start gap-3 rounded-ui border border-line bg-ink-50/70 p-4">
                   <input
                     type="checkbox"
-                    checked={form.applyToFailed}
-                    onChange={(event) => handleChange('applyToFailed', event.target.checked)}
+                    checked={form.fallbackEnabled}
+                    onChange={(event) => handleChange('fallbackEnabled', event.target.checked)}
+                    className="mt-1 h-4 w-4 rounded border-line text-brand-600 focus:ring-brand-500"
                   />
-                  <span className="text-sm text-gray-700">Dla błędów wysyłki (FAILED)</span>
-                </label>
-                <br />
-                <label className="inline-flex items-center gap-2">
-                  <input
-                    type="checkbox"
-                    checked={form.applyToMisconfigured}
-                    onChange={(event) => handleChange('applyToMisconfigured', event.target.checked)}
-                  />
-                  <span className="text-sm text-gray-700">
-                    Dla błędów konfiguracji (MISCONFIGURED)
+                  <span>
+                    <span className="block text-sm font-semibold text-ink-900">
+                      Włącz fallback notyfikacji
+                    </span>
+                    <span className="mt-1 block text-sm leading-6 text-ink-500">
+                      Po włączeniu błędy wysyłki wewnętrznych notyfikacji portingowych mogą być
+                      eskalowane na wskazany adres.
+                    </span>
                   </span>
                 </label>
-              </fieldset>
 
-              <div className="flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => void handleSave()}
-                  disabled={isSaving}
-                  className="btn-primary"
-                >
-                  {isSaving ? 'Zapisywanie...' : 'Zapisz ustawienia'}
-                </button>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <label className="block">
+                    <span className="mb-1 block text-sm font-semibold text-ink-700">
+                      Adres e-mail odbiorcy fallbacku
+                      {form.fallbackEnabled && <span className="text-red-600"> *</span>}
+                    </span>
+                    <input
+                      type="email"
+                      value={form.fallbackRecipientEmail}
+                      onChange={(event) =>
+                        handleChange('fallbackRecipientEmail', event.target.value)
+                      }
+                      className="h-10 w-full rounded-ui border border-line bg-surface px-3 text-sm text-ink-900 shadow-sm outline-none transition focus:border-brand-400 focus:ring-2 focus:ring-brand-100"
+                      placeholder="fallback@example.com"
+                    />
+                  </label>
+
+                  <label className="block">
+                    <span className="mb-1 block text-sm font-semibold text-ink-700">
+                      Nazwa odbiorcy
+                    </span>
+                    <input
+                      type="text"
+                      value={form.fallbackRecipientName}
+                      onChange={(event) =>
+                        handleChange('fallbackRecipientName', event.target.value)
+                      }
+                      className="h-10 w-full rounded-ui border border-line bg-surface px-3 text-sm text-ink-900 shadow-sm outline-none transition focus:border-brand-400 focus:ring-2 focus:ring-brand-100"
+                      placeholder="np. Zespół BOK"
+                    />
+                  </label>
+                </div>
+
+                <fieldset className="space-y-3">
+                  <legend className="text-sm font-semibold text-ink-700">
+                    Typy problemów objęte fallbackiem
+                  </legend>
+                  <div className="grid gap-3 md:grid-cols-2">
+                    <label className="flex items-start gap-3 rounded-ui border border-line bg-surface p-4">
+                      <input
+                        type="checkbox"
+                        checked={form.applyToFailed}
+                        onChange={(event) => handleChange('applyToFailed', event.target.checked)}
+                        className="mt-1 h-4 w-4 rounded border-line text-brand-600 focus:ring-brand-500"
+                      />
+                      <span>
+                        <span className="block text-sm font-semibold text-ink-900">
+                          Błędy wysyłki
+                        </span>
+                        <span className="mt-1 block text-sm leading-6 text-ink-500">
+                          Outcome FAILED, czyli problem z dostarczeniem notyfikacji.
+                        </span>
+                      </span>
+                    </label>
+
+                    <label className="flex items-start gap-3 rounded-ui border border-line bg-surface p-4">
+                      <input
+                        type="checkbox"
+                        checked={form.applyToMisconfigured}
+                        onChange={(event) =>
+                          handleChange('applyToMisconfigured', event.target.checked)
+                        }
+                        className="mt-1 h-4 w-4 rounded border-line text-brand-600 focus:ring-brand-500"
+                      />
+                      <span>
+                        <span className="block text-sm font-semibold text-ink-900">
+                          Błędy konfiguracji
+                        </span>
+                        <span className="mt-1 block text-sm leading-6 text-ink-500">
+                          Outcome MISCONFIGURED, czyli brak lub błędna konfiguracja transportu.
+                        </span>
+                      </span>
+                    </label>
+                  </div>
+                </fieldset>
+
+                {showEnableConfirmation && (
+                  <AlertBanner
+                    tone="warning"
+                    title="Potwierdź włączenie fallbacku"
+                    description={`Po zapisie błędy notyfikacji będą eskalowane na adres ${form.fallbackRecipientEmail.trim()}. Sprawdź, czy to właściwy odbiorca operacyjny.`}
+                    action={
+                      <Button
+                        variant="primary"
+                        size="sm"
+                        isLoading={isSaving}
+                        loadingLabel="Zapisywanie..."
+                        onClick={() => void saveSettings()}
+                      >
+                        Potwierdź włączenie
+                      </Button>
+                    }
+                  />
+                )}
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    variant="primary"
+                    onClick={() => void handleSave()}
+                    isLoading={isSaving}
+                    loadingLabel="Zapisywanie..."
+                  >
+                    Zapisz ustawienia
+                  </Button>
+                </div>
               </div>
-            </div>
-          )}
+            </SectionCard>
 
-          {success && (
-            <div className="mt-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-              {success}
-            </div>
-          )}
-          {error && (
-            <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-              {error}
-            </div>
-          )}
-        </div>
-
-        <div className="card p-6">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">
-            Podglad skutku konfiguracji
-          </h2>
-          <p className="mt-2 text-sm text-gray-600">
-            {!isLoading && getPreviewText(form, liveReadiness)}
-          </p>
-        </div>
+            <SectionCard
+              title="Skutek konfiguracji"
+              description="Podgląd konsekwencji na podstawie edytowanego formularza, jeszcze przed zapisem."
+            >
+              <AlertBanner
+                tone={liveReadiness === 'READY' ? 'info' : liveReadiness === 'INCOMPLETE' ? 'warning' : 'neutral'}
+                title={READINESS_BADGE_CONFIG[liveReadiness].label}
+                description={getPreviewText(form, liveReadiness)}
+              />
+            </SectionCard>
+          </>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- Polish NotificationFallbackSettingsPage with the shared UI design system.
- Replace local Badge and legacy cards/buttons with PageHeader, SectionCard, AlertBanner, EmptyState and global Badge/Button.
- Separate saved server state, editable configuration and live configuration preview.
- Add inline confirmation before enabling fallback from OFF to ON.

## Scope
- Frontend-only admin settings polish.
- No backend changes.
- No DTO changes.
- No API changes.
- No routing changes.
- No workflow changes.
- No seed changes.
- No other admin screens touched.

## Preserved logic
- API calls unchanged.
- Payload unchanged.
- Backend readiness remains source of truth for saved state.
- computeReadiness(form) remains local preview only.
- Fallback OFF + invalid email does not block save.
- Fallback ON + empty/invalid email blocks save.
- Save flow preserved, with confirmation only for OFF → ON.
- ADMIN-only access preserved.

## Validation
- npm run type-check --workspace apps/frontend — PASS
- npm run test --workspace apps/frontend — PASS, 45 files / 313 tests
- npm run build --workspace apps/frontend — PASS
- npx tsc --noEmit in apps/backend — PASS
- npm run test --workspace apps/backend — PASS, 69 files / 513 tests

## Manual QA focus
- Load saved settings.
- OFF state.
- OFF + invalid email save.
- ON + empty email validation.
- ON + invalid email validation.
- OFF → ON inline confirmation.
- Confirm enable actually saves.
- Existing ON → edit email saves without extra confirmation.
- Long fallback email layout.
- Non-admin access denied state.