### PR TITLE
refactor(frontend): polish admin users module

### DIFF
--- a/apps/frontend/src/components/admin-users/AdminUserDeactivateModal.tsx
+++ b/apps/frontend/src/components/admin-users/AdminUserDeactivateModal.tsx
@@ -1,3 +1,5 @@
+import { Button } from '@/components/ui'
+
 interface AdminUserDeactivateModalProps {
   isOpen: boolean
   email: string
@@ -19,45 +21,46 @@ export function AdminUserDeactivateModal({
 
   return (
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-gray-950/40 px-4">
-      <div className="w-full max-w-lg rounded-3xl border border-gray-200 bg-white p-6 shadow-2xl">
+      <div className="w-full max-w-lg rounded-panel border border-line bg-surface p-6 shadow-2xl">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h2 className="text-xl font-semibold text-gray-900">Potwierdź dezaktywację konta</h2>
-            <p className="mt-2 text-sm leading-6 text-gray-600">
+            <h2 className="text-xl font-semibold text-ink-900">Potwierdź dezaktywację konta</h2>
+            <p className="mt-2 text-sm leading-6 text-ink-600">
               Konto <span className="font-medium">{email}</span> zostanie dezaktywowane, a
               użytkownik utraci możliwość logowania do aplikacji do czasu ponownej aktywacji.
             </p>
           </div>
-          <button
+          <Button
             type="button"
             onClick={onClose}
-            className="rounded-lg px-3 py-2 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-900"
+            variant="ghost"
+            size="sm"
             disabled={isSaving}
             data-testid="admin-user-deactivate-close"
           >
             Zamknij
-          </button>
+          </Button>
         </div>
 
         <div className="mt-6 flex justify-end gap-3">
-          <button
+          <Button
             type="button"
             onClick={onClose}
-            className="btn-secondary"
             disabled={isSaving}
             data-testid="admin-user-deactivate-cancel"
           >
             Anuluj
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
             onClick={onConfirm}
-            className="btn-primary"
-            disabled={isSaving}
+            variant="primary"
+            isLoading={isSaving}
+            loadingLabel="Dezaktywowanie..."
             data-testid="admin-user-deactivate-confirm"
           >
-            {isSaving ? 'Dezaktywowanie...' : 'Potwierdź dezaktywację'}
-          </button>
+            Potwierdź dezaktywację
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/frontend/src/components/admin-users/AdminUserDetail.tsx
+++ b/apps/frontend/src/components/admin-users/AdminUserDetail.tsx
@@ -5,6 +5,15 @@ import {
   getAdminUserStatusLabel,
   type AdminUserAuditEntryView,
 } from '@/lib/adminUsers'
+import {
+  AlertBanner,
+  Badge,
+  Button,
+  DataField,
+  EmptyState,
+  PageHeader,
+  SectionCard,
+} from '@/components/ui'
 import { AdminUserDeactivateModal } from './AdminUserDeactivateModal'
 import { AdminUserPasswordResetModal } from './AdminUserPasswordResetModal'
 
@@ -68,9 +77,9 @@ export function AdminUserDetail({
   if (isLoading) {
     return (
       <div className="p-6">
-        <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-14 text-center text-sm text-gray-600">
-          Ladowanie szczegolow uzytkownika...
-        </div>
+        <SectionCard padding="sm">
+          <EmptyState title="Ładowanie szczegółów użytkownika..." />
+        </SectionCard>
       </div>
     )
   }
@@ -78,15 +87,14 @@ export function AdminUserDetail({
   if (error || !user) {
     return (
       <div className="space-y-6 p-6">
-        <button type="button" onClick={onBack} className="text-sm font-medium text-blue-700">
-          {'<'} Wroc do listy
-        </button>
-        <div className="rounded-3xl border border-red-200 bg-red-50 px-6 py-14 text-center">
-          <h1 className="text-2xl font-semibold text-red-900">Nie udalo sie otworzyc konta</h1>
-          <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-red-700">
-            {error ?? 'Brak danych uzytkownika.'}
-          </p>
-        </div>
+        <Button type="button" onClick={onBack} variant="ghost">
+          Wróć do listy
+        </Button>
+        <AlertBanner
+          tone="danger"
+          title="Nie udało się otworzyć konta"
+          description={error ?? 'Brak danych użytkownika.'}
+        />
       </div>
     )
   }
@@ -96,102 +104,93 @@ export function AdminUserDetail({
   return (
     <>
       <div className="space-y-6 p-6">
-        <header className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <button
-              type="button"
-              onClick={onBack}
-              className="mb-4 text-sm font-medium text-blue-700"
-            >
-              {'<'} Wroc do listy
-            </button>
-            <h1 className="text-3xl font-semibold tracking-tight text-gray-900">{displayName}</h1>
-            <p className="mt-2 text-sm text-gray-600">{user.email}</p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              <Badge tone="primary">{USER_ROLE_LABELS[user.role]}</Badge>
-              <Badge tone={user.isActive ? 'success' : 'neutral'}>
-                {getAdminUserStatusLabel(user.isActive)}
-              </Badge>
-              {user.forcePasswordChange && <Badge tone="warning">Wymagana zmiana hasla</Badge>}
+        <PageHeader
+          eyebrow="Użytkownik"
+          title={displayName}
+          description={
+            <div className="space-y-3">
+              <div>{user.email}</div>
+              <div className="flex flex-wrap gap-2">
+                <Badge tone="brand">{USER_ROLE_LABELS[user.role]}</Badge>
+                <Badge tone={user.isActive ? 'emerald' : 'neutral'} leadingDot>
+                  {getAdminUserStatusLabel(user.isActive)}
+                </Badge>
+                {user.forcePasswordChange && <Badge tone="amber">Wymagana zmiana hasła</Badge>}
+              </div>
             </div>
-          </div>
-        </header>
+          }
+          actions={
+            <Button type="button" onClick={onBack} variant="ghost">
+              Wróć do listy
+            </Button>
+          }
+        />
 
-        {feedbackSuccess && <Banner tone="success">{feedbackSuccess}</Banner>}
-        {(feedbackError || error) && <Banner tone="danger">{feedbackError ?? error}</Banner>}
+        {feedbackSuccess && <AlertBanner tone="success" title={feedbackSuccess} />}
+        {(feedbackError || error) && <AlertBanner tone="danger" title={feedbackError ?? error} />}
 
         <section className="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
           <div className="space-y-6">
-            <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900">Dane konta</h2>
-              <div className="mt-5 grid gap-4 md:grid-cols-2">
-                <InfoBox label="Imie i nazwisko" value={displayName} />
-                <InfoBox label="Rola" value={USER_ROLE_LABELS[user.role]} />
-                <InfoBox label="Status konta" value={getAdminUserStatusLabel(user.isActive)} />
-                <InfoBox
-                  label="Wymagana zmiana hasla"
-                  value={user.forcePasswordChange ? 'Tak' : 'Nie'}
-                />
-                <InfoBox
+            <SectionCard title="Dane użytkownika">
+              <dl className="grid gap-4 md:grid-cols-2">
+                <DataField label="Imię i nazwisko" value={displayName} />
+                <DataField label="E-mail" value={user.email} />
+                <DataField
                   label="Ostatnie logowanie"
                   value={formatAdminUserDateTime(user.lastLoginAt)}
                 />
-                <InfoBox
-                  label="Zmiana hasla"
+                <DataField
+                  label="Zmiana hasła"
                   value={formatAdminUserDateTime(user.passwordChangedAt)}
                 />
-                <InfoBox label="Utworzono" value={formatAdminUserDateTime(user.createdAt)} />
-                <InfoBox
+                <DataField label="Utworzono" value={formatAdminUserDateTime(user.createdAt)} />
+                <DataField
                   label="Ostatnia aktualizacja"
                   value={formatAdminUserDateTime(user.updatedAt)}
                 />
-              </div>
+              </dl>
 
               {(user.deactivatedAt || user.reactivatedAt) && (
-                <div className="mt-5 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-4 text-sm text-gray-700">
+                <dl className="mt-5 grid gap-4 rounded-ui border border-line bg-ink-50/70 p-4 md:grid-cols-2">
                   {user.deactivatedAt && (
-                    <p>Dezaktywacja: {formatAdminUserDateTime(user.deactivatedAt)}</p>
+                    <DataField
+                      label="Dezaktywacja"
+                      value={formatAdminUserDateTime(user.deactivatedAt)}
+                    />
                   )}
                   {user.reactivatedAt && (
-                    <p className={user.deactivatedAt ? 'mt-2' : ''}>
-                      Reaktywacja: {formatAdminUserDateTime(user.reactivatedAt)}
-                    </p>
+                    <DataField
+                      label="Reaktywacja"
+                      value={formatAdminUserDateTime(user.reactivatedAt)}
+                    />
                   )}
-                </div>
+                </dl>
               )}
-            </section>
+            </SectionCard>
 
-            <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
-              <div className="flex items-center justify-between gap-4">
-                <div>
-                  <h2 className="text-lg font-semibold text-gray-900">Historia administracyjna</h2>
-                  <p className="mt-1 text-sm text-gray-500">
-                    Zdarzenia pokazywane od najnowszych do najstarszych.
-                  </p>
-                </div>
-              </div>
-
+            <SectionCard
+              title="Historia audytu"
+              description="Zdarzenia pokazywane od najnowszych do najstarszych."
+            >
               {auditEntries.length === 0 ? (
-                <div className="mt-5 rounded-2xl border border-dashed border-gray-300 px-4 py-6 text-sm text-gray-600">
-                  Brak historii administracyjnej dla tego konta.
-                </div>
+                <EmptyState title="Brak historii administracyjnej dla tego konta." />
               ) : (
-                <div className="mt-5 space-y-4">
+                <div className="space-y-4">
                   {auditEntries.map((entry) => (
                     <article
                       key={entry.id}
-                      className="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-4"
+                      className="rounded-ui border border-line bg-ink-50/70 px-4 py-4"
                     >
                       <div className="flex flex-wrap items-start justify-between gap-3">
                         <div>
-                          <h3 className="text-sm font-semibold text-gray-900">
+                          <h3 className="text-sm font-semibold text-ink-900">
                             {entry.actionLabel}
                           </h3>
-                          <p className="mt-1 text-sm leading-6 text-gray-700">
+                          <p className="mt-1 text-sm leading-6 text-ink-700">
                             {entry.description}
                           </p>
                         </div>
-                        <div className="text-right text-xs text-gray-500">
+                        <div className="text-right text-xs text-ink-500">
                           <div>{formatAdminUserDateTime(entry.createdAt)}</div>
                           <div className="mt-1">{entry.actorLabel}</div>
                         </div>
@@ -199,10 +198,10 @@ export function AdminUserDetail({
 
                       {entry.detailLines.length > 0 && (
                         <details className="mt-3">
-                          <summary className="cursor-pointer text-sm font-medium text-blue-700">
-                            Pokaz szczegoly
+                          <summary className="cursor-pointer text-sm font-medium text-brand-700">
+                            Pokaż szczegóły
                           </summary>
-                          <ul className="mt-3 space-y-2 text-sm text-gray-600">
+                          <ul className="mt-3 space-y-2 text-sm text-ink-600">
                             {entry.detailLines.map((line) => (
                               <li key={line}>{line}</li>
                             ))}
@@ -213,17 +212,15 @@ export function AdminUserDetail({
                   ))}
                 </div>
               )}
-            </section>
+            </SectionCard>
           </div>
 
           <div className="space-y-6">
-            <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
-              <h2 className="text-lg font-semibold text-gray-900">Akcje administracyjne</h2>
-
-              <div className="mt-5 rounded-2xl border border-gray-200 p-4">
+            <SectionCard title="Rola">
+              <div className="rounded-ui border border-line bg-ink-50/70 p-4">
                 <div className="flex flex-wrap items-end gap-3">
                   <label className="flex-1">
-                    <span className="label">Rola uzytkownika</span>
+                    <span className="label">Rola użytkownika</span>
                     <select
                       value={roleDraft}
                       onChange={(event) => onRoleChange(event.target.value as UserRole)}
@@ -238,28 +235,30 @@ export function AdminUserDetail({
                       ))}
                     </select>
                   </label>
-                  <button
+                  <Button
                     type="button"
                     onClick={onRoleSave}
-                    className="btn-primary"
-                    disabled={isRoleSaving}
+                    variant="primary"
+                    isLoading={isRoleSaving}
+                    loadingLabel="Zapisywanie..."
                   >
-                    {isRoleSaving ? 'Zapisywanie...' : 'Zmien role'}
-                  </button>
+                    Zmień rolę
+                  </Button>
                 </div>
               </div>
+            </SectionCard>
 
-              <div className="mt-4 rounded-2xl border border-gray-200 p-4">
-                <h3 className="text-sm font-semibold text-gray-900">Status konta</h3>
-                <p className="mt-2 text-sm leading-6 text-gray-600">
+            <SectionCard title="Status konta">
+              <div className="rounded-ui border border-line bg-ink-50/70 p-4">
+                <p className="text-sm leading-6 text-ink-600">
                   {user.isActive
                     ? 'Dezaktywacja zablokuje kolejne logowania, ale nie usuwa konta z systemu.'
-                    : 'Reaktywacja przywroci mozliwosc logowania i korzystania z aplikacji.'}
+                    : 'Reaktywacja przywróci możliwość logowania i korzystania z aplikacji.'}
                 </p>
-                <button
+                <Button
                   type="button"
                   onClick={user.isActive ? onDeactivate : onReactivate}
-                  className="btn-secondary mt-4"
+                  className="mt-4"
                   disabled={isStatusUpdating || (user.isActive && isDeactivateDisabled)}
                   title={
                     user.isActive && isDeactivateDisabled
@@ -267,34 +266,34 @@ export function AdminUserDetail({
                       : undefined
                   }
                   data-testid="admin-user-status-action"
+                  isLoading={isStatusUpdating}
+                  loadingLabel="Zapisywanie..."
                 >
-                  {isStatusUpdating
-                    ? 'Zapisywanie...'
-                    : user.isActive
-                      ? 'Dezaktywuj konto'
-                      : 'Aktywuj konto'}
-                </button>
+                  {user.isActive ? 'Dezaktywuj konto' : 'Aktywuj konto'}
+                </Button>
                 {user.isActive && isDeactivateDisabled && (
                   <p
-                    className="mt-3 text-sm text-gray-500"
+                    className="mt-3 text-sm text-ink-500"
                     data-testid="admin-user-self-deactivate-hint"
                   >
                     Nie możesz dezaktywować własnego konta.
                   </p>
                 )}
               </div>
+            </SectionCard>
 
-              <div className="mt-4 rounded-2xl border border-gray-200 p-4">
-                <h3 className="text-sm font-semibold text-gray-900">Reset hasla</h3>
-                <p className="mt-2 text-sm leading-6 text-gray-600">
-                  Ustaw nowe haslo tymczasowe. Przy kolejnym logowaniu uzytkownik bedzie musial je
-                  zmienic.
+            <SectionCard title="Akcje administracyjne">
+              <div className="rounded-ui border border-line bg-ink-50/70 p-4">
+                <h3 className="text-sm font-semibold text-ink-900">Reset hasła</h3>
+                <p className="mt-2 text-sm leading-6 text-ink-600">
+                  Ustaw nowe hasło tymczasowe. Przy kolejnym logowaniu użytkownik będzie musiał je
+                  zmienić.
                 </p>
-                <button type="button" onClick={onOpenResetPassword} className="btn-secondary mt-4">
-                  Reset hasla
-                </button>
+                <Button type="button" onClick={onOpenResetPassword} className="mt-4">
+                  Reset hasła
+                </Button>
               </div>
-            </section>
+            </SectionCard>
           </div>
         </section>
       </div>
@@ -317,51 +316,5 @@ export function AdminUserDetail({
         onConfirm={onConfirmDeactivate}
       />
     </>
-  )
-}
-
-function InfoBox({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3">
-      <div className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">{label}</div>
-      <div className="mt-1 text-sm text-gray-800">{value}</div>
-    </div>
-  )
-}
-
-function Badge({
-  tone,
-  children,
-}: {
-  tone: 'primary' | 'success' | 'neutral' | 'warning'
-  children: React.ReactNode
-}) {
-  const toneClasses = {
-    primary: 'border-blue-200 bg-blue-50 text-blue-700',
-    success: 'border-green-200 bg-green-50 text-green-700',
-    neutral: 'border-gray-200 bg-gray-100 text-gray-700',
-    warning: 'border-amber-200 bg-amber-50 text-amber-700',
-  } as const
-
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${toneClasses[tone]}`}
-    >
-      {children}
-    </span>
-  )
-}
-
-function Banner({ tone, children }: { tone: 'success' | 'danger'; children: React.ReactNode }) {
-  return (
-    <div
-      className={`rounded-2xl border px-4 py-3 text-sm ${
-        tone === 'success'
-          ? 'border-green-200 bg-green-50 text-green-700'
-          : 'border-red-200 bg-red-50 text-red-700'
-      }`}
-    >
-      {children}
-    </div>
   )
 }

--- a/apps/frontend/src/components/admin-users/AdminUserForm.tsx
+++ b/apps/frontend/src/components/admin-users/AdminUserForm.tsx
@@ -1,4 +1,5 @@
 import { USER_ROLE_LABELS, type UserRole } from '@np-manager/shared'
+import { AlertBanner, Button, PageHeader, SectionCard } from '@/components/ui'
 
 export interface AdminUserFormState {
   email: string
@@ -33,21 +34,26 @@ export function AdminUserForm({
 }: AdminUserFormProps) {
   return (
     <div className="space-y-6 p-6">
-      <header className="max-w-3xl">
-        <button type="button" onClick={onCancel} className="mb-4 text-sm font-medium text-blue-700">
-          {'<'} Wroc do listy
-        </button>
-        <h1 className="text-3xl font-semibold tracking-tight text-gray-900">Nowy uzytkownik</h1>
-        <p className="mt-3 text-sm leading-6 text-gray-600">
-          Utworz konto aplikacyjne z haslem tymczasowym. Backend ustawi wymuszenie zmiany hasla
-          przy pierwszym logowaniu.
-        </p>
-      </header>
+      <PageHeader
+        eyebrow="Administracja"
+        title="Nowy użytkownik"
+        description="Utwórz konto aplikacyjne z hasłem tymczasowym. Backend ustawi wymuszenie zmiany hasła przy pierwszym logowaniu."
+        actions={
+          <Button type="button" onClick={onCancel} variant="ghost">
+            Wróć do listy
+          </Button>
+        }
+      />
 
-      {feedbackSuccess && <Banner tone="success">{feedbackSuccess}</Banner>}
-      {(feedbackError || errors._root) && <Banner tone="danger">{feedbackError ?? errors._root}</Banner>}
+      {feedbackSuccess && <AlertBanner tone="success" title={feedbackSuccess} />}
+      {(feedbackError || errors._root) && (
+        <AlertBanner tone="danger" title={feedbackError ?? errors._root} />
+      )}
 
-      <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
+      <SectionCard
+        title="Dane konta"
+        description="Wypełnij dane wymagane przez istniejący flow tworzenia użytkownika."
+      >
         <div className="grid gap-4 md:grid-cols-2">
           <FormField label="Adres e-mail" error={errors.email}>
             <input
@@ -77,7 +83,7 @@ export function AdminUserForm({
             </select>
           </FormField>
 
-          <FormField label="Imie" error={errors.firstName}>
+          <FormField label="Imię" error={errors.firstName}>
             <input
               value={form.firstName}
               onChange={(event) => onChange('firstName', event.target.value)}
@@ -101,36 +107,43 @@ export function AdminUserForm({
         </div>
 
         <div className="mt-4 grid gap-4 md:grid-cols-[1.2fr,0.8fr]">
-          <FormField label="Haslo tymczasowe" error={errors.temporaryPassword}>
+          <FormField label="Hasło tymczasowe" error={errors.temporaryPassword}>
             <input
               type="password"
               value={form.temporaryPassword}
               onChange={(event) => onChange('temporaryPassword', event.target.value)}
               className={`input-field ${errors.temporaryPassword ? 'input-error' : ''}`}
-              placeholder="Minimum 8 znakow"
+              placeholder="Minimum 8 znaków"
               autoComplete="new-password"
               disabled={isSaving}
               data-testid="admin-user-create-password"
             />
           </FormField>
 
-          <div className="rounded-2xl border border-blue-100 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+          <div className="rounded-ui border border-brand-100 bg-brand-50 px-4 py-3 text-sm text-brand-800">
             <p className="font-medium">Po utworzeniu konta:</p>
             <p className="mt-2 leading-6">
-              konto bedzie aktywne, a flaga wymagania zmiany hasla zostanie ustawiona przez backend.
+              konto będzie aktywne, a flaga wymagania zmiany hasła zostanie ustawiona przez
+              backend.
             </p>
           </div>
         </div>
 
         <div className="mt-6 flex flex-wrap justify-end gap-3">
-          <button type="button" onClick={onCancel} className="btn-secondary" disabled={isSaving}>
+          <Button type="button" onClick={onCancel} disabled={isSaving}>
             Anuluj
-          </button>
-          <button type="button" onClick={onSubmit} className="btn-primary" disabled={isSaving}>
-            {isSaving ? 'Tworzenie...' : 'Utworz konto'}
-          </button>
+          </Button>
+          <Button
+            type="button"
+            onClick={onSubmit}
+            variant="primary"
+            isLoading={isSaving}
+            loadingLabel="Tworzenie..."
+          >
+            Utwórz konto
+          </Button>
         </div>
-      </section>
+      </SectionCard>
     </div>
   )
 }
@@ -150,19 +163,5 @@ function FormField({
       {children}
       {error && <p className="error-message">{error}</p>}
     </label>
-  )
-}
-
-function Banner({ tone, children }: { tone: 'success' | 'danger'; children: React.ReactNode }) {
-  return (
-    <div
-      className={`rounded-2xl border px-4 py-3 text-sm ${
-        tone === 'success'
-          ? 'border-green-200 bg-green-50 text-green-700'
-          : 'border-red-200 bg-red-50 text-red-700'
-      }`}
-    >
-      {children}
-    </div>
   )
 }

--- a/apps/frontend/src/components/admin-users/AdminUserPasswordResetModal.tsx
+++ b/apps/frontend/src/components/admin-users/AdminUserPasswordResetModal.tsx
@@ -1,3 +1,5 @@
+import { AlertBanner, Button } from '@/components/ui'
+
 interface AdminUserPasswordResetModalProps {
   isOpen: boolean
   email: string
@@ -25,54 +27,52 @@ export function AdminUserPasswordResetModal({
 
   return (
     <div className="fixed inset-0 z-40 flex items-center justify-center bg-gray-950/40 px-4">
-      <div className="w-full max-w-lg rounded-3xl border border-gray-200 bg-white p-6 shadow-2xl">
+      <div className="w-full max-w-lg rounded-panel border border-line bg-surface p-6 shadow-2xl">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h2 className="text-xl font-semibold text-gray-900">Reset hasla</h2>
-            <p className="mt-2 text-sm leading-6 text-gray-600">
-              Ustaw nowe haslo tymczasowe dla konta <span className="font-medium">{email}</span>.
+            <h2 className="text-xl font-semibold text-ink-900">Reset hasła</h2>
+            <p className="mt-2 text-sm leading-6 text-ink-600">
+              Ustaw nowe hasło tymczasowe dla konta <span className="font-medium">{email}</span>.
             </p>
           </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-lg px-3 py-2 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-900"
-          >
+          <Button type="button" onClick={onClose} variant="ghost" size="sm">
             Zamknij
-          </button>
+          </Button>
         </div>
 
         <label className="mt-6 block">
-          <span className="label">Haslo tymczasowe</span>
+          <span className="label">Hasło tymczasowe</span>
           <input
             type="password"
             value={temporaryPassword}
             onChange={(event) => onTemporaryPasswordChange(event.target.value)}
             className={`input-field ${error ? 'input-error' : ''}`}
-            placeholder="Minimum 8 znakow"
+            placeholder="Minimum 8 znaków"
             autoComplete="new-password"
             disabled={isSaving}
             data-testid="admin-user-reset-password"
           />
         </label>
 
-        <p className="mt-3 text-xs leading-5 text-gray-500">
-          Haslo nie jest wyswietlane po zapisaniu i nie trafia do historii administracyjnej.
+        <p className="mt-3 text-xs leading-5 text-ink-500">
+          Hasło nie jest wyświetlane po zapisaniu i nie trafia do historii administracyjnej.
         </p>
 
-        {error && (
-          <div className="mt-4 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            {error}
-          </div>
-        )}
+        {error && <AlertBanner className="mt-4" tone="danger" title={error} />}
 
         <div className="mt-6 flex justify-end gap-3">
-          <button type="button" onClick={onClose} className="btn-secondary" disabled={isSaving}>
+          <Button type="button" onClick={onClose} disabled={isSaving}>
             Anuluj
-          </button>
-          <button type="button" onClick={onSubmit} className="btn-primary" disabled={isSaving}>
-            {isSaving ? 'Resetowanie...' : 'Zresetuj haslo'}
-          </button>
+          </Button>
+          <Button
+            type="button"
+            onClick={onSubmit}
+            variant="primary"
+            isLoading={isSaving}
+            loadingLabel="Resetowanie..."
+          >
+            Zresetuj hasło
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/frontend/src/components/admin-users/AdminUsersList.tsx
+++ b/apps/frontend/src/components/admin-users/AdminUsersList.tsx
@@ -6,6 +6,15 @@ import {
   getAdminUserDisplayName,
   getAdminUserStatusLabel,
 } from '@/lib/adminUsers'
+import {
+  AlertBanner,
+  Badge,
+  Button,
+  EmptyState,
+  MetricCard,
+  PageHeader,
+  SectionCard,
+} from '@/components/ui'
 
 export type AdminUsersRoleFilter = 'ALL' | UserRole
 export type AdminUsersStatusFilter = 'ALL' | 'ACTIVE' | 'INACTIVE'
@@ -59,52 +68,44 @@ export function AdminUsersList({
 
   return (
     <div className="space-y-6 p-6">
-      <header className="flex flex-wrap items-start justify-between gap-4">
-        <div className="max-w-3xl">
-          <h1 className="text-3xl font-semibold tracking-tight text-gray-900">Uzytkownicy</h1>
-          <p className="mt-3 text-sm leading-6 text-gray-600">
-            Zarzadzaj kontami aplikacji, rolami oraz stanem aktywnosci bez duplikowania logiki
-            bezpieczenstwa z backendu.
-          </p>
-        </div>
-
-        <button type="button" onClick={onCreate} className="btn-primary">
-          + Nowy uzytkownik
-        </button>
-      </header>
+      <PageHeader
+        eyebrow="Administracja"
+        title="Użytkownicy"
+        description="Zarządzaj kontami aplikacji, rolami oraz stanem aktywności bez duplikowania logiki bezpieczeństwa z backendu."
+        actions={
+          <Button type="button" onClick={onCreate} variant="primary">
+            Nowy użytkownik
+          </Button>
+        }
+      />
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <SummaryCard
-          label="Aktywni"
-          value={summary.activeCount}
+        <MetricCard
+          title="Aktywni"
+          value={formatAdminUsersSummaryValue(summary.activeCount, isLoading)}
           tone="success"
-          isLoading={isLoading}
-          testId="admin-users-summary-active"
         />
-        <SummaryCard
-          label="Nieaktywni"
-          value={summary.inactiveCount}
+        <MetricCard
+          title="Nieaktywni"
+          value={formatAdminUsersSummaryValue(summary.inactiveCount, isLoading)}
           tone="neutral"
-          isLoading={isLoading}
-          testId="admin-users-summary-inactive"
         />
-        <SummaryCard
-          label="Administratorzy"
-          value={summary.adminCount}
-          tone="primary"
-          isLoading={isLoading}
-          testId="admin-users-summary-admin"
+        <MetricCard
+          title="Administratorzy"
+          value={formatAdminUsersSummaryValue(summary.adminCount, isLoading)}
+          tone="brand"
         />
-        <SummaryCard
-          label="Konsultanci BOK"
-          value={summary.consultantCount}
+        <MetricCard
+          title="Konsultanci BOK"
+          value={formatAdminUsersSummaryValue(summary.consultantCount, isLoading)}
           tone="warning"
-          isLoading={isLoading}
-          testId="admin-users-summary-consultant"
         />
       </section>
 
-      <section className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm">
+      <SectionCard
+        title="Filtry"
+        description="Zawęź listę bez zmiany zasad pobierania danych z API."
+      >
         <div className="grid gap-4 lg:grid-cols-[1.4fr,0.9fr,0.9fr]">
           <label className="block">
             <span className="label">Wyszukaj</span>
@@ -149,88 +150,80 @@ export function AdminUsersList({
             </select>
           </label>
         </div>
-      </section>
+      </SectionCard>
 
-      {feedbackSuccess && <Banner tone="success">{feedbackSuccess}</Banner>}
+      {feedbackSuccess && <AlertBanner tone="success" title={feedbackSuccess} />}
 
-      {(feedbackError || error) && <Banner tone="danger">{feedbackError ?? error}</Banner>}
+      {(feedbackError || error) && <AlertBanner tone="danger" title={feedbackError ?? error} />}
 
-      <section className="rounded-3xl border border-gray-200 bg-white shadow-sm">
-        <div className="flex items-center justify-between border-b border-gray-200 px-5 py-4">
-          <div>
-            <h2 className="text-base font-semibold text-gray-900">Lista kont</h2>
-            <p className="mt-1 text-sm text-gray-500">
-              {hasActiveFilters
-                ? `${users.length} z ${totalUsersCount} kont spelnia aktywne filtry.`
-                : `${totalUsersCount} kont dostepnych w systemie.`}
-            </p>
-          </div>
-        </div>
-
+      <SectionCard
+        title="Lista kont"
+        description={
+          hasActiveFilters
+            ? `${users.length} z ${totalUsersCount} kont spełnia aktywne filtry.`
+            : `${totalUsersCount} kont dostępnych w systemie.`
+        }
+        padding="none"
+      >
         {isLoading ? (
-          <div className="px-6 py-14 text-center text-sm text-gray-600">
-            Ladowanie kont uzytkownikow...
-          </div>
+          <EmptyState title="Ładowanie kont użytkowników..." />
         ) : totalUsersCount === 0 ? (
-          <div className="px-6 py-14 text-center">
-            <h3 className="text-xl font-semibold text-gray-900">Brak kont w systemie</h3>
-            <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-gray-600">
-              Utworz pierwsze konto aplikacyjne, aby rozpoczec prace z panelem administracji
-              uzytkownikami.
-            </p>
-            <button type="button" onClick={onCreate} className="btn-primary mt-6">
-              Utworz pierwsze konto
-            </button>
+          <div className="p-5">
+            <EmptyState
+              title="Brak kont w systemie"
+              description="Utwórz pierwsze konto aplikacyjne, aby rozpocząć pracę z panelem administracji użytkownikami."
+              action={
+                <Button type="button" onClick={onCreate} variant="primary">
+                  Utwórz pierwsze konto
+                </Button>
+              }
+            />
           </div>
         ) : users.length === 0 ? (
-          <div className="px-6 py-14 text-center">
-            <h3 className="text-xl font-semibold text-gray-900">Brak wynikow</h3>
-            <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-gray-600">
-              Zmien kryteria filtrowania, aby zobaczyc inne konta.
-            </p>
+          <div className="p-5">
+            <EmptyState
+              title="Brak wyników"
+              description="Zmień kryteria filtrowania, aby zobaczyć inne konta."
+            />
           </div>
         ) : (
           <div className="overflow-x-auto">
             <table className="min-w-full text-sm">
-              <thead className="bg-gray-50">
-                <tr className="border-b border-gray-200 text-left text-gray-600">
-                  <th className="px-5 py-3 font-medium">Uzytkownik</th>
+              <thead className="bg-ink-50">
+                <tr className="border-b border-line text-left text-ink-500">
+                  <th className="px-5 py-3 font-medium">Użytkownik</th>
                   <th className="px-5 py-3 font-medium">Rola</th>
                   <th className="px-5 py-3 font-medium">Status</th>
-                  <th className="px-5 py-3 font-medium">Wymuszona zmiana hasla</th>
+                  <th className="px-5 py-3 font-medium">Wymuszona zmiana hasła</th>
                   <th className="px-5 py-3 font-medium">Utworzono</th>
                   <th className="px-5 py-3 font-medium text-right">Akcja</th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-100">
+              <tbody className="divide-y divide-line">
                 {users.map((user) => (
-                  <tr key={user.id} className="transition hover:bg-gray-50">
+                  <tr key={user.id} className="transition hover:bg-ink-50/70">
                     <td className="px-5 py-4">
-                      <div className="font-medium text-gray-900">
+                      <div className="font-medium text-ink-900">
                         {getAdminUserDisplayName(user)}
                       </div>
-                      <div className="mt-1 text-sm text-gray-500">{user.email}</div>
+                      <div className="mt-1 text-sm text-ink-500">{user.email}</div>
                     </td>
-                    <td className="px-5 py-4 text-gray-700">{USER_ROLE_LABELS[user.role]}</td>
+                    <td className="px-5 py-4 text-ink-700">{USER_ROLE_LABELS[user.role]}</td>
                     <td className="px-5 py-4">
-                      <StatusPill active={user.isActive}>
+                      <Badge tone={user.isActive ? 'emerald' : 'neutral'} leadingDot>
                         {getAdminUserStatusLabel(user.isActive)}
-                      </StatusPill>
+                      </Badge>
                     </td>
-                    <td className="px-5 py-4 text-gray-700">
+                    <td className="px-5 py-4 text-ink-700">
                       {user.forcePasswordChange ? 'Tak' : 'Nie'}
                     </td>
-                    <td className="px-5 py-4 text-gray-700">
+                    <td className="px-5 py-4 text-ink-700">
                       {formatAdminUserDateTime(user.createdAt)}
                     </td>
                     <td className="px-5 py-4 text-right">
-                      <button
-                        type="button"
-                        onClick={() => onOpen(user.id)}
-                        className="btn-secondary"
-                      >
-                        Szczegoly
-                      </button>
+                      <Button type="button" onClick={() => onOpen(user.id)} size="sm">
+                        Szczegóły
+                      </Button>
                     </td>
                   </tr>
                 ))}
@@ -238,65 +231,7 @@ export function AdminUsersList({
             </table>
           </div>
         )}
-      </section>
-    </div>
-  )
-}
-
-function SummaryCard({
-  label,
-  value,
-  tone,
-  isLoading,
-  testId,
-}: {
-  label: string
-  value: number
-  tone: 'success' | 'neutral' | 'primary' | 'warning'
-  isLoading: boolean
-  testId: string
-}) {
-  const toneClasses = {
-    success: 'border-green-200 bg-green-50 text-green-800',
-    neutral: 'border-gray-200 bg-white text-gray-900',
-    primary: 'border-blue-200 bg-blue-50 text-blue-800',
-    warning: 'border-amber-200 bg-amber-50 text-amber-800',
-  } as const
-
-  return (
-    <div className={`rounded-3xl border p-5 shadow-sm ${toneClasses[tone]}`}>
-      <p className="text-sm font-medium">{label}</p>
-      <p className="mt-3 text-3xl font-semibold tracking-tight" data-testid={`${testId}-value`}>
-        {formatAdminUsersSummaryValue(value, isLoading)}
-      </p>
-    </div>
-  )
-}
-
-function StatusPill({ active, children }: { active: boolean; children: React.ReactNode }) {
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${
-        active
-          ? 'border-green-200 bg-green-50 text-green-700'
-          : 'border-gray-200 bg-gray-100 text-gray-600'
-      }`}
-    >
-      {children}
-    </span>
-  )
-}
-
-function Banner({ tone, children }: { tone: 'success' | 'danger'; children: React.ReactNode }) {
-  return (
-    <div
-      className={`rounded-2xl border px-4 py-3 text-sm ${
-        tone === 'success'
-          ? 'border-green-200 bg-green-50 text-green-700'
-          : 'border-red-200 bg-red-50 text-red-700'
-      }`}
-    >
-      {children}
+      </SectionCard>
     </div>
   )
 }

--- a/apps/frontend/src/components/admin-users/AdminUsersModule.test.tsx
+++ b/apps/frontend/src/components/admin-users/AdminUsersModule.test.tsx
@@ -91,9 +91,11 @@ function getTextContent(node: ReactNode): string {
 
 function findButtonByText(tree: ReactNode, label: string): ReactElement | undefined {
   return collectElements(tree).find(
-    (element) =>
-      element.type === 'button' &&
-      getTextContent((element.props as { children?: ReactNode }).children).includes(label),
+    (element) => {
+      const props = element.props as { children?: ReactNode; onClick?: () => void }
+
+      return typeof props.onClick === 'function' && getTextContent(props.children).includes(label)
+    },
   )
 }
 
@@ -122,11 +124,11 @@ describe('Admin users module UI', () => {
       />,
     )
 
-    expect(html).toContain('Uzytkownicy')
+    expect(html).toContain('Użytkownicy')
     expect(html).toContain('Aktywni')
     expect(html).toContain('jan.kowalski@firma.pl')
-    expect(html).toContain('Wymuszona zmiana hasla')
-    expect(html).toContain('Szczegoly')
+    expect(html).toContain('Wymuszona zmiana hasła')
+    expect(html).toContain('Szczegóły')
   })
 
   it('renders loading, empty and no-results states for the list', () => {
@@ -184,11 +186,10 @@ describe('Admin users module UI', () => {
       />,
     )
 
-    expect(loadingHtml).toContain('Ladowanie kont uzytkownikow')
-    expect(loadingHtml).toContain('data-testid="admin-users-summary-active-value">--<')
-    expect(loadingHtml).toContain('data-testid="admin-users-summary-admin-value">--<')
+    expect(loadingHtml).toContain('Ładowanie kont użytkowników')
+    expect(loadingHtml).toContain('--')
     expect(emptyHtml).toContain('Brak kont w systemie')
-    expect(noResultsHtml).toContain('Brak wynikow')
+    expect(noResultsHtml).toContain('Brak wyników')
   })
 
   it('renders create form with required fields and backend contract copy', () => {
@@ -211,10 +212,10 @@ describe('Admin users module UI', () => {
       />,
     )
 
-    expect(html).toContain('Nowy uzytkownik')
+    expect(html).toContain('Nowy użytkownik')
     expect(html).toContain('Adres e-mail')
-    expect(html).toContain('Haslo tymczasowe')
-    expect(html).toContain('Backend ustawi wymuszenie zmiany hasla')
+    expect(html).toContain('Hasło tymczasowe')
+    expect(html).toContain('Backend ustawi wymuszenie zmiany hasła')
   })
 
   it('renders detail view with admin actions and readable audit history', () => {
@@ -267,10 +268,10 @@ describe('Admin users module UI', () => {
     )
 
     expect(html).toContain('Akcje administracyjne')
-    expect(html).toContain('Zmien role')
+    expect(html).toContain('Zmień rolę')
     expect(html).toContain('Dezaktywuj konto')
-    expect(html).toContain('Reset hasla')
-    expect(html).toContain('Historia administracyjna')
+    expect(html).toContain('Reset hasła')
+    expect(html).toContain('Historia audytu')
     expect(html).toContain('Rola zmieniona z Konsultant BOK na Administrator.')
     expect(html).toContain('Anna Admin (Administrator)')
   })
@@ -307,7 +308,7 @@ describe('Admin users module UI', () => {
       />,
     )
 
-    expect(html).toContain('Nie udalo sie otworzyc konta')
+    expect(html).toContain('Nie udało się otworzyć konta')
     expect(html).toContain('Nie udalo sie pobrac szczegolow uzytkownika.')
   })
 

--- a/apps/frontend/src/pages/Admin/AdminUsersPage.test.tsx
+++ b/apps/frontend/src/pages/Admin/AdminUsersPage.test.tsx
@@ -30,7 +30,7 @@ describe('AdminUsersPage', () => {
   it('blocks non-admin users from admin users views', () => {
     const html = renderToStaticMarkup(<AdminUsersPage />)
 
-    expect(html).toContain('Brak dostepu do administracji')
-    expect(html).toContain('Ta sekcja jest dostepna tylko dla administratora systemu.')
+    expect(html).toContain('Brak dostępu do administracji')
+    expect(html).toContain('Ta sekcja jest dostępna tylko dla administratora systemu.')
   })
 })

--- a/apps/frontend/src/pages/Admin/AdminUsersPage.tsx
+++ b/apps/frontend/src/pages/Admin/AdminUsersPage.tsx
@@ -34,6 +34,7 @@ import {
   type AdminUserFormState,
   type AdminUsersListFilters,
 } from '@/components/admin-users'
+import { EmptyState, SectionCard } from '@/components/ui'
 
 type AdminUsersMode = 'LIST' | 'NEW' | 'DETAIL'
 
@@ -107,12 +108,12 @@ function validateCreateForm(form: AdminUserFormState): AdminUserFormErrors {
 function AdminUsersAccessDeniedState() {
   return (
     <div className="p-6">
-      <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-14 text-center">
-        <h1 className="text-2xl font-semibold text-gray-900">Brak dostepu do administracji</h1>
-        <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-gray-600">
-          Ta sekcja jest dostepna tylko dla administratora systemu.
-        </p>
-      </div>
+      <SectionCard padding="sm">
+        <EmptyState
+          title="Brak dostępu do administracji"
+          description="Ta sekcja jest dostępna tylko dla administratora systemu."
+        />
+      </SectionCard>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Polish the Admin Users module with the shared UI design system.
- Replace local SummaryCard, Banner, InfoBox and StatusPill patterns with shared UI components.
- Align list, detail, create form and access-denied states with the redesigned app shell.
- Lightly align deactivate/reset password modals visually without changing their behavior.

## Scope
- Frontend-only Admin Users UI polish.
- No backend changes.
- No shared DTO changes.
- No API service changes.
- No routing changes.
- No seed changes.
- No risky actions UX changes yet.
- No type-to-confirm yet.
- No other admin screens touched.

## Preserved logic
- API calls unchanged.
- List filtering unchanged.
- Create user flow unchanged.
- Role change flow unchanged.
- Deactivate/reactivate flow unchanged.
- Reset password flow unchanged.
- Self-deactivate guard unchanged.
- Audit log behavior unchanged.
- ADMIN-only access unchanged.

## Validation
- npm run type-check --workspace apps/frontend — PASS
- npm run test --workspace apps/frontend — PASS, 313/313
- npm run build --workspace apps/frontend — PASS with existing Vite warnings

## Manual QA focus
- Admin users list renders.
- Summary cards render correct counts.
- Search/role/status filters work.
- Create user form renders and validates.
- User detail loads.
- Role change UI still works.
- Deactivate/reactivate modal still works.
- Reset password modal still works.
- Self-deactivate guard still blocks.
- Audit log still renders.
- Non-admin access denied state.
- Responsiveness of the admin users table.