### PR TITLE
refactor(frontend): polish admin settings panels

### DIFF
--- a/apps/frontend/src/components/admin-settings/PortingNotificationSettingsPanel.test.tsx
+++ b/apps/frontend/src/components/admin-settings/PortingNotificationSettingsPanel.test.tsx
@@ -1,6 +1,7 @@
 import { isValidElement, type ReactElement, type ReactNode } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
+import { Button } from '@/components/ui/Button'
 import { PortingNotificationSettingsPanel } from './PortingNotificationSettingsPanel'
 
 function collectElements(node: ReactNode): ReactElement[] {
@@ -32,7 +33,7 @@ function findElementByPlaceholder(tree: ReactNode, placeholder: string): ReactEl
 
 function findButtonByText(tree: ReactNode, label: string): ReactElement | undefined {
   return collectElements(tree).find((element) => {
-    if (element.type !== 'button') {
+    if (element.type !== 'button' && element.type !== Button) {
       return false
     }
 
@@ -61,7 +62,7 @@ describe('PortingNotificationSettingsPanel', () => {
       />,
     )
 
-    expect(html).toContain('Ustawienia powiadomien portingowych')
+    expect(html).toContain('Powiadomienia portingowe')
     expect(html).toContain('Ustawienia zapisane.')
     expect(html).toContain('Blad zapisu.')
     expect(html).toContain('REAL')

--- a/apps/frontend/src/components/admin-settings/PortingNotificationSettingsPanel.tsx
+++ b/apps/frontend/src/components/admin-settings/PortingNotificationSettingsPanel.tsx
@@ -1,4 +1,9 @@
 import type { PortingNotificationSettingsDiagnosticsDto } from '@np-manager/shared'
+import { AlertBanner } from '@/components/ui/AlertBanner'
+import { Button } from '@/components/ui/Button'
+import { DataField } from '@/components/ui/DataField'
+import { PageHeader } from '@/components/ui/PageHeader'
+import { SectionCard } from '@/components/ui/SectionCard'
 
 export interface PortingNotificationSettingsFormState {
   sharedEmails: string
@@ -32,101 +37,87 @@ export function PortingNotificationSettingsPanel({
 }: PortingNotificationSettingsPanelProps) {
   return (
     <div className="p-6">
-      <div className="mx-auto max-w-4xl space-y-4">
-        <div className="card p-6">
-          <h1 className="text-xl font-semibold text-gray-900">
-            Ustawienia powiadomien portingowych
-          </h1>
-          <p className="mt-1 text-sm text-gray-600">
-            Konfiguracja fallbackowych odbiorcow dla wewnetrznych notyfikacji procesu portowania.
-          </p>
-        </div>
+      <div className="mx-auto max-w-4xl space-y-6">
+        <PageHeader
+          eyebrow="Administracja"
+          title="Powiadomienia portingowe"
+          description="Konfiguracja odbiorców i kanałów dla wewnętrznych powiadomień o sprawach przeniesienia numerów."
+        />
 
-        <div className="card p-6">
-          {isLoading ? (
-            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
-              Ladowanie ustawien...
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <label className="block">
-                <span className="mb-1 block text-sm font-medium text-gray-700">
-                  Fallback shared emails
-                </span>
-                <textarea
-                  value={form.sharedEmails}
-                  onChange={(event) => onChange('sharedEmails', event.target.value)}
-                  rows={3}
-                  className="input-field"
-                  placeholder="bok@multiplay.pl, sud@multiplay.pl"
-                />
-              </label>
+        {isLoading ? (
+          <SectionCard>
+            <p className="text-sm text-ink-500">Ładowanie ustawień...</p>
+          </SectionCard>
+        ) : (
+          <>
+            <SectionCard title="Konfiguracja odbiorców">
+              <div className="space-y-4">
+                <label className="block">
+                  <span className="mb-1 block text-sm font-medium text-ink-700">
+                    Adresy e-mail zespołu
+                  </span>
+                  <textarea
+                    value={form.sharedEmails}
+                    onChange={(event) => onChange('sharedEmails', event.target.value)}
+                    rows={3}
+                    className="input-field"
+                    placeholder="bok@multiplay.pl, sud@multiplay.pl"
+                  />
+                </label>
 
-              <label className="inline-flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={form.teamsEnabled}
-                  onChange={(event) => onChange('teamsEnabled', event.target.checked)}
-                />
-                <span className="text-sm text-gray-700">Teams enabled</span>
-              </label>
+                <label className="inline-flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={form.teamsEnabled}
+                    onChange={(event) => onChange('teamsEnabled', event.target.checked)}
+                  />
+                  <span className="text-sm text-ink-700">Wysyłaj powiadomienia do Teams</span>
+                </label>
 
-              <label className="block">
-                <span className="mb-1 block text-sm font-medium text-gray-700">Teams webhook URL</span>
-                <input
-                  type="url"
-                  value={form.teamsWebhookUrl}
-                  onChange={(event) => onChange('teamsWebhookUrl', event.target.value)}
-                  className="input-field"
-                  placeholder="https://..."
-                />
-              </label>
+                <label className="block">
+                  <span className="mb-1 block text-sm font-medium text-ink-700">
+                    Webhook Teams
+                  </span>
+                  <input
+                    type="url"
+                    value={form.teamsWebhookUrl}
+                    onChange={(event) => onChange('teamsWebhookUrl', event.target.value)}
+                    className="input-field"
+                    placeholder="https://..."
+                  />
+                </label>
 
-              <div className="flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
+                <Button
+                  variant="primary"
                   onClick={onSave}
-                  disabled={isSaving}
-                  className="btn-primary"
+                  isLoading={isSaving}
+                  loadingLabel="Zapisywanie..."
                 >
-                  {isSaving ? 'Zapisywanie...' : 'Zapisz ustawienia'}
-                </button>
+                  Zapisz ustawienia
+                </Button>
+
+                {success && <AlertBanner tone="success" title={success} />}
+                {error && <AlertBanner tone="danger" title={error} />}
               </div>
-            </div>
-          )}
+            </SectionCard>
 
-          {success && (
-            <div className="mt-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-              {success}
-            </div>
-          )}
-          {error && (
-            <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-              {error}
-            </div>
-          )}
-        </div>
-
-        <div className="card p-6">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">
-            Diagnostyka transportu (read-only)
-          </h2>
-          <p className="mt-1 text-sm text-gray-500">
-            Tryb adaptera email i stan konfiguracji SMTP pochodza z env i nie sa edytowalne w tym panelu.
-          </p>
-          <dl className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <div>
-              <dt className="text-xs text-gray-500">Email adapter mode</dt>
-              <dd className="text-sm text-gray-900">{diagnostics?.emailAdapterMode ?? '-'}</dd>
-            </div>
-            <div>
-              <dt className="text-xs text-gray-500">SMTP host skonfigurowany</dt>
-              <dd className="text-sm text-gray-900">
-                {diagnostics ? (diagnostics.smtpConfigured ? 'Tak' : 'Nie') : '-'}
-              </dd>
-            </div>
-          </dl>
-        </div>
+            <SectionCard
+              title="Diagnostyka transportu"
+              description="Dane pochodzą z konfiguracji środowiska i nie są edytowalne w tym panelu."
+            >
+              <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <DataField
+                  label="Tryb wysyłki e-mail"
+                  value={diagnostics?.emailAdapterMode ?? null}
+                />
+                <DataField
+                  label="Konfiguracja SMTP"
+                  value={diagnostics ? (diagnostics.smtpConfigured ? 'Tak' : 'Nie') : null}
+                />
+              </dl>
+            </SectionCard>
+          </>
+        )}
       </div>
     </div>
   )

--- a/apps/frontend/src/components/admin-settings/SystemModeSettingsPanel.test.tsx
+++ b/apps/frontend/src/components/admin-settings/SystemModeSettingsPanel.test.tsx
@@ -1,6 +1,7 @@
 import { isValidElement, type ReactElement, type ReactNode } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it, vi } from 'vitest'
+import { Button } from '@/components/ui/Button'
 import { SystemModeSettingsPanel } from './SystemModeSettingsPanel'
 
 function collectElements(node: ReactNode): ReactElement[] {
@@ -32,7 +33,7 @@ function findElementByPlaceholder(tree: ReactNode, placeholder: string): ReactEl
 
 function findButtonByText(tree: ReactNode, label: string): ReactElement | undefined {
   return collectElements(tree).find((element) => {
-    if (element.type !== 'button') {
+    if (element.type !== 'button' && element.type !== Button) {
       return false
     }
 

--- a/apps/frontend/src/components/admin-settings/SystemModeSettingsPanel.tsx
+++ b/apps/frontend/src/components/admin-settings/SystemModeSettingsPanel.tsx
@@ -3,6 +3,12 @@ import type {
   AdminSystemModeSettingsDiagnosticsDto,
   SystemMode,
 } from '@np-manager/shared'
+import { AlertBanner } from '@/components/ui/AlertBanner'
+import { Badge } from '@/components/ui/Badge'
+import { Button } from '@/components/ui/Button'
+import { DataField } from '@/components/ui/DataField'
+import { PageHeader } from '@/components/ui/PageHeader'
+import { SectionCard } from '@/components/ui/SectionCard'
 
 export interface SystemModeSettingsFormState {
   mode: SystemMode
@@ -28,7 +34,7 @@ interface SystemModeSettingsPanelProps {
 
 const MISSING_FIELD_LABELS: Record<AdminSystemModeMissingField, string> = {
   endpointUrl: 'Endpoint PLI CBD',
-  credentialsRef: 'Referencja credentials',
+  credentialsRef: 'Referencja poświadczeń',
   operatorCode: 'Kod operatora',
 }
 
@@ -38,8 +44,8 @@ function getEffectiveStateLabel(
 ): string {
   if (!diagnostics) return '-'
   if (diagnostics.active) return 'Modul aktywny'
-  if (form.mode === 'STANDALONE') return 'Modul niedostepny w trybie standalone'
-  if (!form.pliCbdEnabled) return 'Modul wylaczony, konfiguracja zachowana'
+  if (form.mode === 'STANDALONE') return 'Moduł niedostępny w trybie standalone'
+  if (!form.pliCbdEnabled) return 'Moduł wyłączony, konfiguracja zachowana'
   return 'Konfiguracja niekompletna'
 }
 
@@ -64,27 +70,48 @@ export function SystemModeSettingsPanel({
 }: SystemModeSettingsPanelProps) {
   return (
     <div className="p-6">
-      <div className="mx-auto max-w-4xl space-y-4">
-        <div className="card p-6">
-          <h1 className="text-xl font-semibold text-gray-900">Tryb systemu i PLI CBD</h1>
-          <p className="mt-1 text-sm text-gray-600">
-            Ustaw tryb pracy systemu oraz konfiguracje modulu integracji z PLI CBD.
-          </p>
-        </div>
+      <div className="mx-auto max-w-4xl space-y-6">
+        <PageHeader
+          eyebrow="Administracja"
+          title="Tryb systemu i PLI CBD"
+          description="Ustaw, czy NP-Manager działa w trybie manualnym, czy z aktywną integracją PLI CBD."
+        />
 
         {isLoading ? (
-          <div className="card p-6">
-            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
-              Ladowanie ustawien...
-            </div>
-          </div>
+          <SectionCard>
+            <p className="text-sm text-ink-500">Ładowanie ustawień...</p>
+          </SectionCard>
         ) : (
           <>
-            <div className="card p-6">
+            <SectionCard title="Aktualny stan">
+              <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <DataField
+                  label="Stan integracji"
+                  value={getEffectiveStateLabel(form, diagnostics)}
+                />
+                <DataField
+                  label="Aktywna integracja"
+                  value={
+                    diagnostics ? (
+                      <Badge tone={diagnostics.active ? 'green' : 'neutral'} leadingDot>
+                        {diagnostics.active ? 'Tak' : 'Nie'}
+                      </Badge>
+                    ) : null
+                  }
+                />
+                <DataField
+                  label="Konfiguracja kompletna"
+                  value={diagnostics ? (diagnostics.configured ? 'Tak' : 'Nie') : null}
+                />
+                <DataField label="Brakujące pola" value={getMissingFieldsLabel(diagnostics)} />
+              </dl>
+            </SectionCard>
+
+            <SectionCard
+              title="Konfiguracja trybu"
+              description="Wybierz, w jakim trybie pracuje system."
+            >
               <fieldset className="space-y-3">
-                <legend className="text-sm font-semibold uppercase tracking-wide text-gray-700">
-                  Tryb systemu
-                </legend>
                 <label className="flex items-start gap-3">
                   <input
                     type="radio"
@@ -94,12 +121,11 @@ export function SystemModeSettingsPanel({
                     className="mt-1"
                   />
                   <span>
-                    <span className="block text-sm font-semibold text-gray-900">
+                    <span className="block text-sm font-semibold text-ink-900">
                       Manualny standalone
                     </span>
-                    <span className="block text-sm text-gray-600">
-                      PLI CBD jest niedostepne w UI i chronione w backendzie jako nieaktywna
-                      capability.
+                    <span className="block text-sm text-ink-500">
+                      Operator prowadzi sprawy ręcznie. Sekcje PLI CBD są niedostępne.
                     </span>
                   </span>
                 </label>
@@ -112,42 +138,35 @@ export function SystemModeSettingsPanel({
                     className="mt-1"
                   />
                   <span>
-                    <span className="block text-sm font-semibold text-gray-900">
+                    <span className="block text-sm font-semibold text-ink-900">
                       Zintegrowany z PLI CBD
                     </span>
-                    <span className="block text-sm text-gray-600">
-                      Modul moze byc aktywny dopiero po wlaczeniu i uzupelnieniu konfiguracji.
+                    <span className="block text-sm text-ink-500">
+                      PLI CBD może być aktywne dopiero po pełnej konfiguracji.
                     </span>
                   </span>
                 </label>
               </fieldset>
-            </div>
+            </SectionCard>
 
-            <div className="card p-6">
+            <SectionCard
+              title="Konfiguracja PLI CBD"
+              description="Niepełna konfiguracja może zostać zapisana — integracja pozostanie nieaktywna, dopóki brakuje wymaganych pól."
+            >
               <div className="space-y-4">
-                <div>
-                  <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">
-                    Konfiguracja PLI CBD
-                  </h2>
-                  <p className="mt-1 text-sm text-gray-600">
-                    Niepelna konfiguracja moze zostac zapisana; capability pozostanie wtedy
-                    nieaktywna.
-                  </p>
-                </div>
-
                 <label className="inline-flex items-center gap-2">
                   <input
                     type="checkbox"
                     checked={form.pliCbdEnabled}
                     onChange={(event) => onChange('pliCbdEnabled', event.target.checked)}
                   />
-                  <span className="text-sm font-medium text-gray-700">Wlacz modul PLI CBD</span>
+                  <span className="text-sm font-medium text-ink-700">
+                    Aktywna integracja PLI CBD
+                  </span>
                 </label>
 
                 <label className="block">
-                  <span className="mb-1 block text-sm font-medium text-gray-700">
-                    Endpoint URL
-                  </span>
+                  <span className="mb-1 block text-sm font-medium text-ink-700">Endpoint URL</span>
                   <input
                     type="url"
                     value={form.pliCbdEndpointUrl}
@@ -158,8 +177,8 @@ export function SystemModeSettingsPanel({
                 </label>
 
                 <label className="block">
-                  <span className="mb-1 block text-sm font-medium text-gray-700">
-                    Credentials ref
+                  <span className="mb-1 block text-sm font-medium text-ink-700">
+                    Referencja poświadczeń
                   </span>
                   <input
                     type="text"
@@ -171,7 +190,7 @@ export function SystemModeSettingsPanel({
                 </label>
 
                 <label className="block">
-                  <span className="mb-1 block text-sm font-medium text-gray-700">
+                  <span className="mb-1 block text-sm font-medium text-ink-700">
                     Kod operatora
                   </span>
                   <input
@@ -183,54 +202,27 @@ export function SystemModeSettingsPanel({
                   />
                 </label>
 
-                <button type="button" onClick={onSave} disabled={isSaving} className="btn-primary">
-                  {isSaving ? 'Zapisywanie...' : 'Zapisz ustawienia'}
-                </button>
-              </div>
+                <Button
+                  variant="primary"
+                  onClick={onSave}
+                  isLoading={isSaving}
+                  loadingLabel="Zapisywanie..."
+                >
+                  Zapisz ustawienia
+                </Button>
 
-              {success && (
-                <div className="mt-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-                  {success}
-                </div>
-              )}
-              {error && (
-                <div className="mt-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-                  {error}
-                </div>
-              )}
-            </div>
+                {success && <AlertBanner tone="success" title={success} />}
+                {error && <AlertBanner tone="danger" title={error} />}
+              </div>
+            </SectionCard>
+
+            <AlertBanner
+              tone="info"
+              title="Skutki zmian konfiguracji"
+              description="Zmiana trybu systemu wpływa na dostępność sekcji PLI CBD w aplikacji. Integracja pozostaje nieaktywna, dopóki konfiguracja jest niekompletna."
+            />
           </>
         )}
-
-        <div className="card p-6">
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">
-            Efektywny stan modulu
-          </h2>
-          <dl className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <div>
-              <dt className="text-xs text-gray-500">Stan</dt>
-              <dd className="text-sm font-semibold text-gray-900">
-                {getEffectiveStateLabel(form, diagnostics)}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs text-gray-500">Capability active</dt>
-              <dd className="text-sm text-gray-900">
-                {diagnostics ? (diagnostics.active ? 'Tak' : 'Nie') : '-'}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs text-gray-500">Konfiguracja kompletna</dt>
-              <dd className="text-sm text-gray-900">
-                {diagnostics ? (diagnostics.configured ? 'Tak' : 'Nie') : '-'}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs text-gray-500">Brakujace pola</dt>
-              <dd className="text-sm text-gray-900">{getMissingFieldsLabel(diagnostics)}</dd>
-            </div>
-          </dl>
-        </div>
       </div>
     </div>
   )

--- a/apps/frontend/src/pages/Admin/PortingNotificationSettingsPage.test.tsx
+++ b/apps/frontend/src/pages/Admin/PortingNotificationSettingsPage.test.tsx
@@ -54,8 +54,8 @@ describe('PortingNotificationSettingsPage', () => {
 
     const html = renderToStaticMarkup(<PortingNotificationSettingsPage />)
 
-    expect(html).toContain('Ustawienia powiadomien portingowych')
-    expect(html).toContain('Ladowanie ustawien...')
+    expect(html).toContain('Powiadomienia portingowe')
+    expect(html).toContain('Ładowanie ustawień...')
   })
 
   it('blocks non-admin users from admin settings view', () => {
@@ -70,7 +70,7 @@ describe('PortingNotificationSettingsPage', () => {
 
     const html = renderToStaticMarkup(<PortingNotificationSettingsPage />)
 
-    expect(html).toContain('Brak dostepu do administracji')
-    expect(html).toContain('Ta sekcja jest dostepna tylko dla administratora systemu.')
+    expect(html).toContain('Brak dostępu do administracji')
+    expect(html).toContain('Ta sekcja jest dostępna tylko dla administratora systemu.')
   })
 })

--- a/apps/frontend/src/pages/Admin/PortingNotificationSettingsPage.tsx
+++ b/apps/frontend/src/pages/Admin/PortingNotificationSettingsPage.tsx
@@ -6,6 +6,7 @@ import {
   getAdminPortingNotificationSettings,
   updateAdminPortingNotificationSettings,
 } from '@/services/adminPortingNotificationSettings.api'
+import { EmptyState } from '@/components/ui/EmptyState'
 import {
   PortingNotificationSettingsPanel,
   type PortingNotificationSettingsFormState,
@@ -50,12 +51,10 @@ function getErrorMessage(error: unknown, fallback: string): string {
 function AdminAccessDeniedState() {
   return (
     <div className="p-6">
-      <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-14 text-center">
-        <h1 className="text-2xl font-semibold text-gray-900">Brak dostepu do administracji</h1>
-        <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-gray-600">
-          Ta sekcja jest dostepna tylko dla administratora systemu.
-        </p>
-      </div>
+      <EmptyState
+        title="Brak dostępu do administracji"
+        description="Ta sekcja jest dostępna tylko dla administratora systemu."
+      />
     </div>
   )
 }
@@ -92,7 +91,7 @@ export function PortingNotificationSettingsPage() {
       })
       setDiagnostics(result.diagnostics)
     } catch (errorValue) {
-      setError(getErrorMessage(errorValue, 'Nie udalo sie zaladowac ustawien powiadomien.'))
+      setError(getErrorMessage(errorValue, 'Nie udało się załadować ustawień powiadomień.'))
       setForm(EMPTY_FORM)
       setDiagnostics(null)
     } finally {
@@ -122,7 +121,7 @@ export function PortingNotificationSettingsPage() {
     if (isSaving) return
 
     if (!isValidEmailList(form.sharedEmails)) {
-      setError('Podaj poprawna liste adresow e-mail (rozdzielonych przecinkami).')
+      setError('Podaj poprawną listę adresów e-mail (rozdzielonych przecinkami).')
       setSuccess(null)
       return
     }
@@ -150,9 +149,9 @@ export function PortingNotificationSettingsPage() {
         teamsWebhookUrl: result.teamsWebhookUrl,
       })
       setDiagnostics(result.diagnostics)
-      setSuccess('Ustawienia powiadomien portingowych zostaly zapisane.')
+      setSuccess('Ustawienia powiadomień portingowych zostały zapisane.')
     } catch (errorValue) {
-      setError(getErrorMessage(errorValue, 'Nie udalo sie zapisac ustawien powiadomien.'))
+      setError(getErrorMessage(errorValue, 'Nie udało się zapisać ustawień powiadomień.'))
     } finally {
       setIsSaving(false)
     }

--- a/apps/frontend/src/pages/Admin/SystemModeSettingsPage.test.tsx
+++ b/apps/frontend/src/pages/Admin/SystemModeSettingsPage.test.tsx
@@ -64,7 +64,7 @@ describe('SystemModeSettingsPage', () => {
     const html = renderToStaticMarkup(<SystemModeSettingsPage />)
 
     expect(html).toContain('Tryb systemu i PLI CBD')
-    expect(html).toContain('Ladowanie ustawien...')
+    expect(html).toContain('Ładowanie ustawień...')
   })
 
   it('blocks non-admin users from admin settings view', () => {
@@ -79,8 +79,8 @@ describe('SystemModeSettingsPage', () => {
 
     const html = renderToStaticMarkup(<SystemModeSettingsPage />)
 
-    expect(html).toContain('Brak dostepu do administracji')
-    expect(html).toContain('Ta sekcja jest dostepna tylko dla administratora systemu.')
+    expect(html).toContain('Brak dostępu do administracji')
+    expect(html).toContain('Ta sekcja jest dostępna tylko dla administratora systemu.')
   })
 
   it('validates optional endpoint URL syntactically', () => {

--- a/apps/frontend/src/pages/Admin/SystemModeSettingsPage.tsx
+++ b/apps/frontend/src/pages/Admin/SystemModeSettingsPage.tsx
@@ -11,6 +11,7 @@ import {
   getAdminSystemModeSettings,
   updateAdminSystemModeSettings,
 } from '@/services/adminSystemModeSettings.api'
+import { EmptyState } from '@/components/ui/EmptyState'
 import {
   SystemModeSettingsPanel,
   type SystemModeSettingsFormState,
@@ -77,12 +78,10 @@ export function buildSystemModeSettingsPayload(
 function AdminAccessDeniedState() {
   return (
     <div className="p-6">
-      <div className="rounded-3xl border border-dashed border-gray-300 bg-white px-6 py-14 text-center">
-        <h1 className="text-2xl font-semibold text-gray-900">Brak dostepu do administracji</h1>
-        <p className="mx-auto mt-3 max-w-2xl text-sm leading-6 text-gray-600">
-          Ta sekcja jest dostepna tylko dla administratora systemu.
-        </p>
-      </div>
+      <EmptyState
+        title="Brak dostępu do administracji"
+        description="Ta sekcja jest dostępna tylko dla administratora systemu."
+      />
     </div>
   )
 }
@@ -110,7 +109,7 @@ export function SystemModeSettingsPage() {
       setDiagnostics(result.diagnostics)
       setCapabilitiesSnapshot(result.capabilities)
     } catch (errorValue) {
-      setError(getErrorMessage(errorValue, 'Nie udalo sie zaladowac ustawien trybu systemu.'))
+      setError(getErrorMessage(errorValue, 'Nie udało się załadować ustawień trybu systemu.'))
       setForm(EMPTY_FORM)
       setDiagnostics(null)
     } finally {
@@ -155,9 +154,9 @@ export function SystemModeSettingsPage() {
       setForm(toSystemModeFormState(result.settings))
       setDiagnostics(result.diagnostics)
       setCapabilitiesSnapshot(result.capabilities)
-      setSuccess('Ustawienia trybu systemu zostaly zapisane.')
+      setSuccess('Ustawienia trybu systemu zostały zapisane.')
     } catch (errorValue) {
-      setError(getErrorMessage(errorValue, 'Nie udalo sie zapisac ustawien trybu systemu.'))
+      setError(getErrorMessage(errorValue, 'Nie udało się zapisać ustawień trybu systemu.'))
     } finally {
       setIsSaving(false)
     }


### PR DESCRIPTION
## Summary
- Polish System Mode and Porting Notification admin settings with the shared UI design system.
- Split settings screens into clearer sections: current state, configuration and read-only diagnostics.
- Improve admin-facing copy around PLI CBD mode, notification recipients and transport diagnostics.
- Keep settings API behavior unchanged.

## Scope
- Frontend-only admin settings polish.
- SystemModeSettingsPage / SystemModeSettingsPanel.
- PortingNotificationSettingsPage / PortingNotificationSettingsPanel.
- No backend changes.
- No DTO changes.
- No API service changes.
- No routing changes.
- No capability logic changes.
- No NotificationFallback/AdminUsers/CommunicationTemplates/Requests/RequestDetail changes.
- No dark mode.

## Preserved logic
- SystemMode API calls unchanged.
- SystemMode payload unchanged.
- setCapabilitiesSnapshot still called after load/save.
- URL validation unchanged.
- PortingNotification API calls unchanged.
- PortingNotification payload unchanged.
- Email list validation unchanged.
- Webhook URL validation unchanged.
- ADMIN-only access unchanged.

## Adescom / PLI CBD context
- Technical PLI CBD settings remain visible but are presented as configuration/diagnostics.
- Admin-facing copy explains operational effects instead of exposing capability jargon as the main message.
- Manual mode and integrated mode are described in user-friendly language.

## Validation
- npm run type-check --workspace apps/frontend — PASS
- npm run test --workspace apps/frontend — PASS, 317/317
- npm run build --workspace apps/frontend — PASS

## Manual QA focus
- System mode page loads.
- Non-admin access denied.
- Standalone vs PLI CBD integrated descriptions.
- Invalid PLI CBD endpoint blocks save.
- Save updates capabilities snapshot.
- Porting notifications page loads.
- Invalid email list blocks save.
- Invalid Teams webhook blocks save.
- Valid notification settings save.
- Diagnostics sections display read-only data.
- Visual layout of DataField/Badge in diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)