### PR TITLE
feat(frontend): strengthen communication template publish confirmation

### DIFF
--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatePublishModal.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatePublishModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { AlertBanner, Button } from '@/components/ui'
 
 interface CommunicationTemplatePublishModalProps {
@@ -19,6 +20,14 @@ export function CommunicationTemplatePublishModal({
   onConfirm,
   onCancel,
 }: CommunicationTemplatePublishModalProps) {
+  const [confirmed, setConfirmed] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen) {
+      setConfirmed(false)
+    }
+  }, [isOpen])
+
   if (!isOpen) {
     return null
   }
@@ -35,21 +44,49 @@ export function CommunicationTemplatePublishModal({
         <AlertBanner
           tone="warning"
           title="Publikacja wpływa na przyszłe komunikaty"
-          description="Przed zatwierdzeniem upewnij się, że temat, treść i placeholdery zostały sprawdzone w podglądzie."
+          description="Przed zatwierdzeniem upewnij się, że temat, treść i placeholdery zostały sprawdzone w podglądzie. Tej operacji nie można cofnąć — opublikowana wersja zacznie być używana natychmiast."
           className="mt-5"
         />
 
         <div className="mt-5 rounded-panel border border-line bg-ink-50/60 px-4 py-4">
-          <div className="text-sm font-medium text-ink-900">{templateName}</div>
-          <div className="mt-1 text-sm text-ink-600">{versionLabel}</div>
+          <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-sm">
+            <span className="font-medium text-ink-700">Szablon:</span>
+            <span className="text-ink-900">{templateName}</span>
+            <span className="font-medium text-ink-700">Wersja:</span>
+            <span className="text-ink-900">{versionLabel}</span>
+            <span className="font-medium text-ink-700">Skutek:</span>
+            <span className="text-ink-600">
+              Ta wersja stanie się aktywna dla kolejnych komunikatów tego typu.
+            </span>
+          </div>
         </div>
 
         {publishError && (
-          <AlertBanner tone="danger" title="Nie udało się opublikować wersji" description={publishError} className="mt-5" />
+          <AlertBanner
+            tone="danger"
+            title="Nie udało się opublikować wersji"
+            description={publishError}
+            className="mt-5"
+          />
         )}
 
+        <label className="mt-5 flex cursor-pointer items-start gap-3">
+          <input
+            type="checkbox"
+            className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer rounded border-line accent-primary-600"
+            checked={confirmed}
+            onChange={(e) => setConfirmed(e.target.checked)}
+            disabled={isPublishing}
+            aria-label="Potwierdzenie publikacji"
+            data-testid="publish-confirm-checkbox"
+          />
+          <span className="text-sm leading-6 text-ink-700">
+            Rozumiem, że ta wersja będzie używana w kolejnych komunikatach.
+          </span>
+        </label>
+
         <div className="mt-6 flex flex-wrap justify-end gap-2">
-          <Button type="button" onClick={onCancel} disabled={isPublishing}>
+          <Button type="button" onClick={onCancel} disabled={isPublishing} data-testid="publish-cancel-button">
             Anuluj
           </Button>
           <Button
@@ -58,6 +95,8 @@ export function CommunicationTemplatePublishModal({
             variant="primary"
             isLoading={isPublishing}
             loadingLabel="Publikowanie..."
+            disabled={!confirmed || isPublishing}
+            data-testid="publish-confirm-button"
           >
             Publikuj wersję
           </Button>

--- a/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatesAdmin.test.tsx
+++ b/apps/frontend/src/components/CommunicationTemplatesAdmin/CommunicationTemplatesAdmin.test.tsx
@@ -1,5 +1,7 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { CommunicationTemplateDto, CommunicationTemplateListItemDto } from '@np-manager/shared'
 import {
   buildCommunicationTemplateDetailView,
@@ -111,6 +113,10 @@ const TEMPLATE_LIST_ITEMS: CommunicationTemplateListItemDto[] = [
     },
   },
 ]
+
+afterEach(() => {
+  cleanup()
+})
 
 describe('Communication templates admin UX', () => {
   it('renders list view with summary cards and backend-driven statuses', () => {
@@ -319,5 +325,114 @@ describe('Communication templates admin UX', () => {
     expect(realHtml).toContain('Podgląd na realnej sprawie')
     expect(realHtml).toContain('FNP-SEED-COMM-DRAFT-001')
     expect(realHtml).toContain('Nie znaleziono wskazanej sprawy do podglądu szablonu.')
+  })
+})
+
+describe('CommunicationTemplatePublishModal — risky UX confirmation', () => {
+  const BASE_PROPS = {
+    isOpen: true,
+    versionLabel: 'v4',
+    templateName: 'Potwierdzenie przyjecia sprawy',
+    isPublishing: false,
+    publishError: null,
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  }
+
+  it('shows template name and version in summary', () => {
+    const html = renderToStaticMarkup(<CommunicationTemplatePublishModal {...BASE_PROPS} />)
+    expect(html).toContain('Potwierdzenie przyjecia sprawy')
+    expect(html).toContain('v4')
+    expect(html).toContain('Szablon:')
+    expect(html).toContain('Wersja:')
+  })
+
+  it('shows warning about publish consequences', () => {
+    const html = renderToStaticMarkup(<CommunicationTemplatePublishModal {...BASE_PROPS} />)
+    expect(html).toContain('Publikacja wpływa na przyszłe komunikaty')
+    expect(html).toContain('Ta wersja stanie się aktywna dla kolejnych komunikatów tego typu.')
+  })
+
+  it('shows confirm checkbox and confirmation label', () => {
+    const html = renderToStaticMarkup(<CommunicationTemplatePublishModal {...BASE_PROPS} />)
+    expect(html).toContain('Rozumiem, że ta wersja będzie używana w kolejnych komunikatach.')
+    expect(html).toContain('type="checkbox"')
+  })
+
+  it('renders publish button as disabled when checkbox is unchecked (initial state)', () => {
+    render(<CommunicationTemplatePublishModal {...BASE_PROPS} onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    expect((screen.getByTestId('publish-confirm-button') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('checking the checkbox enables the publish button', () => {
+    render(<CommunicationTemplatePublishModal {...BASE_PROPS} onConfirm={vi.fn()} onCancel={vi.fn()} />)
+    const button = screen.getByTestId('publish-confirm-button') as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+
+    fireEvent.click(screen.getByTestId('publish-confirm-checkbox'))
+    expect(button.disabled).toBe(false)
+  })
+
+  it('clicking publish button after confirmation calls onConfirm', () => {
+    const onConfirm = vi.fn()
+    render(<CommunicationTemplatePublishModal {...BASE_PROPS} onConfirm={onConfirm} onCancel={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('publish-confirm-checkbox'))
+    fireEvent.click(screen.getByTestId('publish-confirm-button'))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking cancel calls onCancel', () => {
+    const onCancel = vi.fn()
+    render(<CommunicationTemplatePublishModal {...BASE_PROPS} onConfirm={vi.fn()} onCancel={onCancel} />)
+
+    fireEvent.click(screen.getByTestId('publish-cancel-button'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('reopening modal resets checkbox to unchecked', () => {
+    const { rerender } = render(
+      <CommunicationTemplatePublishModal {...BASE_PROPS} onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByTestId('publish-confirm-checkbox'))
+    expect((screen.getByTestId('publish-confirm-checkbox') as HTMLInputElement).checked).toBe(true)
+
+    rerender(
+      <CommunicationTemplatePublishModal
+        {...BASE_PROPS}
+        isOpen={false}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    rerender(
+      <CommunicationTemplatePublishModal {...BASE_PROPS} onConfirm={vi.fn()} onCancel={vi.fn()} />,
+    )
+    expect((screen.getByTestId('publish-confirm-checkbox') as HTMLInputElement).checked).toBe(false)
+  })
+
+  it('shows publishError via AlertBanner when provided', () => {
+    const html = renderToStaticMarkup(
+      <CommunicationTemplatePublishModal
+        {...BASE_PROPS}
+        publishError="Błąd serwera. Spróbuj ponownie."
+      />,
+    )
+    expect(html).toContain('Nie udało się opublikować wersji')
+    expect(html).toContain('Błąd serwera. Spróbuj ponownie.')
+  })
+
+  it('disables both buttons and shows loading label while publishing', () => {
+    render(
+      <CommunicationTemplatePublishModal
+        {...BASE_PROPS}
+        isPublishing
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+    expect((screen.getByTestId('publish-confirm-button') as HTMLButtonElement).disabled).toBe(true)
+    expect((screen.getByTestId('publish-cancel-button') as HTMLButtonElement).disabled).toBe(true)
+    expect(screen.getByTestId('publish-confirm-button').textContent).toContain('Publikowanie...')
   })
 })


### PR DESCRIPTION
## Summary
- Strengthen the communication template publish confirmation UX.
- Add an explicit confirmation checkbox before publishing a template version.
- Show clearer publication impact summary.
- Keep publish API behavior unchanged.

## Scope
- Frontend-only risky action UX for CommunicationTemplatesAdmin.
- No backend changes.
- No DTO changes.
- No API service changes.
- No routing changes.
- No seed changes.
- No Redux/store changes.
- No other admin screens touched.

## Preserved logic
- publishCommunicationTemplateVersion unchanged.
- Publish payload unchanged.
- onConfirm/onCancel flow unchanged.
- Save draft unchanged.
- Clone/archive unchanged.
- Preview TEST/REAL unchanged.
- DRAFT/PUBLISHED/ARCHIVED semantics unchanged.
- Placeholder validation unchanged.
- Role access unchanged.

## UX changes
- Publish button is disabled until the admin confirms understanding.
- Modal explains that the version will be used in future operational communication.
- Modal summarizes template, version and effect.
- Checkbox resets after closing/reopening the modal.
- Existing publishError and isPublishing behavior preserved.

## Validation
- npm run test --workspace apps/frontend — PASS, 327/327
- npm run type-check --workspace apps/frontend — PASS
- npm run build --workspace apps/frontend — PASS

## Manual QA focus
- Open publish modal.
- Confirm publish button is disabled before checking the checkbox.
- Check the checkbox and confirm button enables.
- Cancel closes modal.
- Reopen modal and checkbox is reset.
- publishError still displays.
- isPublishing disables controls.
- Check tablet/mobile click area for checkbox label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)