### PR TITLE
refactor(frontend): polish communication templates admin

### DIFF
--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplateDetail.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplateDetail.tsx
@@ -1,4 +1,6 @@
+import { CONTACT_CHANNEL_LABELS } from '@np-manager/shared'
 import type { CommunicationTemplateGroupView, CommunicationTemplateVersionView } from '@/lib/communicationTemplates'
+import { AlertBanner, Badge, Button, DataField, EmptyState, PageHeader, SectionCard } from '@/components/ui'
 import { CommunicationTemplatePlaceholdersCard } from './CommunicationTemplatePlaceholdersCard'
 import { CommunicationTemplateVersionCard } from './CommunicationTemplateVersionCard'
 
@@ -50,9 +52,9 @@ export function CommunicationTemplateDetail({
   if (isLoading) {
     return (
       <div className="p-6">
-        <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-12 text-center text-sm text-gray-600">
-          Ladowanie szczegolow szablonu...
-        </div>
+        <SectionCard padding="none">
+          <EmptyState title="Ładowanie szczegółów szablonu..." />
+        </SectionCard>
       </div>
     )
   }
@@ -60,12 +62,10 @@ export function CommunicationTemplateDetail({
   if (error) {
     return (
       <div className="space-y-6 p-6">
-        <button type="button" onClick={onBack} className="btn-secondary">
-          Wroc do listy
-        </button>
-        <div className="rounded-3xl border border-red-200 bg-red-50 px-6 py-6 text-sm text-red-700">
-          {error}
-        </div>
+        <Button type="button" onClick={onBack}>
+          Wróć do listy
+        </Button>
+        <AlertBanner tone="danger" title="Nie udało się pobrać szablonu" description={error} />
       </div>
     )
   }
@@ -73,68 +73,60 @@ export function CommunicationTemplateDetail({
   if (!group) {
     return (
       <div className="space-y-6 p-6">
-        <button type="button" onClick={onBack} className="btn-secondary">
-          Wroc do listy
-        </button>
-        <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-12 text-center">
-          <h1 className="text-xl font-semibold text-gray-900">Nie znaleziono szablonu</h1>
-          <p className="mt-3 text-sm text-gray-600">
-            Wybrany kod komunikatu nie istnieje albo nie ma jeszcze zadnych wersji.
-          </p>
-        </div>
+        <Button type="button" onClick={onBack}>
+          Wróć do listy
+        </Button>
+        <SectionCard padding="none">
+          <EmptyState
+            title="Nie znaleziono szablonu"
+            description="Wybrany kod komunikatu nie istnieje albo nie ma jeszcze żadnych wersji."
+          />
+        </SectionCard>
       </div>
     )
   }
 
   return (
     <div className="space-y-6 p-6">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div>
-          <button type="button" onClick={onBack} className="btn-secondary">
-            Wroc do listy
-          </button>
-          <h1 className="mt-4 text-3xl font-semibold tracking-tight text-gray-900">{group.name}</h1>
-          <p className="mt-2 text-sm font-medium text-gray-600">{group.code}</p>
-          <p className="mt-3 max-w-3xl text-sm leading-6 text-gray-600">
-            {group.description || 'Brak opisu operacyjnego dla tego szablonu.'}
-          </p>
-          <div className="mt-4 flex flex-wrap gap-3 text-sm text-gray-600">
-            <span className="rounded-full border border-green-200 bg-green-50 px-3 py-1 font-medium text-green-700">
-              {group.publishedVersion ? 'Opublikowana' : 'Brak opublikowanej wersji'}
-            </span>
-            <span className="rounded-full border border-gray-200 bg-gray-50 px-3 py-1 font-medium">
-              {group.publishedVersion
-                ? `Wersja aktywna: v${group.publishedVersion.versionNumber}`
-                : 'Wersja aktywna: brak'}
-            </span>
-          </div>
-        </div>
+      <PageHeader
+        eyebrow="Szablon komunikatu"
+        title={group.name}
+        description={group.description || 'Brak opisu operacyjnego dla tego szablonu.'}
+        actions={
+          <>
+            <Button type="button" onClick={onBack}>
+              Wróć do listy
+            </Button>
+            <Button type="button" onClick={() => onCreateDraft(group)} variant="primary">
+              Utwórz nową wersję roboczą
+            </Button>
+          </>
+        }
+      />
 
-        <button type="button" onClick={() => onCreateDraft(group)} className="btn-primary">
-          Utworz nowa wersje robocza
-        </button>
+      <div className="flex flex-wrap gap-2">
+        <Badge tone={group.publishedVersion ? 'green' : 'amber'} leadingDot>
+          {group.publishedVersion ? 'Opublikowana' : 'Brak opublikowanej wersji'}
+        </Badge>
+        <Badge tone="brand">
+          {group.publishedVersion
+            ? `Wersja aktywna: v${group.publishedVersion.versionNumber}`
+            : 'Wersja aktywna: brak'}
+        </Badge>
       </div>
 
       {feedbackSuccess && (
-        <div className="rounded-2xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-          {feedbackSuccess}
-        </div>
+        <AlertBanner tone="success" title="Zapisano zmianę" description={feedbackSuccess} />
       )}
 
       {feedbackError && (
-        <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {feedbackError}
-        </div>
+        <AlertBanner tone="danger" title="Nie udało się wykonać akcji" description={feedbackError} />
       )}
 
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-xl font-semibold text-gray-900">Aktualnie uzywane operacyjnie</h2>
-          <p className="mt-2 text-sm text-gray-600">
-            To ta wersja jest obecnie wykorzystywana przez system przy tworzeniu nowych draftow komunikacji.
-          </p>
-        </div>
-
+      <SectionCard
+        title="Aktualnie opublikowana wersja"
+        description="Ta wersja jest obecnie używana przez system przy przygotowywaniu komunikacji."
+      >
         {group.publishedVersion ? (
           <CommunicationTemplateVersionCard
             version={group.publishedVersion}
@@ -146,20 +138,17 @@ export function CommunicationTemplateDetail({
             onDetails={onDetailsVersion}
           />
         ) : (
-          <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-8 text-sm text-gray-600">
-            Brak opublikowanej wersji tego szablonu.
-          </div>
+          <EmptyState
+            title="Brak opublikowanej wersji"
+            description="Utwórz wersję roboczą, sprawdź podgląd i opublikuj ją dopiero po weryfikacji treści."
+          />
         )}
-      </section>
+      </SectionCard>
 
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-xl font-semibold text-gray-900">Wersje robocze</h2>
-          <p className="mt-2 text-sm text-gray-600">
-            Zmiany przygotowujesz w wersjach roboczych. Opublikowanej wersji nie edytujemy bezposrednio.
-          </p>
-        </div>
-
+      <SectionCard
+        title="Wersje robocze"
+        description="Tutaj przygotowujesz zmiany. Opublikowana wersja pozostaje aktywna do momentu świadomej publikacji."
+      >
         {group.draftVersions.length > 0 ? (
           <div className="space-y-4">
             {group.draftVersions.map((version) => (
@@ -178,35 +167,44 @@ export function CommunicationTemplateDetail({
             ))}
           </div>
         ) : (
-          <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-8 text-sm text-gray-600">
-            Brak wersji roboczych. Aby przygotowac zmiany, utworz nowa wersje robocza na podstawie aktualnie opublikowanego szablonu.
-          </div>
+          <EmptyState
+            title="Brak wersji roboczych"
+            description="Aby przygotować zmianę treści, utwórz nową wersję roboczą na podstawie istniejącego szablonu."
+          />
         )}
-      </section>
+      </SectionCard>
 
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-xl font-semibold text-gray-900">Historia wersji</h2>
-          <p className="mt-2 text-sm text-gray-600">
-            Lista wszystkich wersji od najnowszej do najstarszej, z widocznym statusem i szybkim podgladem.
-          </p>
-        </div>
+      <SectionCard
+        title="Wersje archiwalne"
+        description="Historia poprzednich wersji jest dostępna do wglądu i klonowania, bez wpływu na aktywną komunikację."
+      >
+        {group.archivedVersions.length > 0 ? (
+          <div className="space-y-4">
+            {group.archivedVersions.map((version) => (
+              <CommunicationTemplateVersionCard
+                key={version.id}
+                version={version}
+                title={`${group.name} - v${version.versionNumber}`}
+                subtitle={`Utworzono ${formatDateTime(version.createdAt)} · ostatnia zmiana ${formatDateTime(version.updatedAt)}.`}
+                onPreview={onPreviewVersion}
+                onClone={onCloneVersion}
+                onDetails={onDetailsVersion}
+              />
+            ))}
+          </div>
+        ) : (
+          <EmptyState title="Brak wersji archiwalnych" description="Ten szablon nie ma jeszcze starszych wersji." />
+        )}
+      </SectionCard>
 
-        <div className="space-y-4">
-          {group.versions.map((version) => (
-            <CommunicationTemplateVersionCard
-              key={version.id}
-              version={version}
-              title={`${group.name} - v${version.versionNumber}`}
-              subtitle={`Utworzono ${formatDateTime(version.createdAt)} · ostatnia zmiana ${formatDateTime(version.updatedAt)}.`}
-              onPreview={onPreviewVersion}
-              onArchive={version.status === 'DRAFT' ? onArchiveVersion : undefined}
-              onClone={onCloneVersion}
-              onDetails={onDetailsVersion}
-            />
-          ))}
-        </div>
-      </section>
+      <SectionCard title="Metadane szablonu" description="Informacje porządkujące szablon w administracji.">
+        <dl className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <DataField label="Kod komunikatu" value={group.code} mono />
+          <DataField label="Kanał" value={CONTACT_CHANNEL_LABELS[group.channel]} />
+          <DataField label="Wersje łącznie" value={group.versions.length} />
+          <DataField label="Ostatnia aktualizacja" value={formatDateTime(group.lastUpdatedAt)} />
+        </dl>
+      </SectionCard>
 
       <CommunicationTemplatePlaceholdersCard code={group.code} />
     </div>

--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplateEditor.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplateEditor.tsx
@@ -7,6 +7,7 @@ import {
 } from '@np-manager/shared'
 import type { CommunicationTemplatePreviewResult } from '@/lib/communicationTemplates'
 import { getSupportedCommunicationTemplateChannelOptions } from '@/lib/communicationTemplateAdmin'
+import { AlertBanner, Badge, Button, DataField, PageHeader, SectionCard } from '@/components/ui'
 import { CommunicationTemplatePlaceholdersCard } from './CommunicationTemplatePlaceholdersCard'
 import { CommunicationTemplateValidationPanel } from './CommunicationTemplateValidationPanel'
 import type {
@@ -64,8 +65,8 @@ export function CommunicationTemplateEditor({
     bodyTemplate: false,
   })
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
-  const subjectError = !form.subjectTemplate.trim() ? 'Temat wiadomosci jest wymagany.' : null
-  const bodyError = !form.bodyTemplate.trim() ? 'Tresc wiadomosci jest wymagana.' : null
+  const subjectError = !form.subjectTemplate.trim() ? 'Temat wiadomości jest wymagany.' : null
+  const bodyError = !form.bodyTemplate.trim() ? 'Treść wiadomości jest wymagana.' : null
   const nameError = !form.name.trim() ? 'Nazwa biznesowa jest wymagana.' : null
   const shouldShowNameError = !!nameError && (hasAttemptedSubmit || touchedFields.name)
   const shouldShowSubjectError = !!subjectError && (hasAttemptedSubmit || touchedFields.subjectTemplate)
@@ -78,7 +79,7 @@ export function CommunicationTemplateEditor({
       return null
     }
 
-    return 'Uzupelnij wymagane pola przed zapisem lub publikacja.'
+    return 'Uzupełnij wymagane pola przed zapisem lub publikacją.'
   }, [hasAttemptedSubmit, hasRequiredFieldErrors])
 
   useEffect(() => {
@@ -119,39 +120,32 @@ export function CommunicationTemplateEditor({
 
   return (
     <div className="space-y-6 p-6">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="max-w-3xl">
-          <h1 className="text-3xl font-semibold tracking-tight text-gray-900">{title}</h1>
-          <p className="mt-3 text-sm leading-6 text-gray-600">{subtitle}</p>
-        </div>
-
-        <button type="button" onClick={onCancel} className="btn-secondary">
-          Anuluj
-        </button>
-      </div>
+      <PageHeader
+        eyebrow="Edycja szablonu"
+        title={title}
+        description={subtitle}
+        actions={
+          <Button type="button" onClick={onCancel}>
+            Anuluj
+          </Button>
+        }
+      />
 
       {feedbackSuccess && (
-        <div className="rounded-2xl border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-          {feedbackSuccess}
-        </div>
+        <AlertBanner tone="success" title="Wersja robocza zapisana" description={feedbackSuccess} />
       )}
 
       {(feedbackError || validationFeedbackError) && (
-        <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {feedbackError ?? validationFeedbackError}
-        </div>
+        <AlertBanner tone="danger" title="Nie można kontynuować" description={feedbackError ?? validationFeedbackError} />
       )}
 
       <div className="grid gap-6 xl:grid-cols-[1.45fr,0.95fr]">
         <div className="space-y-6">
-          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
-            <div className="mb-5">
-              <h2 className="text-lg font-semibold text-gray-900">Dane podstawowe</h2>
-              <p className="mt-2 text-sm text-gray-600">
-                Te dane identyfikuja szablon i porzadkuja komunikacje po stronie administracyjnej.
-              </p>
-            </div>
-
+          <SectionCard
+            title="Dane podstawowe"
+            description="Te dane identyfikują szablon i porządkują komunikację po stronie administracyjnej."
+            padding="md"
+          >
             <div className="grid gap-4 lg:grid-cols-2">
               <label className="block">
                 <span className="label">Nazwa biznesowa</span>
@@ -161,7 +155,7 @@ export function CommunicationTemplateEditor({
                   onChange={(event) => onChange('name', event.target.value)}
                   onBlur={() => markFieldTouched('name')}
                   className={`input-field ${shouldShowNameError ? 'input-error' : ''}`}
-                  placeholder="Np. Potwierdzenie przyjecia sprawy"
+                  placeholder="Np. Potwierdzenie przyjęcia sprawy"
                 />
                 {shouldShowNameError && <p className="error-message">{nameError}</p>}
               </label>
@@ -183,7 +177,7 @@ export function CommunicationTemplateEditor({
               </label>
 
               <label className="block">
-                <span className="label">Kanal</span>
+                <span className="label">Kanał</span>
                 <select
                   value={form.channel}
                   onChange={(event) => onChange('channel', event.target.value as ContactChannel)}
@@ -199,25 +193,21 @@ export function CommunicationTemplateEditor({
               </label>
 
               <label className="block">
-                <span className="label">Opis wewnetrzny</span>
+                <span className="label">Opis wewnętrzny</span>
                 <textarea
                   value={form.description}
                   onChange={(event) => onChange('description', event.target.value)}
                   className="input-field min-h-[108px]"
-                  placeholder="Krotki opis dla administratora i QA"
+                  placeholder="Krótki opis dla administratora i QA"
                 />
               </label>
             </div>
-          </section>
+          </SectionCard>
 
-          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
-            <div className="mb-5">
-              <h2 className="text-lg font-semibold text-gray-900">Temat wiadomosci</h2>
-              <p className="mt-2 text-sm text-gray-600">
-                Mozesz uzywac placeholderow, np. {'{{portedNumber}}'} lub {'{{plannedPortDate}}'}.
-              </p>
-            </div>
-
+          <SectionCard
+            title="Temat wiadomości"
+            description={<>Możesz używać placeholderów, np. {'{{portedNumber}}'} lub {'{{plannedPortDate}}'}.</>}
+          >
             <textarea
               value={form.subjectTemplate}
               onChange={(event) => onChange('subjectTemplate', event.target.value)}
@@ -226,110 +216,91 @@ export function CommunicationTemplateEditor({
               placeholder="Np. Sprawa {{caseNumber}} - aktualizacja procesu"
             />
             {shouldShowSubjectError && <p className="error-message">{subjectError}</p>}
-          </section>
+          </SectionCard>
 
-          <section className="rounded-3xl border border-gray-200 bg-white p-6 shadow-sm">
-            <div className="mb-5">
-              <h2 className="text-lg font-semibold text-gray-900">Tresc wiadomosci</h2>
-              <p className="mt-2 text-sm text-gray-600">
-                Tresc zostanie wyrenderowana z danymi sprawy podczas tworzenia draftu.
-              </p>
-            </div>
-
+          <SectionCard
+            title="Treść wiadomości"
+            description="Treść zostanie wyrenderowana z danymi sprawy podczas przygotowania komunikatu."
+          >
             <textarea
               value={form.bodyTemplate}
               onChange={(event) => onChange('bodyTemplate', event.target.value)}
               onBlur={() => markFieldTouched('bodyTemplate')}
               className={`input-field min-h-[340px] font-mono ${shouldShowBodyError ? 'input-error' : ''}`}
-              placeholder={'Dzien dobry {{clientName}},\n\nnumer sprawy: {{caseNumber}}'}
+              placeholder={'Dzień dobry {{clientName}},\n\nnumer sprawy: {{caseNumber}}'}
             />
             {shouldShowBodyError && <p className="error-message">{bodyError}</p>}
 
             <div className="mt-5 space-y-3">
-              <div className="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700">
-                {preview.usedPlaceholders.length > 0 ? (
-                  <>
-                    Wykryte placeholdery:{' '}
-                    {preview.usedPlaceholders.map((item) => `{{${item}}}`).join(', ')}
-                  </>
-                ) : (
-                  'W tej wersji nie wykryto placeholderow.'
-                )}
-              </div>
+                <AlertBanner
+                  tone="neutral"
+                  title="Placeholdery w tej wersji"
+                  description={
+                    preview.usedPlaceholders.length > 0
+                      ? preview.usedPlaceholders.map((item) => `{{${item}}}`).join(', ')
+                      : 'W tej wersji nie wykryto placeholderów.'
+                  }
+                />
 
               {preview.unknownPlaceholders.length > 0 && (
-                <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-                  Wykryto nieznane placeholdery:{' '}
-                  {preview.unknownPlaceholders.map((item) => `{{${item}}}`).join(', ')}
-                </div>
+                <AlertBanner
+                  tone="warning"
+                  title="Nieznane placeholdery"
+                  description={preview.unknownPlaceholders.map((item) => `{{${item}}}`).join(', ')}
+                />
               )}
             </div>
-          </section>
+          </SectionCard>
 
-          <div className="sticky bottom-0 z-10 rounded-3xl border border-gray-200 bg-white/95 p-4 shadow-xl backdrop-blur">
+          <div className="sticky bottom-0 z-10 rounded-panel border border-line bg-surface/95 p-4 shadow-panel backdrop-blur">
             <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="text-sm text-gray-600">
+              <div className="flex items-center gap-2 text-sm text-ink-600">
+                <Badge tone={isPublishReady ? 'green' : 'amber'} leadingDot>
+                  {isPublishReady ? 'Gotowa do publikacji' : 'Wymaga uwagi'}
+                </Badge>
                 {isPublishReady
                   ? 'Wersja jest gotowa do publikacji.'
-                  : 'Przed publikacja popraw walidacje widoczne po prawej stronie.'}
+                  : 'Przed publikacją popraw walidację widoczną po prawej stronie.'}
               </div>
 
-              <div className="flex flex-wrap gap-3">
-                <button
+              <div className="flex flex-wrap gap-2">
+                <Button
                   type="button"
                   onClick={handleSaveClick}
-                  className="btn-secondary"
-                  disabled={isSaving || isPublishing}
+                  disabled={isPublishing}
+                  isLoading={isSaving}
+                  loadingLabel="Zapisywanie..."
                 >
-                  {isSaving ? 'Zapisywanie...' : 'Zapisz draft'}
-                </button>
-                <button type="button" onClick={onPreview} className="btn-secondary" disabled={isSaving || isPublishing}>
-                  Podglad
-                </button>
-                <button
+                  Zapisz wersję roboczą
+                </Button>
+                <Button type="button" onClick={onPreview} disabled={isSaving || isPublishing}>
+                  Podgląd
+                </Button>
+                <Button
                   type="button"
                   onClick={handlePublishClick}
-                  className="btn-primary"
+                  variant="primary"
                   disabled={!isPublishReady || isSaving || isPublishing}
                 >
-                  {isPublishing ? 'Publikowanie...' : 'Publikuj'}
-                </button>
-                <button type="button" onClick={onCancel} className="btn-secondary" disabled={isSaving || isPublishing}>
+                  Publikuj
+                </Button>
+                <Button type="button" onClick={onCancel} disabled={isSaving || isPublishing}>
                   Anuluj
-                </button>
+                </Button>
               </div>
             </div>
           </div>
         </div>
 
         <div className="space-y-6">
-          <section className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-gray-500">
-              Status wersji
-            </h2>
-            <div className="mt-4 space-y-3 text-sm text-gray-700">
-              <div className="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3">
-                <div className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Wersja</div>
-                <div className="mt-1 text-base font-medium text-gray-900">{statusInfo.versionLabel}</div>
-              </div>
-              <div className="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3">
-                <div className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Status</div>
-                <div className="mt-1 text-base font-medium text-gray-900">{statusInfo.statusLabel}</div>
-              </div>
-              <div className="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3">
-                <div className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Ostatnia edycja</div>
-                <div className="mt-1 text-base font-medium text-gray-900">
-                  {statusInfo.lastEditedAt ?? 'Jeszcze nie zapisano'}
-                </div>
-              </div>
-              <div className="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3">
-                <div className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Autor</div>
-                <div className="mt-1 text-base font-medium text-gray-900">
-                  {statusInfo.lastEditedByDisplayName ?? 'Biezacy administrator'}
-                </div>
-              </div>
-            </div>
-          </section>
+          <SectionCard title="Status wersji" description="Bieżący stan edytowanej wersji szablonu.">
+            <dl className="space-y-3">
+              <DataField label="Wersja" value={statusInfo.versionLabel} />
+              <DataField label="Status" value={statusInfo.statusLabel} />
+              <DataField label="Ostatnia edycja" value={statusInfo.lastEditedAt ?? 'Jeszcze nie zapisano'} />
+              <DataField label="Autor" value={statusInfo.lastEditedByDisplayName ?? 'Bieżący administrator'} />
+            </dl>
+          </SectionCard>
 
           <CommunicationTemplatePlaceholdersCard code={form.code} />
 
@@ -340,30 +311,27 @@ export function CommunicationTemplateEditor({
             showRequiredFieldIssues={hasAttemptedSubmit}
           />
 
-          <section className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-gray-500">
-              Szybki podglad
-            </h2>
-            <p className="mt-2 text-sm leading-6 text-gray-600">
-              Podglad korzysta z testowych danych biznesowych i pomaga ocenic tonalnosc komunikatu.
-            </p>
-            <div className="mt-4 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-4">
-              <div className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Temat</div>
-              <p className="mt-2 text-sm text-gray-800">
+          <SectionCard
+            title="Szybki podgląd"
+            description="Podgląd korzysta z testowych danych biznesowych i pomaga ocenić ton komunikatu."
+          >
+            <div className="rounded-panel border border-line bg-ink-50/60 px-4 py-4">
+              <div className="text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">Temat</div>
+              <p className="mt-2 text-sm text-ink-800">
                 {preview.renderedSubject || 'Brak tematu.'}
               </p>
             </div>
-            <div className="mt-4 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-4">
-              <div className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Tresc</div>
-              <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-gray-800">
-                {preview.renderedBody.slice(0, 280) || 'Brak tresci.'}
+            <div className="mt-4 rounded-panel border border-line bg-ink-50/60 px-4 py-4">
+              <div className="text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">Treść</div>
+              <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-ink-800">
+                {preview.renderedBody.slice(0, 280) || 'Brak treści.'}
                 {preview.renderedBody.length > 280 ? '...' : ''}
               </p>
             </div>
-            <button type="button" onClick={onPreview} className="btn-secondary mt-4">
-              Otworz pelny podglad
-            </button>
-          </section>
+            <Button type="button" onClick={onPreview} className="mt-4">
+              Otwórz pełny podgląd
+            </Button>
+          </SectionCard>
         </div>
       </div>
     </div>

--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatePlaceholdersCard.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatePlaceholdersCard.tsx
@@ -1,5 +1,6 @@
 import type { CommunicationTemplateCode } from '@np-manager/shared'
 import { getCommunicationTemplatePlaceholderItems } from '@/lib/communicationTemplates'
+import { DataField, SectionCard } from '@/components/ui'
 
 interface CommunicationTemplatePlaceholdersCardProps {
   code?: CommunicationTemplateCode
@@ -9,32 +10,31 @@ interface CommunicationTemplatePlaceholdersCardProps {
 
 export function CommunicationTemplatePlaceholdersCard({
   code,
-  title = 'Dostepne placeholdery',
-  description = 'Uzyj placeholderow w temacie lub tresci, aby system uzupelnil dane sprawy podczas tworzenia komunikatu.',
+  title = 'Dostępne placeholdery',
+  description = 'Użyj placeholderów w temacie lub treści, aby system uzupełnił dane sprawy podczas tworzenia komunikatu.',
 }: CommunicationTemplatePlaceholdersCardProps) {
   const placeholders = getCommunicationTemplatePlaceholderItems()
 
   return (
-    <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-      <div className="mb-4">
-        <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-gray-500">{title}</h2>
-        <p className="mt-2 text-sm leading-6 text-gray-600">
+    <SectionCard
+      title={title}
+      description={
+        <>
           {description}
-          {code ? ` Dla kodu ${code} pelna walidacja per typ bedzie rozszerzana w kolejnym etapie.` : ''}
-        </p>
-      </div>
-
+          {code ? ` Dla kodu ${code} pełna walidacja per typ będzie rozszerzana w kolejnym etapie.` : ''}
+        </>
+      }
+    >
       <div className="space-y-3">
         {placeholders.map((item) => (
           <div
             key={item.placeholder}
-            className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3"
+            className="rounded-panel border border-line bg-ink-50/60 px-4 py-3"
           >
-            <div className="font-mono text-xs text-gray-900">{`{{${item.placeholder}}}`}</div>
-            <p className="mt-1 text-sm text-gray-600">{item.label}</p>
+            <DataField label={`{{${item.placeholder}}}`} value={item.label} mono />
           </div>
         ))}
       </div>
-    </section>
+    </SectionCard>
   )
 }

--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatePreviewModal.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatePreviewModal.tsx
@@ -4,6 +4,7 @@ import {
   type CommunicationTemplatePreviewResult,
 } from '@/lib/communicationTemplates'
 import { createPreviewModalKeydownHandler as createEscapeHandler } from '@/lib/communicationTemplateAdmin'
+import { AlertBanner, Badge, Button, DataField, SectionCard } from '@/components/ui'
 
 interface CommunicationTemplatePreviewModalProps {
   isOpen: boolean
@@ -60,50 +61,42 @@ export function CommunicationTemplatePreviewModal({
   const placeholders = getCommunicationTemplatePlaceholderItems()
 
   return (
-    <div className="fixed inset-0 z-40 flex items-center justify-center bg-gray-950/50 px-4 py-6">
-      <div className="max-h-[90vh] w-full max-w-5xl overflow-hidden rounded-3xl bg-white shadow-2xl">
-        <div className="flex items-start justify-between gap-4 border-b border-gray-200 px-6 py-5">
+    <div className="fixed inset-0 z-40 flex items-center justify-center bg-ink-950/50 px-4 py-6">
+      <div className="max-h-[90vh] w-full max-w-5xl overflow-hidden rounded-panel bg-surface shadow-2xl">
+        <div className="flex items-start justify-between gap-4 border-b border-line px-6 py-5">
           <div>
-            <h2 className="text-xl font-semibold text-gray-900">{title}</h2>
-            <p className="mt-2 text-sm text-gray-600">
+            <h2 className="text-xl font-semibold text-ink-900">{title}</h2>
+            <p className="mt-2 text-sm text-ink-600">
               {subtitle ??
-                'Sprawdz temat, tresc oraz placeholdery przed zapisaniem lub publikacja wersji.'}
+                'Sprawdź temat, treść oraz placeholdery przed zapisaniem lub publikacją wersji.'}
             </p>
           </div>
 
-          <button type="button" onClick={onClose} className="btn-secondary">
+          <Button type="button" onClick={onClose}>
             Zamknij
-          </button>
+          </Button>
         </div>
 
-        <div className="border-b border-gray-200 px-6 py-4">
+        <div className="border-b border-line px-6 py-4">
           <div className="flex flex-wrap gap-3">
-            <button
+            <Button
               type="button"
               onClick={() => onModeChange('TEST')}
-              className={`rounded-full px-4 py-2 text-sm font-medium ${
-                mode === 'TEST'
-                  ? 'bg-blue-600 text-white'
-                  : 'border border-gray-200 bg-white text-gray-700'
-              }`}
+              variant={mode === 'TEST' ? 'primary' : 'secondary'}
             >
               Dane testowe
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
               onClick={() => onModeChange('REAL')}
-              className={`rounded-full px-4 py-2 text-sm font-medium ${
-                mode === 'REAL'
-                  ? 'bg-blue-600 text-white'
-                  : 'border border-gray-200 bg-white text-gray-700'
-              }`}
+              variant={mode === 'REAL' ? 'primary' : 'secondary'}
             >
               Realna sprawa
-            </button>
+            </Button>
           </div>
 
           {mode === 'REAL' && (
-            <div className="mt-4 space-y-4 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-4">
+            <div className="mt-4 space-y-4 rounded-panel border border-line bg-ink-50/60 px-4 py-4">
               <div className="grid gap-3 lg:grid-cols-[1.4fr,auto]">
                 <label className="block">
                   <span className="label">Numer sprawy lub ID sprawy</span>
@@ -118,34 +111,33 @@ export function CommunicationTemplatePreviewModal({
                 </label>
 
                 <div className="flex items-end">
-                  <button
+                  <Button
                     type="button"
                     onClick={onRunRealCasePreview}
-                    className="btn-primary"
+                    variant="primary"
                     disabled={!isRealCaseAvailable || isRealCaseLoading}
+                    isLoading={isRealCaseLoading}
+                    loadingLabel="Ładowanie..."
                   >
-                    {isRealCaseLoading ? 'Ladowanie...' : 'Uruchom preview'}
-                  </button>
+                    Uruchom podgląd
+                  </Button>
                 </div>
               </div>
 
               {!isRealCaseAvailable && (
-                <div className="rounded-xl border border-dashed border-gray-300 bg-white px-4 py-3 text-sm text-gray-600">
-                  {realCaseHelpText ??
-                    'Preview na realnej sprawie jest dostepny dla zapisanych wersji backendowych.'}
-                </div>
+                <AlertBanner
+                  tone="neutral"
+                  title="Podgląd na realnej sprawie jest niedostępny"
+                  description={realCaseHelpText ?? 'Podgląd na realnej sprawie jest dostępny dla zapisanych wersji.'}
+                />
               )}
 
               {isRealCaseAvailable && realCaseHelpText && (
-                <div className="rounded-xl border border-gray-200 bg-white px-4 py-3 text-sm text-gray-600">
-                  {realCaseHelpText}
-                </div>
+                <AlertBanner tone="info" title="Podgląd na realnej sprawie" description={realCaseHelpText} />
               )}
 
               {realCaseError && (
-                <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-                  {realCaseError}
-                </div>
+                <AlertBanner tone="danger" title="Nie udało się przygotować podglądu" description={realCaseError} />
               )}
             </div>
           )}
@@ -154,144 +146,110 @@ export function CommunicationTemplatePreviewModal({
         <div className="grid max-h-[calc(90vh-180px)] gap-6 overflow-y-auto px-6 py-6 lg:grid-cols-[1.45fr,0.95fr]">
           <div className="space-y-5">
             {mode === 'REAL' && preview.previewContextSummary && (
-              <section className="rounded-2xl border border-blue-200 bg-blue-50 p-5">
-                <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-blue-700">
-                  Preview realnej sprawy
-                </h3>
-                <div className="mt-3 grid gap-3 text-sm text-blue-900 md:grid-cols-2">
-                  <div>
-                    <div className="text-xs font-semibold uppercase tracking-[0.14em] text-blue-700">
-                      Sprawa
-                    </div>
-                    <div className="mt-1">{preview.previewContextSummary.caseNumber}</div>
-                  </div>
-                  <div>
-                    <div className="text-xs font-semibold uppercase tracking-[0.14em] text-blue-700">
-                      Klient
-                    </div>
-                    <div className="mt-1">{preview.previewContextSummary.clientName}</div>
-                  </div>
-                  <div>
-                    <div className="text-xs font-semibold uppercase tracking-[0.14em] text-blue-700">
-                      Dawca
-                    </div>
-                    <div className="mt-1">{preview.previewContextSummary.donorOperatorName}</div>
-                  </div>
-                  <div>
-                    <div className="text-xs font-semibold uppercase tracking-[0.14em] text-blue-700">
-                      Planowana data
-                    </div>
-                    <div className="mt-1">{preview.previewContextSummary.plannedPortDate ?? 'Brak danych'}</div>
-                  </div>
-                </div>
-                <p className="mt-3 text-sm text-blue-800">
-                  Preview uruchomiono na: {realCaseLabel}
-                </p>
-              </section>
+              <SectionCard title="Podgląd na realnej sprawie" description={`Uruchomiono na: ${realCaseLabel}`}>
+                <dl className="grid gap-3 text-sm md:grid-cols-2">
+                  <DataField label="Sprawa" value={preview.previewContextSummary.caseNumber} />
+                  <DataField label="Klient" value={preview.previewContextSummary.clientName} />
+                  <DataField label="Dawca" value={preview.previewContextSummary.donorOperatorName} />
+                  <DataField label="Planowana data" value={preview.previewContextSummary.plannedPortDate ?? 'Brak danych'} />
+                </dl>
+              </SectionCard>
             )}
 
-            <section className="rounded-2xl border border-gray-200 bg-gray-50 p-5">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500">
-                Temat
-              </h3>
-              <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-gray-800">
+            <SectionCard title="Temat">
+              <p className="whitespace-pre-wrap text-sm leading-6 text-ink-800">
                 {preview.renderedSubject || 'Brak tematu.'}
               </p>
-            </section>
+            </SectionCard>
 
-            <section className="rounded-2xl border border-gray-200 bg-gray-50 p-5">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500">
-                Tresc
-              </h3>
-              <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-gray-800">
-                {preview.renderedBody || 'Brak tresci.'}
+            <SectionCard title="Treść">
+              <p className="whitespace-pre-wrap text-sm leading-6 text-ink-800">
+                {preview.renderedBody || 'Brak treści.'}
               </p>
-            </section>
+            </SectionCard>
           </div>
 
           <div className="space-y-5">
-            <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500">
-                Stan renderowania
-              </h3>
-              <div
-                className={`mt-3 rounded-xl border px-4 py-3 text-sm ${
+            <SectionCard title="Stan renderowania">
+              <AlertBanner
+                tone={preview.isRenderable ? 'success' : 'warning'}
+                title={
                   preview.isRenderable
-                    ? 'border-green-200 bg-green-50 text-green-700'
-                    : 'border-amber-200 bg-amber-50 text-amber-800'
-                }`}
-              >
-                {preview.isRenderable
-                  ? mode === 'REAL'
-                    ? 'Szablon jest renderowalny na wskazanej sprawie.'
-                    : 'Szablon jest renderowalny na danych testowych.'
-                  : 'Szablon wymaga poprawek przed publikacja.'}
-              </div>
-            </section>
+                    ? mode === 'REAL'
+                      ? 'Szablon renderuje się na wskazanej sprawie.'
+                      : 'Szablon renderuje się na danych testowych.'
+                    : 'Szablon wymaga poprawek przed publikacją.'
+                }
+              />
+            </SectionCard>
 
-            <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500">
-                Uzyte placeholdery
-              </h3>
+            <SectionCard title="Użyte placeholdery">
               <div className="mt-3 flex flex-wrap gap-2">
                 {preview.usedPlaceholders.length > 0 ? (
                   preview.usedPlaceholders.map((item) => (
-                    <span
-                      key={item}
-                      className="rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs font-medium text-gray-700"
-                    >
+                    <Badge key={item} tone="neutral">
                       {`{{${item}}}`}
-                    </span>
+                    </Badge>
                   ))
                 ) : (
-                  <span className="text-sm text-gray-500">Brak placeholderow.</span>
+                  <span className="text-sm text-ink-500">Brak placeholderów.</span>
                 )}
               </div>
-            </section>
+            </SectionCard>
 
-            <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500">
-                Problemy
-              </h3>
-              <div className="mt-3 space-y-3 text-sm">
-                <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-gray-700">
-                  {preview.unknownPlaceholders.length > 0
-                    ? `Nieznane placeholdery: ${preview.unknownPlaceholders.map((item) => `{{${item}}}`).join(', ')}`
-                    : 'Brak nieznanych placeholderow.'}
-                </div>
-                <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-gray-700">
-                  {preview.missingPlaceholders.length > 0
-                    ? `Brakujace dane: ${preview.missingPlaceholders.map((item) => `{{${item}}}`).join(', ')}`
-                    : mode === 'REAL'
-                      ? 'Brak brakujacych danych w wybranej sprawie.'
-                      : 'Brak brakujacych danych testowych.'}
-                </div>
+            <SectionCard title="Problemy">
+              <div className="space-y-3 text-sm">
+                <AlertBanner
+                  tone={preview.unknownPlaceholders.length > 0 ? 'warning' : 'neutral'}
+                  title={preview.unknownPlaceholders.length > 0 ? 'Nieznane placeholdery' : 'Brak nieznanych placeholderów.'}
+                  description={
+                    preview.unknownPlaceholders.length > 0
+                      ? preview.unknownPlaceholders.map((item) => `{{${item}}}`).join(', ')
+                      : undefined
+                  }
+                />
+                <AlertBanner
+                  tone={preview.missingPlaceholders.length > 0 ? 'warning' : 'neutral'}
+                  title={
+                    preview.missingPlaceholders.length > 0
+                      ? 'Brakujące dane'
+                      : mode === 'REAL'
+                        ? 'Brak brakujących danych w wybranej sprawie.'
+                        : 'Brak brakujących danych testowych.'
+                  }
+                  description={
+                    preview.missingPlaceholders.length > 0
+                      ? preview.missingPlaceholders.map((item) => `{{${item}}}`).join(', ')
+                      : undefined
+                  }
+                />
                 {preview.warnings.length > 0 && (
-                  <div className="rounded-xl border border-orange-200 bg-orange-50 px-4 py-3 text-orange-700">
-                    <ul className="space-y-1">
-                      {preview.warnings.map((warning) => (
-                        <li key={warning}>{warning}</li>
-                      ))}
-                    </ul>
-                  </div>
+                  <AlertBanner
+                    tone="warning"
+                    title="Uwagi"
+                    description={
+                      <ul className="space-y-1">
+                        {preview.warnings.map((warning) => (
+                          <li key={warning}>{warning}</li>
+                        ))}
+                      </ul>
+                    }
+                  />
                 )}
               </div>
-            </section>
+            </SectionCard>
 
-            <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-              <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-gray-500">
-                Sciaga placeholderow
-              </h3>
+            <SectionCard title="Ściąga placeholderów">
               <div className="mt-3 space-y-2">
                 {placeholders.map((item) => (
-                  <div key={item.placeholder} className="text-sm text-gray-600">
-                    <span className="font-mono text-xs text-gray-900">{`{{${item.placeholder}}}`}</span>
+                  <div key={item.placeholder} className="text-sm text-ink-600">
+                    <span className="font-mono text-xs text-ink-900">{`{{${item.placeholder}}}`}</span>
                     {' - '}
                     {item.label}
                   </div>
                 ))}
               </div>
-            </section>
+            </SectionCard>
           </div>
         </div>
       </div>

--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatePublishModal.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatePublishModal.tsx
@@ -1,3 +1,5 @@
+import { AlertBanner, Button } from '@/components/ui'
+
 interface CommunicationTemplatePublishModalProps {
   isOpen: boolean
   versionLabel: string
@@ -22,32 +24,43 @@ export function CommunicationTemplatePublishModal({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-gray-950/50 px-4 py-6">
-      <div className="w-full max-w-xl rounded-3xl bg-white p-6 shadow-2xl">
-        <h2 className="text-xl font-semibold text-gray-900">Opublikowac te wersje?</h2>
-        <p className="mt-3 text-sm leading-6 text-gray-600">
-          Po publikacji ta wersja stanie sie aktywnym szablonem uzywanym przez system przy
-          tworzeniu nowych draftow komunikacji. Poprzednia opublikowana wersja zostanie zastapiona.
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-ink-950/50 px-4 py-6">
+      <div className="w-full max-w-xl rounded-panel bg-surface p-6 shadow-2xl">
+        <h2 className="text-xl font-semibold text-ink-900">Opublikować tę wersję?</h2>
+        <p className="mt-3 text-sm leading-6 text-ink-600">
+          Po publikacji ta wersja stanie się aktywnym szablonem używanym przez system przy
+          przygotowywaniu nowych komunikatów. Poprzednia opublikowana wersja zostanie zastąpiona.
         </p>
 
-        <div className="mt-5 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-4">
-          <div className="text-sm font-medium text-gray-900">{templateName}</div>
-          <div className="mt-1 text-sm text-gray-600">{versionLabel}</div>
+        <AlertBanner
+          tone="warning"
+          title="Publikacja wpływa na przyszłe komunikaty"
+          description="Przed zatwierdzeniem upewnij się, że temat, treść i placeholdery zostały sprawdzone w podglądzie."
+          className="mt-5"
+        />
+
+        <div className="mt-5 rounded-panel border border-line bg-ink-50/60 px-4 py-4">
+          <div className="text-sm font-medium text-ink-900">{templateName}</div>
+          <div className="mt-1 text-sm text-ink-600">{versionLabel}</div>
         </div>
 
         {publishError && (
-          <div className="mt-5 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-            {publishError}
-          </div>
+          <AlertBanner tone="danger" title="Nie udało się opublikować wersji" description={publishError} className="mt-5" />
         )}
 
-        <div className="mt-6 flex flex-wrap justify-end gap-3">
-          <button type="button" onClick={onCancel} className="btn-secondary" disabled={isPublishing}>
+        <div className="mt-6 flex flex-wrap justify-end gap-2">
+          <Button type="button" onClick={onCancel} disabled={isPublishing}>
             Anuluj
-          </button>
-          <button type="button" onClick={onConfirm} className="btn-primary" disabled={isPublishing}>
-            {isPublishing ? 'Publikowanie...' : 'Publikuj wersje'}
-          </button>
+          </Button>
+          <Button
+            type="button"
+            onClick={onConfirm}
+            variant="primary"
+            isLoading={isPublishing}
+            loadingLabel="Publikowanie..."
+          >
+            Publikuj wersję
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplateValidationPanel.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplateValidationPanel.tsx
@@ -1,4 +1,5 @@
 import type { CommunicationTemplatePreviewResult } from '@/lib/communicationTemplates'
+import { AlertBanner, SectionCard } from '@/components/ui'
 
 interface CommunicationTemplateValidationPanelProps {
   preview: CommunicationTemplatePreviewResult
@@ -18,11 +19,11 @@ export function CommunicationTemplateValidationPanel({
   const hasEmptyRequiredFields = !subjectTemplate.trim() || !bodyTemplate.trim()
 
   if (showRequiredFieldIssues && !subjectTemplate.trim()) {
-    issues.push('Temat wiadomosci jest wymagany.')
+    issues.push('Temat wiadomości jest wymagany.')
   }
 
   if (showRequiredFieldIssues && !bodyTemplate.trim()) {
-    issues.push('Tresc wiadomosci jest wymagana.')
+    issues.push('Treść wiadomości jest wymagana.')
   }
 
   if (preview.unknownPlaceholders.length > 0) {
@@ -37,61 +38,51 @@ export function CommunicationTemplateValidationPanel({
     )
   }
 
-  warnings.push('Preview na realnej sprawie uruchomisz z poziomu pelnego podgladu wersji.')
+  warnings.push('Podgląd na realnej sprawie uruchomisz z poziomu pełnego podglądu wersji.')
 
   const isReady = issues.length === 0 && !hasEmptyRequiredFields
 
   return (
-    <section className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
-      <div className="mb-4">
-        <h2 className="text-sm font-semibold uppercase tracking-[0.18em] text-gray-500">Walidacja</h2>
-        <p className="mt-2 text-sm leading-6 text-gray-600">
-          Sprawdzamy podstawowa gotowosc wersji do publikacji i wykrywamy placeholdery, ktore wymagaja poprawy.
-        </p>
-      </div>
-
-      <div
-        className={`rounded-xl border px-4 py-3 text-sm ${
-          isReady
-            ? 'border-green-200 bg-green-50 text-green-700'
-            : 'border-amber-200 bg-amber-50 text-amber-800'
-        }`}
-      >
-        {isReady ? 'Szablon jest gotowy do publikacji.' : 'Wersja nie jest gotowa do publikacji.'}
-      </div>
+    <SectionCard
+      title="Walidacja"
+      description="Sprawdzamy podstawową gotowość wersji do publikacji i wykrywamy placeholdery wymagające poprawy."
+    >
+      <AlertBanner
+        tone={isReady ? 'success' : 'warning'}
+        title={isReady ? 'Szablon jest gotowy do publikacji.' : 'Wersja nie jest gotowa do publikacji.'}
+      />
 
       <div className="mt-4 space-y-3 text-sm">
-        <div className="rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-gray-700">
-          {preview.unknownPlaceholders.length === 0 ? (
-            'Brak nieznanych placeholderow.'
-          ) : (
-            <span>
-              Wykryto nieznane placeholdery:{' '}
-              {preview.unknownPlaceholders.map((item) => `{{${item}}}`).join(', ')}
-            </span>
-          )}
-        </div>
+        <AlertBanner
+          tone={preview.unknownPlaceholders.length === 0 ? 'neutral' : 'warning'}
+          title={preview.unknownPlaceholders.length === 0 ? 'Brak nieznanych placeholderów.' : 'Wykryto nieznane placeholdery'}
+          description={
+            preview.unknownPlaceholders.length > 0
+              ? preview.unknownPlaceholders.map((item) => `{{${item}}}`).join(', ')
+              : undefined
+          }
+        />
 
         {issues.length > 0 && (
-          <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-red-700">
+          <AlertBanner tone="danger" title="Błędy wymagające poprawy" description={
             <ul className="space-y-1">
               {issues.map((issue) => (
                 <li key={issue}>{issue}</li>
               ))}
             </ul>
-          </div>
+          } />
         )}
 
         {warnings.length > 0 && (
-          <div className="rounded-xl border border-orange-200 bg-orange-50 px-4 py-3 text-orange-700">
+          <AlertBanner tone="warning" title="Uwagi do sprawdzenia" description={
             <ul className="space-y-1">
               {warnings.map((warning) => (
                 <li key={warning}>{warning}</li>
               ))}
             </ul>
-          </div>
+          } />
         )}
       </div>
-    </section>
+    </SectionCard>
   )
 }

--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplateVersionCard.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplateVersionCard.tsx
@@ -1,10 +1,10 @@
 import { CONTACT_CHANNEL_LABELS, type ContactChannel } from '@np-manager/shared'
 import {
-  getCommunicationTemplateStatusClasses,
   getCommunicationTemplateStatusLabel,
   type CommunicationTemplateUiStatus,
   type CommunicationTemplateVersionView,
 } from '@/lib/communicationTemplates'
+import { Badge, Button, DataField, type BadgeTone } from '@/components/ui'
 
 interface CommunicationTemplateVersionCardProps {
   version: CommunicationTemplateVersionView
@@ -37,14 +37,11 @@ function getChannelLabel(channel: ContactChannel): string {
   return CONTACT_CHANNEL_LABELS[channel] ?? channel
 }
 
-function StatusBadge({ status }: { status: CommunicationTemplateUiStatus }) {
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${getCommunicationTemplateStatusClasses(status)}`}
-    >
-      {getCommunicationTemplateStatusLabel(status)}
-    </span>
-  )
+function getStatusTone(status: CommunicationTemplateUiStatus): BadgeTone {
+  if (status === 'PUBLISHED') return 'green'
+  if (status === 'DRAFT') return 'amber'
+  if (status === 'ARCHIVED') return 'neutral'
+  return 'orange'
 }
 
 export function CommunicationTemplateVersionCard({
@@ -61,80 +58,70 @@ export function CommunicationTemplateVersionCard({
 }: CommunicationTemplateVersionCardProps) {
   return (
     <article
-      className={`rounded-3xl border p-5 shadow-sm ${
-        highlight ? 'border-green-200 bg-green-50/60' : 'border-gray-200 bg-white'
+      className={`rounded-panel border p-5 ${
+        highlight ? 'border-emerald-200 bg-emerald-50/50' : 'border-line bg-surface'
       }`}
     >
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
-            {title && <h3 className="text-lg font-semibold text-gray-900">{title}</h3>}
-            <StatusBadge status={version.uiStatus} />
-            <span className="rounded-full border border-gray-200 bg-white px-3 py-1 text-xs font-medium text-gray-600">
-              v{version.versionNumber}
-            </span>
+            {title && <h3 className="text-lg font-semibold text-ink-900">{title}</h3>}
+            <Badge tone={getStatusTone(version.uiStatus)} leadingDot>
+              {getCommunicationTemplateStatusLabel(version.uiStatus)}
+            </Badge>
+            <Badge tone="brand">v{version.versionNumber}</Badge>
           </div>
-          {subtitle && <p className="mt-2 text-sm leading-6 text-gray-600">{subtitle}</p>}
+          {subtitle && <p className="mt-2 text-sm leading-6 text-ink-600">{subtitle}</p>}
         </div>
 
-        <button type="button" onClick={() => onPreview?.(version)} className="btn-secondary">
-          Podglad
-        </button>
+        {onPreview && (
+          <Button type="button" onClick={() => onPreview(version)} size="sm">
+            Podgląd
+          </Button>
+        )}
       </div>
 
-      <dl className="mt-5 grid gap-4 text-sm sm:grid-cols-2 xl:grid-cols-4">
-        <div>
-          <dt className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Kanal</dt>
-          <dd className="mt-1 text-gray-800">{getChannelLabel(version.channel)}</dd>
-        </div>
-        <div>
-          <dt className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Ostatnia zmiana</dt>
-          <dd className="mt-1 text-gray-800">{formatDateTime(version.updatedAt)}</dd>
-        </div>
-        <div>
-          <dt className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Autor</dt>
-          <dd className="mt-1 text-gray-800">{version.updatedByDisplayName ?? 'Brak danych'}</dd>
-        </div>
-        <div>
-          <dt className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Temat</dt>
-          <dd className="mt-1 line-clamp-2 text-gray-800">{version.subjectTemplate || 'Brak tematu'}</dd>
-        </div>
+      <dl className="mt-5 grid gap-4 rounded-panel border border-line bg-ink-50/60 p-4 text-sm sm:grid-cols-2 xl:grid-cols-4">
+        <DataField label="Kanał" value={getChannelLabel(version.channel)} />
+        <DataField label="Ostatnia zmiana" value={formatDateTime(version.updatedAt)} />
+        <DataField label="Autor" value={version.updatedByDisplayName ?? 'Brak danych'} />
+        <DataField label="Temat" value={version.subjectTemplate || 'Brak tematu'} />
       </dl>
 
-      <div className="mt-5 rounded-2xl border border-gray-200 bg-white px-4 py-4">
-        <div className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">Fragment tresci</div>
-        <p className="mt-2 text-sm leading-6 text-gray-700">{version.excerpt || 'Brak tresci.'}</p>
+      <div className="mt-5 rounded-panel border border-line bg-surface px-4 py-4">
+        <div className="text-xs font-semibold uppercase tracking-[0.08em] text-ink-400">Fragment treści</div>
+        <p className="mt-2 text-sm leading-6 text-ink-700">{version.excerpt || 'Brak treści.'}</p>
       </div>
 
-      <div className="mt-5 flex flex-wrap gap-3">
+      <div className="mt-5 flex flex-wrap gap-2">
         {onEdit && version.uiStatus === 'DRAFT' && (
-          <button type="button" onClick={() => onEdit(version)} className="btn-primary">
+          <Button type="button" onClick={() => onEdit(version)} variant="primary" size="sm">
             Edytuj
-          </button>
+          </Button>
         )}
 
         {onPublish && version.uiStatus === 'DRAFT' && (
-          <button type="button" onClick={() => onPublish(version)} className="btn-primary">
+          <Button type="button" onClick={() => onPublish(version)} variant="primary" size="sm">
             Publikuj
-          </button>
+          </Button>
         )}
 
         {onArchive && version.uiStatus === 'DRAFT' && (
-          <button type="button" onClick={() => onArchive(version)} className="btn-secondary">
+          <Button type="button" onClick={() => onArchive(version)} size="sm">
             Archiwizuj
-          </button>
+          </Button>
         )}
 
         {onClone && (
-          <button type="button" onClick={() => onClone(version)} className="btn-secondary">
-            Sklonuj do nowej wersji roboczej
-          </button>
+          <Button type="button" onClick={() => onClone(version)} size="sm">
+            Sklonuj do wersji roboczej
+          </Button>
         )}
 
         {onDetails && (
-          <button type="button" onClick={() => onDetails(version)} className="btn-secondary">
-            Szczegoly
-          </button>
+          <Button type="button" onClick={() => onDetails(version)} size="sm">
+            Szczegóły
+          </Button>
         )}
       </div>
     </article>

--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatesAdmin.test.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatesAdmin.test.tsx
@@ -131,10 +131,12 @@ describe('Communication templates admin UX', () => {
       />,
     )
 
-    expect(html).toContain('Szablony komunikatow')
-    expect(html).toContain('Lacznie szablonow')
+    expect(html).toContain('Szablony komunikatów')
+    expect(html).toContain('Łącznie szablonów')
+    expect(html).toContain('Filtry')
     expect(html).toContain('Wersja aktywna: v3')
     expect(html).toContain('Opublikowana v3 i 1 robocza')
+    expect(html).toContain('Otwórz')
   })
 
   it('renders a friendly empty state when there are no templates', () => {
@@ -155,8 +157,8 @@ describe('Communication templates admin UX', () => {
       />,
     )
 
-    expect(html).toContain('Brak szablonow komunikatow')
-    expect(html).toContain('Utworz pierwszy szablon')
+    expect(html).toContain('Brak szablonów komunikatów')
+    expect(html).toContain('Utwórz pierwszy szablon')
   })
 
   it('renders detail sections for operational version, drafts, history and placeholders', () => {
@@ -179,10 +181,11 @@ describe('Communication templates admin UX', () => {
       />,
     )
 
-    expect(html).toContain('Aktualnie uzywane operacyjnie')
+    expect(html).toContain('Aktualnie opublikowana wersja')
     expect(html).toContain('Wersje robocze')
-    expect(html).toContain('Historia wersji')
-    expect(html).toContain('Dostepne placeholdery')
+    expect(html).toContain('Wersje archiwalne')
+    expect(html).toContain('Metadane szablonu')
+    expect(html).toContain('Dostępne placeholdery')
     expect(html).toContain('Archiwizuj')
   })
 
@@ -244,7 +247,7 @@ describe('Communication templates admin UX', () => {
     expect(editorHtml).toContain('Wykryto nieznane placeholdery')
     expect(editorHtml).toContain('Wersja nie jest gotowa do publikacji.')
     expect(editorHtml).not.toContain('Nazwa biznesowa jest wymagana.')
-    expect(modalHtml).toContain('Opublikowac te wersje?')
+    expect(modalHtml).toContain('Opublikować tę wersję?')
   })
 
   it('renders preview modal with real-case context and keeps test preview flow intact', () => {
@@ -274,7 +277,7 @@ describe('Communication templates admin UX', () => {
     const testHtml = renderToStaticMarkup(
       <CommunicationTemplatePreviewModal
         isOpen
-        title="Podglad testowy"
+        title="Podgląd testowy"
         subtitle="Dane testowe"
         preview={testPreview}
         mode="TEST"
@@ -283,7 +286,7 @@ describe('Communication templates admin UX', () => {
         isRealCaseAvailable={false}
         isRealCaseLoading={false}
         realCaseError={null}
-        realCaseHelpText="Zapisz wersje robocza, aby uruchomic preview na realnej sprawie."
+        realCaseHelpText="Zapisz wersję roboczą, aby uruchomić podgląd na realnej sprawie."
         onModeChange={vi.fn()}
         onRealCaseReferenceChange={vi.fn()}
         onRunRealCasePreview={vi.fn()}
@@ -294,7 +297,7 @@ describe('Communication templates admin UX', () => {
     const realHtml = renderToStaticMarkup(
       <CommunicationTemplatePreviewModal
         isOpen
-        title="Podglad real-case"
+        title="Podgląd na realnej sprawie"
         subtitle="Realna sprawa"
         preview={realPreview}
         mode="REAL"
@@ -302,8 +305,8 @@ describe('Communication templates admin UX', () => {
         realCaseLabel="FNP-SEED-COMM-DRAFT-001"
         isRealCaseAvailable
         isRealCaseLoading={false}
-        realCaseError="Nie znaleziono wskazanej sprawy do preview szablonu."
-        realCaseHelpText="Preview real-case nie zapisuje komunikacji."
+        realCaseError="Nie znaleziono wskazanej sprawy do podglądu szablonu."
+        realCaseHelpText="Podgląd na realnej sprawie nie zapisuje komunikacji."
         onModeChange={vi.fn()}
         onRealCaseReferenceChange={vi.fn()}
         onRunRealCasePreview={vi.fn()}
@@ -313,8 +316,8 @@ describe('Communication templates admin UX', () => {
 
     expect(testHtml).toContain('Dane testowe')
     expect(testHtml).toContain('Temat FNP-ADMIN-001')
-    expect(realHtml).toContain('Preview realnej sprawy')
+    expect(realHtml).toContain('Podgląd na realnej sprawie')
     expect(realHtml).toContain('FNP-SEED-COMM-DRAFT-001')
-    expect(realHtml).toContain('Nie znaleziono wskazanej sprawy do preview szablonu.')
+    expect(realHtml).toContain('Nie znaleziono wskazanej sprawy do podglądu szablonu.')
   })
 })

--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatesList.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatesList.tsx
@@ -2,11 +2,23 @@ import { COMMUNICATION_TEMPLATE_CODE_LABELS, CONTACT_CHANNEL_LABELS } from '@np-
 import type {
   CommunicationTemplateListFilterStatus,
   CommunicationTemplateListItemView,
+  CommunicationTemplateUiStatus,
 } from '@/lib/communicationTemplates'
 import {
-  getCommunicationTemplateStatusClasses,
   getCommunicationTemplateStatusLabel,
 } from '@/lib/communicationTemplates'
+import {
+  ActionMenu,
+  AlertBanner,
+  Badge,
+  Button,
+  DataField,
+  EmptyState,
+  MetricCard,
+  PageHeader,
+  SectionCard,
+  type BadgeTone,
+} from '@/components/ui'
 
 interface CommunicationTemplatesListFilters {
   search: string
@@ -40,6 +52,13 @@ function formatDateTime(value: string): string {
   }).format(new Date(value))
 }
 
+function getStatusBadgeTone(status: CommunicationTemplateUiStatus): BadgeTone {
+  if (status === 'PUBLISHED') return 'green'
+  if (status === 'DRAFT') return 'amber'
+  if (status === 'ARCHIVED') return 'neutral'
+  return 'orange'
+}
+
 export function CommunicationTemplatesList({
   items,
   isLoading,
@@ -62,30 +81,28 @@ export function CommunicationTemplatesList({
 
   return (
     <div className="space-y-6 p-6">
-      <header className="flex flex-wrap items-start justify-between gap-4">
-        <div className="max-w-3xl">
-          <h1 className="text-3xl font-semibold tracking-tight text-gray-900">
-            Szablony komunikatow
-          </h1>
-          <p className="mt-3 text-sm leading-6 text-gray-600">
-            Zarzadzaj trescia komunikatow wysylanych do klientow na kolejnych etapach procesu.
-            Zmiany publikujesz bez modyfikacji kodu aplikacji.
-          </p>
-        </div>
-
-        <button type="button" onClick={onCreate} className="btn-primary">
-          + Nowy szablon
-        </button>
-      </header>
+      <PageHeader
+        eyebrow="Administracja"
+        title="Szablony komunikatów"
+        description="Zarządzaj treścią wiadomości wysyłanych do klientów i operatorów na kolejnych etapach procesu przeniesienia numeru."
+        actions={
+          <Button type="button" onClick={onCreate} variant="primary">
+            Nowy szablon
+          </Button>
+        }
+      />
 
       <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-        <SummaryCard label="Lacznie szablonow" value={String(items.length)} tone="neutral" />
-        <SummaryCard label="Opublikowane" value={String(publishedCount)} tone="published" />
-        <SummaryCard label="Wersje robocze" value={String(totalDrafts)} tone="draft" />
-        <SummaryCard label="Archiwalne" value={String(totalArchived)} tone="archived" />
+        <MetricCard title="Łącznie szablonów" value={items.length} description="Wynik po aktywnych filtrach" />
+        <MetricCard title="Opublikowane" value={publishedCount} tone="success" description="Mają aktywną wersję" />
+        <MetricCard title="Wersje robocze" value={totalDrafts} tone="warning" description="Czekają na decyzję" />
+        <MetricCard title="Archiwalne" value={totalArchived} description="Zachowane historycznie" />
       </section>
 
-      <section className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm">
+      <SectionCard
+        title="Filtry"
+        description="Zawęź listę po nazwie, kodzie komunikatu, kanale albo stanie aktywnej wersji."
+      >
         <div className="grid gap-4 lg:grid-cols-[1.4fr,0.8fr,0.8fr,0.8fr]">
           <label className="block">
             <span className="label">Wyszukaj</span>
@@ -129,13 +146,13 @@ export function CommunicationTemplatesList({
           </label>
 
           <label className="block">
-            <span className="label">Kanal</span>
+            <span className="label">Kanał</span>
             <select
               value={filters.channel}
               onChange={(event) => onChannelChange(event.target.value)}
               className="input-field mt-1"
             >
-              <option value="">Wszystkie kanaly</option>
+              <option value="">Wszystkie kanały</option>
               {channelOptions.map((channel) => (
                 <option key={channel} value={channel}>
                   {CONTACT_CHANNEL_LABELS[channel]}
@@ -144,143 +161,106 @@ export function CommunicationTemplatesList({
             </select>
           </label>
         </div>
-      </section>
+      </SectionCard>
 
       {error && (
-        <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {error}
-        </div>
+        <AlertBanner tone="danger" title="Nie udało się pobrać szablonów" description={error} />
       )}
 
       {isLoading ? (
-        <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-12 text-center text-sm text-gray-600">
-          Ladowanie szablonow komunikatow...
-        </div>
+        <SectionCard padding="none">
+          <EmptyState title="Ładowanie szablonów komunikatów..." />
+        </SectionCard>
       ) : items.length === 0 ? (
-        <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-14 text-center">
-          <h2 className="text-xl font-semibold text-gray-900">Brak szablonow komunikatow</h2>
-          <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-gray-600">
-            Dodaj pierwszy szablon, aby system mogl generowac komunikaty dla klientow.
-          </p>
-          <button type="button" onClick={onCreate} className="btn-primary mt-6">
-            Utworz pierwszy szablon
-          </button>
-        </div>
+        <SectionCard padding="none">
+          <EmptyState
+            title="Brak szablonów komunikatów"
+            description="Dodaj pierwszy szablon, aby system mógł przygotowywać czytelne komunikaty dla klientów i operatorów."
+            action={
+              <Button type="button" onClick={onCreate} variant="primary">
+                Utwórz pierwszy szablon
+              </Button>
+            }
+          />
+        </SectionCard>
       ) : (
-        <div className="space-y-4">
-          {items.map((item) => (
-            <article
-              key={item.key}
-              className="rounded-3xl border border-gray-200 bg-white p-5 shadow-sm transition hover:border-gray-300"
-            >
-              <div className="flex flex-wrap items-start justify-between gap-4">
-                <div className="max-w-3xl">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <h2 className="text-lg font-semibold text-gray-900">
-                      {item.name || COMMUNICATION_TEMPLATE_CODE_LABELS[item.code]}
-                    </h2>
-                    <span
-                      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold ${getCommunicationTemplateStatusClasses(item.primaryStatus)}`}
-                    >
-                      {getCommunicationTemplateStatusLabel(item.primaryStatus)}
-                    </span>
-                    {item.publishedVersionNumber !== null && (
-                      <span className="rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-xs font-medium text-gray-600">
-                        Wersja aktywna: v{item.publishedVersionNumber}
-                      </span>
-                    )}
+        <SectionCard
+          title="Lista szablonów"
+          description="Każdy szablon może mieć wersję opublikowaną, roboczą i archiwalną."
+        >
+          <div className="space-y-4">
+            {items.map((item) => (
+              <article
+                key={item.key}
+                className="rounded-panel border border-line bg-surface p-5 transition hover:border-brand-200"
+              >
+                <div className="flex flex-wrap items-start justify-between gap-4">
+                  <div className="max-w-3xl">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h2 className="text-lg font-semibold text-ink-900">
+                        {item.name || COMMUNICATION_TEMPLATE_CODE_LABELS[item.code]}
+                      </h2>
+                      <Badge tone={getStatusBadgeTone(item.primaryStatus)} leadingDot>
+                        {getCommunicationTemplateStatusLabel(item.primaryStatus)}
+                      </Badge>
+                      {item.publishedVersionNumber !== null && (
+                        <Badge tone="brand">Wersja aktywna: v{item.publishedVersionNumber}</Badge>
+                      )}
+                    </div>
+
+                    <p className="mt-2 text-sm font-medium text-ink-500">
+                      {COMMUNICATION_TEMPLATE_CODE_LABELS[item.code]} · {item.code}
+                    </p>
+
+                    <p className="mt-3 text-sm leading-6 text-ink-600">
+                      {item.description || 'Brak opisu operacyjnego dla tego szablonu.'}
+                    </p>
                   </div>
 
-                  <p className="mt-2 text-sm font-medium text-gray-600">
-                    {COMMUNICATION_TEMPLATE_CODE_LABELS[item.code]} · {item.code}
-                  </p>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button type="button" onClick={() => onOpen(item.code)} variant="primary" size="sm">
+                      Otwórz
+                    </Button>
 
-                  <p className="mt-3 text-sm leading-6 text-gray-600">
-                    {item.description || 'Brak opisu operacyjnego dla tego szablonu.'}
-                  </p>
+                    <ActionMenu
+                      items={[
+                        {
+                          label: 'Utwórz nową wersję roboczą',
+                          description: 'Na podstawie istniejącej wersji szablonu.',
+                          onClick: () => onCreateDraft(item.code),
+                        },
+                        {
+                          label: 'Podgląd aktywnej wersji',
+                          description: 'Sprawdź treść aktualnie używaną operacyjnie.',
+                          disabled: !item.publishedVersionId,
+                          onClick: () => onPreviewPublished(item.code),
+                        },
+                      ]}
+                    />
+                  </div>
                 </div>
 
-                <div className="flex flex-wrap gap-3">
-                  <button type="button" onClick={() => onOpen(item.code)} className="btn-primary">
-                    Otworz
-                  </button>
-
-                  <details className="relative">
-                    <summary className="btn-secondary cursor-pointer list-none">Akcje</summary>
-                    <div className="absolute right-0 z-10 mt-2 w-64 rounded-2xl border border-gray-200 bg-white p-2 shadow-xl">
-                      <button
-                        type="button"
-                        onClick={() => onCreateDraft(item.code)}
-                        className="w-full rounded-xl px-3 py-2 text-left text-sm text-gray-700 transition hover:bg-gray-50"
-                      >
-                        Utworz nowa wersje robocza
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onPreviewPublished(item.code)}
-                        className="mt-1 w-full rounded-xl px-3 py-2 text-left text-sm text-gray-700 transition hover:bg-gray-50"
-                        disabled={!item.publishedVersionId}
-                      >
-                        Podglad aktywnej wersji
-                      </button>
-                    </div>
-                  </details>
-                </div>
-              </div>
-
-              <div className="mt-5 grid gap-4 text-sm md:grid-cols-2 xl:grid-cols-5">
-                <InfoBox label="Kanal" value={CONTACT_CHANNEL_LABELS[item.channel]} />
-                <InfoBox label="Status operacyjny" value={item.statusSummary} />
-                <InfoBox
-                  label="Ostatnia zmiana"
-                  value={formatDateTime(item.lastVersionUpdatedAt ?? item.updatedAt)}
-                />
-                <InfoBox
-                  label="Autor ostatniej zmiany"
-                  value={item.lastVersionUpdatedByDisplayName ?? item.updatedByDisplayName ?? 'Brak danych'}
-                />
-                <InfoBox
-                  label="Zakres wersji"
-                  value={`${item.versionCounts.total} lacznie · ${item.versionCounts.draft} robocze`}
-                />
-              </div>
-            </article>
-          ))}
-        </div>
+                <dl className="mt-5 grid gap-4 rounded-panel border border-line bg-ink-50/60 p-4 text-sm md:grid-cols-2 xl:grid-cols-5">
+                  <DataField label="Kanał" value={CONTACT_CHANNEL_LABELS[item.channel]} />
+                  <DataField label="Status operacyjny" value={item.statusSummary} />
+                  <DataField
+                    label="Ostatnia zmiana"
+                    value={formatDateTime(item.lastVersionUpdatedAt ?? item.updatedAt)}
+                  />
+                  <DataField
+                    label="Autor ostatniej zmiany"
+                    value={item.lastVersionUpdatedByDisplayName ?? item.updatedByDisplayName ?? 'Brak danych'}
+                  />
+                  <DataField
+                    label="Zakres wersji"
+                    value={`${item.versionCounts.total} łącznie · ${item.versionCounts.draft} robocze`}
+                  />
+                </dl>
+              </article>
+            ))}
+          </div>
+        </SectionCard>
       )}
-    </div>
-  )
-}
-
-function SummaryCard({
-  label,
-  value,
-  tone,
-}: {
-  label: string
-  value: string
-  tone: 'neutral' | 'published' | 'draft' | 'archived'
-}) {
-  const toneClasses = {
-    neutral: 'border-gray-200 bg-white text-gray-900',
-    published: 'border-green-200 bg-green-50 text-green-800',
-    draft: 'border-amber-200 bg-amber-50 text-amber-800',
-    archived: 'border-gray-200 bg-gray-100 text-gray-700',
-  } as const
-
-  return (
-    <div className={`rounded-3xl border p-5 shadow-sm ${toneClasses[tone]}`}>
-      <p className="text-sm font-medium">{label}</p>
-      <p className="mt-3 text-3xl font-semibold tracking-tight">{value}</p>
-    </div>
-  )
-}
-
-function InfoBox({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3">
-      <div className="text-xs font-semibold uppercase tracking-[0.14em] text-gray-500">{label}</div>
-      <div className="mt-1 text-sm text-gray-800">{value}</div>
     </div>
   )
 }

--- a/apps/frontend/src/pages/Admin/CommunicationTemplatesAdminPage.test.tsx
+++ b/apps/frontend/src/pages/Admin/CommunicationTemplatesAdminPage.test.tsx
@@ -23,7 +23,7 @@ describe('CommunicationTemplatesAdminPage', () => {
   it('blocks non-admin users from admin templates views', () => {
     const html = renderToStaticMarkup(<CommunicationTemplatesAdminPage />)
 
-    expect(html).toContain('Szablony komunikatow')
-    expect(html).toContain('Ten widok jest dostepny wylacznie dla administratora.')
+    expect(html).toContain('Brak dostępu do administracji')
+    expect(html).toContain('Ten widok jest dostępny wyłącznie dla administratora.')
   })
 })

--- a/apps/frontend/src/pages/Admin/CommunicationTemplatesAdminPage.tsx
+++ b/apps/frontend/src/pages/Admin/CommunicationTemplatesAdminPage.tsx
@@ -46,6 +46,7 @@ import {
   type CommunicationTemplateEditorFormState,
   type CommunicationTemplateEditorStatusInfo,
 } from '@/components/CommunicationTemplatesAdmin'
+import { EmptyState, SectionCard } from '@/components/ui'
 
 type AdminMode = 'LIST' | 'DETAIL' | 'NEW' | 'EDIT'
 
@@ -204,13 +205,13 @@ function createInitialPublishState(): PublishModalState {
 function AdminAccessDeniedState() {
   return (
     <div className="p-6">
-      <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-14 text-center">
-        <h1 className="text-2xl font-semibold text-gray-900">Szablony komunikatow</h1>
-        <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-gray-600">
-          Ten widok jest dostepny wylacznie dla administratora. Jesli potrzebujesz dostepu,
-          skontaktuj sie z wlascicielem systemu.
-        </p>
-      </div>
+      <SectionCard padding="none">
+        <EmptyState
+          title="Brak dostępu do administracji"
+          description="Ten widok jest dostępny wyłącznie dla administratora. Jeśli potrzebujesz dostępu, skontaktuj się z właścicielem systemu."
+          className="border-0 bg-transparent"
+        />
+      </SectionCard>
     </div>
   )
 }
@@ -304,7 +305,7 @@ export function CommunicationTemplatesAdminPage() {
       setPageError(null)
     } catch (error) {
       setTemplateItems([])
-      setPageError(getTemplateErrorMessage(error, 'Nie udalo sie pobrac szablonow komunikatow.'))
+      setPageError(getTemplateErrorMessage(error, 'Nie udało się pobrać szablonów komunikatów.'))
     } finally {
       setIsListLoading(false)
     }
@@ -320,7 +321,7 @@ export function CommunicationTemplatesAdminPage() {
       return template
     } catch (error) {
       setSelectedTemplate(null)
-      setPageError(getTemplateErrorMessage(error, 'Nie udalo sie pobrac szczegolow szablonu komunikatu.'))
+      setPageError(getTemplateErrorMessage(error, 'Nie udało się pobrać szczegółów szablonu komunikatu.'))
       return null
     } finally {
       setIsDetailLoading(false)
@@ -446,7 +447,7 @@ export function CommunicationTemplatesAdminPage() {
     if (!reference) {
       setPreviewState((current) => ({
         ...current,
-        realCaseError: 'Podaj numer sprawy albo ID sprawy do preview real-case.',
+        realCaseError: 'Podaj numer sprawy albo ID sprawy do podglądu na realnej sprawie.',
       }))
       return
     }
@@ -473,7 +474,7 @@ export function CommunicationTemplatesAdminPage() {
       setPreviewState((current) => ({
         ...current,
         isRealCaseLoading: false,
-        realCaseError: getTemplateErrorMessage(error, 'Nie udalo sie przygotowac preview dla wskazanej sprawy.'),
+        realCaseError: getTemplateErrorMessage(error, 'Nie udało się przygotować podglądu dla wskazanej sprawy.'),
       }))
     }
   }
@@ -517,7 +518,7 @@ export function CommunicationTemplatesAdminPage() {
     } catch (error) {
       setFeedback({
         success: null,
-        error: getTemplateErrorMessage(error, 'Nie udalo sie utworzyc nowej wersji roboczej.'),
+        error: getTemplateErrorMessage(error, 'Nie udało się utworzyć nowej wersji roboczej.'),
       })
     }
   }
@@ -557,7 +558,7 @@ export function CommunicationTemplatesAdminPage() {
     } catch (error) {
       setFeedback({
         success: null,
-        error: getTemplateErrorMessage(error, 'Nie udalo sie sklonowac wersji do nowego draftu.'),
+        error: getTemplateErrorMessage(error, 'Nie udało się sklonować wersji do nowej wersji roboczej.'),
       })
     }
   }
@@ -575,19 +576,19 @@ export function CommunicationTemplatesAdminPage() {
     } catch (error) {
       setFeedback({
         success: null,
-        error: getTemplateErrorMessage(error, 'Nie udalo sie zarchiwizowac wersji.'),
+        error: getTemplateErrorMessage(error, 'Nie udało się zarchiwizować wersji.'),
       })
     }
   }
 
   const handleOpenVersionPreview = (version: CommunicationTemplateVersionView) => {
     openPreview({
-      title: `${version.name} - podglad`,
+      title: `${version.name} - podgląd`,
       subtitle: `Wersja v${version.versionNumber} · ${version.status === 'PUBLISHED' ? 'opublikowana' : version.status === 'DRAFT' ? 'robocza' : 'archiwalna'}`,
       subjectTemplate: version.subjectTemplate,
       bodyTemplate: version.bodyTemplate,
       versionId: version.id,
-      realCaseHelpText: 'Preview real-case nie zapisuje komunikacji i sluzy tylko do bezpiecznego sprawdzenia renderu.',
+      realCaseHelpText: 'Podgląd na realnej sprawie nie zapisuje komunikacji i służy tylko do bezpiecznego sprawdzenia treści.',
     })
   }
 
@@ -673,7 +674,7 @@ export function CommunicationTemplatesAdminPage() {
     } catch (error) {
       setFeedback({
         success: null,
-        error: getTemplateErrorMessage(error, 'Nie udalo sie zapisac wersji roboczej.'),
+        error: getTemplateErrorMessage(error, 'Nie udało się zapisać wersji roboczej.'),
       })
     } finally {
       setIsSaving(false)
@@ -682,14 +683,14 @@ export function CommunicationTemplatesAdminPage() {
 
   const handleOpenEditorPreview = () => {
     openPreview({
-      title: editorForm.name.trim() || 'Podglad wersji roboczej',
-      subtitle: 'Podglad na danych testowych. Dla zapisanych wersji mozesz uruchomic tez preview na realnej sprawie.',
+      title: editorForm.name.trim() || 'Podgląd wersji roboczej',
+      subtitle: 'Podgląd na danych testowych. Dla zapisanych wersji możesz uruchomić też podgląd na realnej sprawie.',
       subjectTemplate: editorForm.subjectTemplate,
       bodyTemplate: editorForm.bodyTemplate,
       versionId: editorForm.id,
       realCaseHelpText: editorForm.id
-        ? 'Preview real-case sprawdza zapisany stan wersji backendowej.'
-        : 'Zapisz wersje robocza, aby uruchomic preview na realnej sprawie.',
+        ? 'Podgląd na realnej sprawie sprawdza zapisany stan wersji.'
+        : 'Zapisz wersję roboczą, aby uruchomić podgląd na realnej sprawie.',
     })
   }
 
@@ -719,7 +720,7 @@ export function CommunicationTemplatesAdminPage() {
     if (isInvalid) {
       setFeedback({
         success: null,
-        error: 'Nie mozna opublikowac wersji z bledami walidacji.',
+        error: 'Nie można opublikować wersji z błędami walidacji.',
       })
       return
     }
@@ -741,7 +742,7 @@ export function CommunicationTemplatesAdminPage() {
     if (!version.subjectTemplate.trim() || !version.bodyTemplate.trim() || preview.unknownPlaceholders.length > 0) {
       setFeedback({
         success: null,
-        error: 'Nie mozna opublikowac wersji z bledami walidacji.',
+        error: 'Nie można opublikować wersji z błędami walidacji.',
       })
       return
     }
@@ -785,7 +786,7 @@ export function CommunicationTemplatesAdminPage() {
       setPublishError(
         getTemplateErrorMessage(
           error,
-          'Nie udalo sie opublikowac wersji. Widok zostal odswiezony zgodnie z aktualnym stanem danych.',
+          'Nie udało się opublikować wersji. Widok został odświeżony zgodnie z aktualnym stanem danych.',
         ),
       )
       await refreshCurrentTemplate(publishState.code)
@@ -897,8 +898,8 @@ export function CommunicationTemplatesAdminPage() {
         title={mode === 'NEW' ? 'Nowy szablon komunikatu' : 'Edycja wersji roboczej'}
         subtitle={
           mode === 'NEW'
-            ? 'Przygotuj nowy szablon i zapisz go jako wersje robocza. Publikacja jest osobna, swiadoma akcja.'
-            : 'Pracujesz na wersji roboczej. Opublikowana wersja pozostaje bezpieczna, dopoki nie zatwierdzisz zmian.'
+            ? 'Przygotuj nowy szablon i zapisz go jako wersję roboczą. Publikacja jest osobną, świadomą akcją.'
+            : 'Pracujesz na wersji roboczej. Opublikowana wersja pozostaje aktywna, dopóki nie zatwierdzisz zmian.'
         }
         form={editorForm}
         statusInfo={editorStatusInfo}


### PR DESCRIPTION
## Summary
- Polish CommunicationTemplatesAdmin with the shared UI design system.
- Align list, detail, editor, preview modal and publish modal with the redesigned admin UI.
- Improve operational microcopy while keeping technical template codes visible.
- Keep publish/preview/save/archive/clone logic unchanged.

## Scope
- Frontend-only CommunicationTemplatesAdmin polish.
- No backend changes.
- No DTO changes.
- No API service changes.
- No routing changes.
- No seed changes.
- No Redux/store changes.
- No publish risky UX/type-to-confirm yet.
- No other admin screens touched.

## Preserved logic
- API calls unchanged.
- List filters unchanged.
- Detail callbacks unchanged.
- Editor fields and validation unchanged.
- Save draft flow unchanged.
- Clone/archive flow unchanged.
- Preview TEST/REAL flow unchanged.
- Publish modal onConfirm/onCancel unchanged.
- DRAFT/PUBLISHED/ARCHIVED semantics unchanged.
- Placeholder validation unchanged.
- ADMIN-only access unchanged.

## Adescom / PLI CBD context
- Technical template codes are preserved.
- Copy is more operational and user-friendly.
- UI does not copy Adescom-style technical complexity.
- The module remains suitable for templates related to porting communications.

## Validation
- npm run type-check --workspace apps/frontend — PASS
- npm run test --workspace apps/frontend — PASS
- npm run build --workspace apps/frontend — PASS