### PR TITLE
refactor(frontend): polish notification operations UI

### DIFF
--- a/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx
+++ b/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx
@@ -82,14 +82,14 @@ describe('InternalNotificationAttemptsPanel', () => {
   it('renders retry action only for retryable attempts', () => {
     renderPanel()
 
-    expect(screen.getByRole('button', { name: 'Ponow' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Ponów' })).toBeTruthy()
     expect(screen.getByText('Tego typu proby nie mozna ponowic.')).toBeTruthy()
   })
 
   it('calls retry callback for selected attempt', () => {
     const { onRetryAttempt } = renderPanel()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Ponow' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Ponów' }))
 
     expect(onRetryAttempt).toHaveBeenCalledWith('attempt-1')
     expect(onRetryAttempt).toHaveBeenCalledTimes(1)
@@ -106,7 +106,7 @@ describe('InternalNotificationAttemptsPanel', () => {
   it('hides retry button when role cannot trigger retry', () => {
     renderPanel({ canRetryAttempts: false })
 
-    expect(screen.queryByRole('button', { name: 'Ponow' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Ponów' })).toBeNull()
     expect(screen.getByText('Ponowienie dostepne dla zespolu operacyjnego.')).toBeTruthy()
   })
 

--- a/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx
+++ b/apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx
@@ -1,5 +1,6 @@
 import type { InternalNotificationDeliveryAttemptDto } from '@np-manager/shared'
 import { getInternalNotificationRetryBlockedReasonLabel } from '@/lib/internalNotificationRetryMessages'
+import { AlertBanner, Badge, Button, type BadgeTone } from '@/components/ui'
 
 interface InternalNotificationAttemptsPanelProps {
   items: InternalNotificationDeliveryAttemptDto[]
@@ -23,9 +24,9 @@ function formatDateTime(value: string): string {
 }
 
 function formatOrigin(origin: InternalNotificationDeliveryAttemptDto['attemptOrigin']): string {
-  if (origin === 'PRIMARY') return 'Primary dispatch'
-  if (origin === 'ERROR_FALLBACK') return 'Error fallback'
-  return 'Retry'
+  if (origin === 'PRIMARY') return 'Pierwotna wysyłka'
+  if (origin === 'ERROR_FALLBACK') return 'Fallback błędu'
+  return 'Ponowienie'
 }
 
 function formatChannel(channel: InternalNotificationDeliveryAttemptDto['channel']): string {
@@ -36,17 +37,26 @@ function formatChannel(channel: InternalNotificationDeliveryAttemptDto['channel'
 function formatFailureKind(
   failureKind: InternalNotificationDeliveryAttemptDto['failureKind'],
 ): string {
-  if (failureKind === 'DELIVERY') return 'Blad wysylki'
-  if (failureKind === 'CONFIGURATION') return 'Blad konfiguracji'
+  if (failureKind === 'DELIVERY') return 'Błąd wysyłki'
+  if (failureKind === 'CONFIGURATION') return 'Błąd konfiguracji'
   if (failureKind === 'POLICY') return 'Polityka'
   return '-'
 }
 
-function getOutcomeClass(outcome: InternalNotificationDeliveryAttemptDto['outcome']): string {
-  if (outcome === 'FAILED') return 'bg-red-100 text-red-700'
-  if (outcome === 'MISCONFIGURED') return 'bg-amber-100 text-amber-700'
-  if (outcome === 'SENT' || outcome === 'STUBBED') return 'bg-emerald-100 text-emerald-700'
-  return 'bg-gray-100 text-gray-700'
+function getOutcomeTone(outcome: InternalNotificationDeliveryAttemptDto['outcome']): BadgeTone {
+  if (outcome === 'FAILED') return 'red'
+  if (outcome === 'MISCONFIGURED') return 'amber'
+  if (outcome === 'SENT' || outcome === 'STUBBED') return 'emerald'
+  return 'neutral'
+}
+
+function getOutcomeLabel(outcome: InternalNotificationDeliveryAttemptDto['outcome']): string {
+  if (outcome === 'SENT') return 'Wysłano'
+  if (outcome === 'STUBBED') return 'Stub'
+  if (outcome === 'DISABLED') return 'Wyłączone'
+  if (outcome === 'MISCONFIGURED') return 'Błąd konfiguracji'
+  if (outcome === 'FAILED') return 'Błąd wysyłki'
+  return 'Pominięto'
 }
 
 export function InternalNotificationAttemptsPanel({
@@ -62,38 +72,35 @@ export function InternalNotificationAttemptsPanel({
   return (
     <div className="card p-5">
       <div className="mb-4">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">
-          Proby dostarczenia notyfikacji
+        <h2 className="text-sm font-semibold text-ink-900">
+          Próby dostarczenia notyfikacji
         </h2>
-        <p className="mt-1 text-sm text-gray-500">
-          Ledger wykonanych prob transportu internal notifications. Szersza historia routingu i
-          auditow pozostaje w panelu historii powiadomien wewnetrznych.
+        <p className="mt-1 text-sm text-ink-500">
+          Historia wysyłek dla tej sprawy. Ponów nieudaną próbę lub sprawdź przyczynę błędu.
         </p>
       </div>
 
       {retrySuccessMessage && (
-        <div className="mb-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-          {retrySuccessMessage}
+        <div className="mb-4">
+          <AlertBanner tone="success" title={retrySuccessMessage} />
         </div>
       )}
 
       {retryErrorMessage && (
-        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {retryErrorMessage}
+        <div className="mb-4">
+          <AlertBanner tone="danger" title={retryErrorMessage} />
         </div>
       )}
 
       {isLoading ? (
-        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">
-          Ladowanie prob dostarczenia...
+        <div className="rounded-panel border border-dashed border-line bg-ink-50 px-4 py-3 text-sm text-ink-500">
+          Ładowanie prób dostarczenia...
         </div>
       ) : error ? (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {error}
-        </div>
+        <AlertBanner tone="danger" title={error} />
       ) : items.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
-          Brak zapisanych prob transportu w modelu attempts dla tej sprawy.
+        <div className="rounded-panel border border-dashed border-line bg-ink-50 px-4 py-3 text-sm text-ink-600">
+          Brak prób dostarczenia notyfikacji dla tej sprawy.
         </div>
       ) : (
         <div className="space-y-3">
@@ -102,62 +109,61 @@ export function InternalNotificationAttemptsPanel({
             const canShowRetryButton = item.canRetry && canRetryAttempts
 
             return (
-              <article key={item.id} className="rounded-lg border border-gray-200 bg-white p-4">
+              <article key={item.id} className="rounded-panel border border-line bg-surface p-4">
                 <div className="flex flex-wrap items-start justify-between gap-2">
                   <div>
-                    <h3 className="text-sm font-semibold text-gray-900">{item.eventLabel}</h3>
-                    <p className="mt-0.5 text-xs text-gray-500">
+                    <h3 className="text-sm font-semibold text-ink-900">{item.eventLabel}</h3>
+                    <p className="mt-0.5 text-xs text-ink-500">
                       {formatDateTime(item.createdAt)}
                       {item.eventCode ? ` | ${item.eventCode}` : ''}
                     </p>
                   </div>
-                  <span
-                    className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getOutcomeClass(
-                      item.outcome,
-                    )}`}
-                  >
-                    {item.outcome}
-                  </span>
+                  <Badge tone={getOutcomeTone(item.outcome)}>
+                    {getOutcomeLabel(item.outcome)}
+                  </Badge>
                 </div>
 
-                <dl className="mt-3 grid grid-cols-1 gap-2 text-sm text-gray-700 sm:grid-cols-2">
+                <dl className="mt-3 grid grid-cols-1 gap-2 text-sm text-ink-700 sm:grid-cols-2">
                   <div>
-                    <dt className="text-xs text-gray-500">Pochodzenie proby</dt>
+                    <dt className="text-xs text-ink-400">Typ wysyłki</dt>
                     <dd>{formatOrigin(item.attemptOrigin)}</dd>
                   </div>
                   <div>
-                    <dt className="text-xs text-gray-500">Kanal</dt>
+                    <dt className="text-xs text-ink-400">Kanał</dt>
                     <dd>{formatChannel(item.channel)}</dd>
                   </div>
                   <div>
-                    <dt className="text-xs text-gray-500">Odbiorca</dt>
-                    <dd>{item.recipient}</dd>
+                    <dt className="text-xs text-ink-400">Odbiorca</dt>
+                    <dd className="break-all">{item.recipient}</dd>
                   </div>
                   <div>
-                    <dt className="text-xs text-gray-500">Tryb</dt>
+                    <dt className="text-xs text-ink-400">Tryb</dt>
                     <dd>{item.mode}</dd>
                   </div>
                   <div>
-                    <dt className="text-xs text-gray-500">Rodzaj problemu</dt>
+                    <dt className="text-xs text-ink-400">Rodzaj błędu</dt>
                     <dd>{formatFailureKind(item.failureKind)}</dd>
                   </div>
                   <div>
-                    <dt className="text-xs text-gray-500">Licznik retry</dt>
+                    <dt className="text-xs text-ink-400">Ponowienia</dt>
                     <dd>{item.retryCount}</dd>
                   </div>
                 </dl>
 
                 {canShowRetryButton ? (
-                  <button
-                    type="button"
-                    onClick={() => onRetryAttempt(item.id)}
-                    disabled={isRetrying}
-                    className="mt-3 rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    {isRetrying ? 'Ponawiam...' : 'Ponow'}
-                  </button>
+                  <div className="mt-3">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => onRetryAttempt(item.id)}
+                      disabled={isRetrying}
+                    >
+                      {isRetrying ? 'Ponawiam...' : 'Ponów'}
+                    </Button>
+                  </div>
                 ) : (
-                  <p className="mt-3 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-xs text-gray-600">
+                  <p className="mt-3 rounded-panel border border-line bg-ink-50 px-3 py-2 text-xs text-ink-600">
                     {item.canRetry
                       ? 'Ponowienie dostepne dla zespolu operacyjnego.'
                       : getInternalNotificationRetryBlockedReasonLabel(item.retryBlockedReasonCode)}
@@ -165,8 +171,8 @@ export function InternalNotificationAttemptsPanel({
                 )}
 
                 {item.errorMessage && (
-                  <p className="mt-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-                    Blad transportu: {item.errorMessage}
+                  <p className="mt-3 rounded-panel border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                    Błąd wysyłki: {item.errorMessage}
                   </p>
                 )}
               </article>

--- a/apps/frontend/src/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.tsx
+++ b/apps/frontend/src/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.tsx
@@ -1,4 +1,5 @@
 import type { NotificationFailureHistoryItemDto } from '@np-manager/shared'
+import { Badge, type BadgeTone } from '@/components/ui'
 
 interface NotificationFailureHistoryPanelProps {
   items: NotificationFailureHistoryItemDto[]
@@ -23,17 +24,17 @@ function getIssueLabel(item: NotificationFailureHistoryItemDto): string {
   return 'Blad wysylki'
 }
 
-function getIssueBadgeClass(item: NotificationFailureHistoryItemDto): string {
+function getIssueTone(item: NotificationFailureHistoryItemDto): BadgeTone {
   if (item.isConfigurationIssue) {
-    return 'bg-amber-100 text-amber-700'
+    return 'amber'
   }
-  return 'bg-red-100 text-red-700'
+  return 'red'
 }
 
 function formatChannel(channel: NotificationFailureHistoryItemDto['channel']): string {
   if (channel === 'EMAIL') return 'E-mail'
   if (channel === 'TEAMS') return 'Teams'
-  return 'Nieznany kanal'
+  return 'Nieznany kanał'
 }
 
 export function NotificationFailureHistoryPanel({
@@ -44,55 +45,53 @@ export function NotificationFailureHistoryPanel({
   return (
     <div className="card p-5">
       <div className="mb-4">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">
+        <h2 className="text-sm font-semibold text-ink-900">
           Ostatnie problemy notyfikacji
         </h2>
-        <p className="mt-1 text-sm text-gray-500">
-          Najnowsze nieudane proby dispatchu z podzialem na problem konfiguracji i problem wysylki.
+        <p className="mt-1 text-sm text-ink-500">
+          Najnowsze nieudane próby wysyłki — błędy konfiguracji i błędy dostarczenia.
         </p>
       </div>
 
       {isLoading ? (
-        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-500">
-          Ladowanie historii problemow notyfikacji...
+        <div className="rounded-panel border border-dashed border-line bg-ink-50 px-4 py-3 text-sm text-ink-500">
+          Ładowanie historii błędów notyfikacji...
         </div>
       ) : error ? (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div className="rounded-panel border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           {error}
         </div>
       ) : items.length === 0 ? (
-        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+        <div className="rounded-panel border border-dashed border-line bg-ink-50 px-4 py-3 text-sm text-ink-600">
           Brak zarejestrowanych problemow notyfikacji.
         </div>
       ) : (
         <div className="space-y-3">
           {items.map((item) => (
-            <article key={item.id} className="rounded-lg border border-gray-200 bg-white p-4">
+            <article key={item.id} className="rounded-panel border border-line bg-surface p-4">
               <div className="flex flex-wrap items-start justify-between gap-2">
                 <div>
-                  <h3 className="text-sm font-semibold text-gray-900">{item.message}</h3>
-                  <p className="mt-0.5 text-xs text-gray-500">{formatDateTime(item.occurredAt)}</p>
+                  <h3 className="text-sm font-semibold text-ink-900">{item.message}</h3>
+                  <p className="mt-0.5 text-xs text-ink-400">{formatDateTime(item.occurredAt)}</p>
                 </div>
-                <span
-                  className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getIssueBadgeClass(item)}`}
-                >
+                <Badge tone={getIssueTone(item)}>
                   {getIssueLabel(item)}
-                </span>
+                </Badge>
               </div>
 
-              <dl className="mt-3 grid grid-cols-1 gap-2 text-sm text-gray-700 sm:grid-cols-2">
+              <dl className="mt-3 grid grid-cols-1 gap-2 text-sm text-ink-700 sm:grid-cols-2">
                 <div>
-                  <dt className="text-xs text-gray-500">Kanal</dt>
+                  <dt className="text-xs text-ink-400">Kanał</dt>
                   <dd>{formatChannel(item.channel)}</dd>
                 </div>
                 <div>
-                  <dt className="text-xs text-gray-500">Typ</dt>
+                  <dt className="text-xs text-ink-400">Wynik</dt>
                   <dd>{item.outcome}</dd>
                 </div>
               </dl>
 
               {item.technicalDetailsPreview && (
-                <p className="mt-3 rounded-md border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700">
+                <p className="mt-3 rounded-panel border border-line bg-ink-50 px-3 py-2 text-sm text-ink-700">
                   Szczegoly techniczne: {item.technicalDetailsPreview}
                 </p>
               )}

--- a/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx
+++ b/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx
@@ -8,6 +8,7 @@ import {
   deriveOperationalStatus,
   OPERATIONAL_STATUS_CONFIG,
 } from '@/lib/notificationFailureQueueOperationalStatus'
+import { Badge, Button, type BadgeTone } from '@/components/ui'
 
 interface NotificationFailureQueueTableProps {
   items: GlobalNotificationFailureQueueItemDto[]
@@ -17,10 +18,10 @@ interface NotificationFailureQueueTableProps {
   onRetryAttempt: (item: GlobalNotificationFailureQueueItemDto) => void
 }
 
-function getOutcomeClass(outcome: GlobalNotificationFailureQueueItemDto['outcome']): string {
-  if (outcome === 'FAILED') return 'bg-red-100 text-red-700'
-  if (outcome === 'MISCONFIGURED') return 'bg-amber-100 text-amber-700'
-  return 'bg-gray-100 text-gray-700'
+function getOutcomeTone(outcome: GlobalNotificationFailureQueueItemDto['outcome']): BadgeTone {
+  if (outcome === 'FAILED') return 'red'
+  if (outcome === 'MISCONFIGURED') return 'amber'
+  return 'neutral'
 }
 
 function getOutcomeLabel(outcome: GlobalNotificationFailureQueueItemDto['outcome']): string {
@@ -38,7 +39,6 @@ function getFailureKindLabel(
   return '—'
 }
 
-
 function getChannelLabel(channel: GlobalNotificationFailureQueueItemDto['channel']): string {
   if (channel === 'EMAIL') return 'E-mail'
   if (channel === 'TEAMS') return 'Teams'
@@ -55,7 +55,7 @@ const RETRY_BLOCKED_REASON_LABELS: Record<InternalNotificationRetryBlockedReason
 function getRetryBlockedReasonLabel(
   reasonCode: GlobalNotificationFailureQueueItemDto['retryBlockedReasonCode'],
 ): string {
-  return reasonCode ? RETRY_BLOCKED_REASON_LABELS[reasonCode] : 'Retry niedostepne'
+  return reasonCode ? RETRY_BLOCKED_REASON_LABELS[reasonCode] : 'Ponowienie niedostępne'
 }
 
 function formatRelativeTime(isoString: string): string {
@@ -78,15 +78,15 @@ export function NotificationFailureQueueTable({
 }: NotificationFailureQueueTableProps) {
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-12 text-sm text-gray-500">
-        Ładowanie...
+      <div className="flex items-center justify-center py-12 text-sm text-ink-500">
+        Ładowanie kolejki błędów...
       </div>
     )
   }
 
   if (error) {
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+      <div className="px-4 py-3 text-sm text-red-700">
         {error}
       </div>
     )
@@ -95,7 +95,7 @@ export function NotificationFailureQueueTable({
   if (items.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-14 text-center">
-        <p className="text-sm text-gray-500">Brak problematycznych prób notyfikacji.</p>
+        <p className="text-sm text-ink-500">Brak problematycznych prób notyfikacji.</p>
       </div>
     )
   }
@@ -104,12 +104,12 @@ export function NotificationFailureQueueTable({
     <div className="overflow-x-auto">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-gray-200 bg-gray-50 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+          <tr className="border-b border-line bg-ink-50 text-left text-xs font-semibold uppercase text-ink-500">
             <th className="px-4 py-3">Sprawa</th>
             <th className="px-4 py-3">Zdarzenie</th>
-            <th className="px-4 py-3">Kanal</th>
+            <th className="px-4 py-3">Kanał</th>
             <th className="px-4 py-3">Odbiorca</th>
-            <th className="px-4 py-3">Wynik</th>
+            <th className="px-4 py-3">Wynik wysyłki</th>
             <th className="px-4 py-3">Rodzaj błędu</th>
             <th className="px-4 py-3">Ponowienia</th>
             <th className="px-4 py-3">Status operacyjny</th>
@@ -117,38 +117,39 @@ export function NotificationFailureQueueTable({
             <th className="px-4 py-3">Akcja</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-100">
+        <tbody className="divide-y divide-line">
           {items.map((item) => {
             const isRetrying = retryingAttemptIds.includes(item.attemptId)
             const opStatus = deriveOperationalStatus(item)
             const opConfig = OPERATIONAL_STATUS_CONFIG[opStatus]
 
             return (
-              <tr key={item.attemptId} className={`bg-white hover:bg-gray-50 ${opConfig.rowAccentClass}`}>
+              <tr key={item.attemptId} className={`bg-surface hover:bg-ink-50/70 ${opConfig.rowAccentClass}`}>
                 <td className="px-4 py-3 font-mono text-xs">
                   <Link
                     to={buildPath(ROUTES.REQUEST_DETAIL, item.requestId)}
-                    className="text-blue-600 hover:underline"
+                    className="font-semibold text-brand-700 hover:underline"
                   >
                     {item.caseNumber}
                   </Link>
                 </td>
-                <td className="px-4 py-3 text-gray-900">{item.eventLabel}</td>
-                <td className="px-4 py-3 text-gray-600">{getChannelLabel(item.channel)}</td>
-                <td className="max-w-[220px] truncate px-4 py-3 text-gray-600" title={item.recipient}>
+                <td className="px-4 py-3 text-ink-900">{item.eventLabel}</td>
+                <td className="px-4 py-3 text-ink-650">{getChannelLabel(item.channel)}</td>
+                <td
+                  className="max-w-[220px] truncate px-4 py-3 text-ink-650"
+                  title={item.recipient}
+                >
                   {item.recipient}
                 </td>
                 <td className="px-4 py-3">
-                  <span
-                    className={`rounded-full px-2.5 py-1 text-[11px] font-medium uppercase tracking-wide ${getOutcomeClass(item.outcome)}`}
-                  >
+                  <Badge tone={getOutcomeTone(item.outcome)}>
                     {getOutcomeLabel(item.outcome)}
-                  </span>
+                  </Badge>
                 </td>
-                <td className="px-4 py-3 text-gray-600">
+                <td className="px-4 py-3 text-ink-650">
                   {getFailureKindLabel(item.failureKind)}
                 </td>
-                <td className="px-4 py-3 text-gray-600">{item.retryCount} / 3</td>
+                <td className="px-4 py-3 text-ink-650">{item.retryCount} / 3</td>
                 <td className="px-4 py-3">
                   <span
                     className={`rounded-full px-2.5 py-1 text-[11px] font-medium ${opConfig.badgeClass}`}
@@ -156,19 +157,20 @@ export function NotificationFailureQueueTable({
                     {opConfig.label}
                   </span>
                 </td>
-                <td className="px-4 py-3 text-gray-400">{formatRelativeTime(item.createdAt)}</td>
+                <td className="px-4 py-3 text-ink-400">{formatRelativeTime(item.createdAt)}</td>
                 <td className="px-4 py-3">
                   {item.canRetry ? (
-                    <button
+                    <Button
                       type="button"
+                      size="sm"
+                      variant="secondary"
                       onClick={() => onRetryAttempt(item)}
                       disabled={isRetrying}
-                      className="rounded-lg border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
                     >
                       {isRetrying ? 'Ponawiam...' : 'Ponów'}
-                    </button>
+                    </Button>
                   ) : (
-                    <span className="text-xs text-gray-500">
+                    <span className="text-xs text-ink-500">
                       {getRetryBlockedReasonLabel(item.retryBlockedReasonCode)}
                     </span>
                   )}

--- a/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.test.tsx
+++ b/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.test.tsx
@@ -84,7 +84,7 @@ describe('InternalNotificationAttemptsPage', () => {
     const table = screen.getByRole('table')
     expect(within(table).getByText('Zmiana statusu sprawy')).toBeTruthy()
     expect(within(table).getByText('bok@test.pl')).toBeTruthy()
-    expect(within(table).getByText('Blad wysylki')).toBeTruthy()
+    expect(within(table).getByText('Błąd wysyłki')).toBeTruthy()
     expect(within(table).getByText('SMTP unavailable')).toBeTruthy()
     expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenCalledWith({
       limit: 50,
@@ -97,7 +97,7 @@ describe('InternalNotificationAttemptsPage', () => {
 
     renderPage()
 
-    expect(screen.getByText('Ladowanie prob notyfikacji...')).toBeTruthy()
+    expect(screen.getByText('Ładowanie prób notyfikacji...')).toBeTruthy()
   })
 
   it('shows empty state when backend returns no attempts', async () => {
@@ -108,7 +108,7 @@ describe('InternalNotificationAttemptsPage', () => {
 
     renderPage()
 
-    expect(await screen.findByText('Brak zapisanych prob notyfikacji.')).toBeTruthy()
+    expect(await screen.findByText('Brak zapisanych prób notyfikacji.')).toBeTruthy()
   })
 
   it('shows error state instead of empty state after failed load', async () => {
@@ -117,9 +117,9 @@ describe('InternalNotificationAttemptsPage', () => {
     renderPage()
 
     expect(
-      await screen.findByText('Nie udalo sie pobrac globalnej listy prob notyfikacji.'),
+      await screen.findByText('Nie udało się pobrać globalnej listy prób notyfikacji.'),
     ).toBeTruthy()
-    expect(screen.queryByText('Brak zapisanych prob notyfikacji.')).toBeNull()
+    expect(screen.queryByText('Brak zapisanych prób notyfikacji.')).toBeNull()
   })
 
   it('keeps pagination read-only and backed by existing offset params', async () => {
@@ -130,7 +130,7 @@ describe('InternalNotificationAttemptsPage', () => {
 
     renderPage()
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Nastepna' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Następna' }))
 
     await waitFor(() => {
       expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenCalledWith({
@@ -155,7 +155,7 @@ describe('InternalNotificationAttemptsPage', () => {
 
     renderPage()
 
-    expect(await screen.findByRole('button', { name: 'Ponow' })).toBeTruthy()
+    expect(await screen.findByRole('button', { name: 'Ponów' })).toBeTruthy()
     expect(screen.getByText('Limit ponowien osiagniety.')).toBeTruthy()
   })
 
@@ -178,7 +178,7 @@ describe('InternalNotificationAttemptsPage', () => {
 
     renderPage()
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Ponow' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponów' }))
 
     expect(screen.getByRole('button', { name: 'Ponawiam...' }).hasAttribute('disabled')).toBe(true)
     expect(retryInternalNotificationAttemptMock).toHaveBeenCalledWith('request-1', 'attempt-1')
@@ -203,7 +203,7 @@ describe('InternalNotificationAttemptsPage', () => {
     await screen.findByRole('link', { name: 'FNP-20260411-ABC123' })
 
     // navigate to second page
-    fireEvent.click(screen.getByRole('button', { name: 'Nastepna' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Następna' }))
     await waitFor(() => {
       expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
         limit: 50,
@@ -239,7 +239,7 @@ describe('InternalNotificationAttemptsPage', () => {
     })
 
     // toggle retryableOnly
-    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko mozliwe do ponowienia/ }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko możliwe do ponowienia/ }))
     await waitFor(() => {
       expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
         limit: 50,
@@ -262,9 +262,9 @@ describe('InternalNotificationAttemptsPage', () => {
 
     fireEvent.change(screen.getByLabelText('Filtr wynik'), { target: { value: 'FAILED' } })
     fireEvent.change(screen.getByLabelText('Filtr kanal'), { target: { value: 'EMAIL' } })
-    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko mozliwe do ponowienia/ }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko możliwe do ponowienia/ }))
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Wyczysc filtry' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Wyczyść filtry' }))
 
     await waitFor(() => {
       expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
@@ -276,7 +276,7 @@ describe('InternalNotificationAttemptsPage', () => {
       })
     })
 
-    expect(screen.queryByRole('button', { name: 'Wyczysc filtry' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Wyczyść filtry' })).toBeNull()
   })
 
   it('retry reloads data using currently active filters', async () => {
@@ -289,7 +289,7 @@ describe('InternalNotificationAttemptsPage', () => {
     await screen.findByRole('link', { name: 'FNP-20260411-ABC123' })
 
     fireEvent.change(screen.getByLabelText('Filtr wynik'), { target: { value: 'FAILED' } })
-    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko mozliwe do ponowienia/ }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko możliwe do ponowienia/ }))
 
     await waitFor(() => {
       expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
@@ -301,7 +301,7 @@ describe('InternalNotificationAttemptsPage', () => {
       })
     })
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Ponow' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponów' }))
 
     await waitFor(() => {
       expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
@@ -324,7 +324,7 @@ describe('InternalNotificationAttemptsPage', () => {
       .mockResolvedValueOnce({ items: [makeAttempt()], total: 51 })
       // after toggling retryableOnly -> offset=0, retryableOnly=true
       .mockResolvedValueOnce({ items: [makeAttempt()], total: 51 })
-      // after clicking Nastepna -> offset=50, retryableOnly=true (only 1 retryable left)
+      // after clicking Następna -> offset=50, retryableOnly=true (only 1 retryable left)
       .mockResolvedValueOnce({ items: [pageTwoItem], total: 51 })
       // retry success refresh -> offset=50 but total shrank to 50 -> empty, triggers clamp
       .mockResolvedValueOnce({ items: [], total: 50 })
@@ -339,7 +339,7 @@ describe('InternalNotificationAttemptsPage', () => {
 
     await screen.findByRole('link', { name: 'FNP-20260411-ABC123' })
 
-    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko mozliwe do ponowienia/ }))
+    fireEvent.click(screen.getByRole('checkbox', { name: /Tylko możliwe do ponowienia/ }))
     await waitFor(() => {
       expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
         limit: 50,
@@ -350,7 +350,7 @@ describe('InternalNotificationAttemptsPage', () => {
       })
     })
 
-    fireEvent.click(screen.getByRole('button', { name: 'Nastepna' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Następna' }))
     await waitFor(() => {
       expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
         limit: 50,
@@ -361,7 +361,7 @@ describe('InternalNotificationAttemptsPage', () => {
       })
     })
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Ponow' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponów' }))
 
     await waitFor(() => {
       expect(getGlobalInternalNotificationAttemptsMock).toHaveBeenLastCalledWith({
@@ -379,7 +379,7 @@ describe('InternalNotificationAttemptsPage', () => {
 
     renderPage()
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Ponow' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Ponów' }))
 
     expect(await screen.findByText('Nie udalo sie ponowic proby dostarczenia.')).toBeTruthy()
     expect(screen.getByText('Zmiana statusu sprawy')).toBeTruthy()

--- a/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.tsx
+++ b/apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.tsx
@@ -7,7 +7,7 @@ import type {
   InternalNotificationAttemptOutcomeDto,
   InternalNotificationFailureKindDto,
 } from '@np-manager/shared'
-import { Badge, Button, MetricCard, type BadgeTone } from '@/components/ui'
+import { AlertBanner, Badge, Button, MetricCard, PageHeader, SectionCard, type BadgeTone } from '@/components/ui'
 import { buildPath, ROUTES } from '@/constants/routes'
 import {
   getInternalNotificationRetryBlockedReasonLabel,
@@ -35,18 +35,18 @@ function getChannelLabel(channel: InternalNotificationAttemptChannelDto): string
 }
 
 function getOriginLabel(origin: InternalNotificationAttemptOriginDto): string {
-  if (origin === 'PRIMARY') return 'Primary'
-  if (origin === 'ERROR_FALLBACK') return 'Error fallback'
-  return 'Retry'
+  if (origin === 'PRIMARY') return 'Pierwotna'
+  if (origin === 'ERROR_FALLBACK') return 'Fallback błędu'
+  return 'Ponowienie'
 }
 
 function getOutcomeLabel(outcome: InternalNotificationAttemptOutcomeDto): string {
-  if (outcome === 'SENT') return 'Wyslano'
+  if (outcome === 'SENT') return 'Wysłano'
   if (outcome === 'STUBBED') return 'Stub'
-  if (outcome === 'DISABLED') return 'Wylaczone'
-  if (outcome === 'MISCONFIGURED') return 'Blad konfiguracji'
-  if (outcome === 'FAILED') return 'Blad wysylki'
-  return 'Pominieto'
+  if (outcome === 'DISABLED') return 'Wyłączone'
+  if (outcome === 'MISCONFIGURED') return 'Błąd konfiguracji'
+  if (outcome === 'FAILED') return 'Błąd wysyłki'
+  return 'Pominięto'
 }
 
 function getOutcomeTone(outcome: InternalNotificationAttemptOutcomeDto): BadgeTone {
@@ -57,14 +57,14 @@ function getOutcomeTone(outcome: InternalNotificationAttemptOutcomeDto): BadgeTo
 }
 
 function getFailureKindLabel(failureKind: InternalNotificationFailureKindDto): string {
-  if (failureKind === 'DELIVERY') return 'Transport'
+  if (failureKind === 'DELIVERY') return 'Wysyłka'
   if (failureKind === 'CONFIGURATION') return 'Konfiguracja'
   if (failureKind === 'POLICY') return 'Polityka'
   return '-'
 }
 
 function getVisibleRange(offset: number, itemsCount: number, total: number): string {
-  if (total === 0) return 'Brak rekordow'
+  if (total === 0) return 'Brak rekordów'
   return `${offset + 1}-${offset + itemsCount} z ${total}`
 }
 
@@ -90,15 +90,15 @@ function AttemptsTable({
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-12 text-sm text-ink-500">
-        Ladowanie prob notyfikacji...
+        Ładowanie prób notyfikacji...
       </div>
     )
   }
 
   if (error) {
     return (
-      <div className="m-4 rounded-ui border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-        {error}
+      <div className="m-4">
+        <AlertBanner tone="danger" title={error} />
       </div>
     )
   }
@@ -106,9 +106,9 @@ function AttemptsTable({
   if (items.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-14 text-center">
-        <p className="text-sm font-medium text-ink-700">Brak zapisanych prob notyfikacji.</p>
+        <p className="text-sm font-medium text-ink-700">Brak zapisanych prób notyfikacji.</p>
         <p className="mt-1 text-sm text-ink-500">
-          Globalny ledger nie zawiera jeszcze wykonanych prob transportu.
+          Rejestr nie zawiera jeszcze żadnych prób dostarczenia.
         </p>
       </div>
     )
@@ -122,11 +122,11 @@ function AttemptsTable({
             <th className="px-4 py-3">Sprawa</th>
             <th className="px-4 py-3">Zdarzenie</th>
             <th className="px-4 py-3">Odbiorca</th>
-            <th className="px-4 py-3">Kanal</th>
+            <th className="px-4 py-3">Kanał</th>
             <th className="px-4 py-3">Wynik</th>
-            <th className="px-4 py-3">Retry</th>
+            <th className="px-4 py-3">Ponowienia</th>
             <th className="px-4 py-3">Utworzono</th>
-            <th className="px-4 py-3">Blad</th>
+            <th className="px-4 py-3">Błąd</th>
             <th className="px-4 py-3">Akcja</th>
           </tr>
         </thead>
@@ -178,7 +178,7 @@ function AttemptsTable({
                 <td className="max-w-[280px] px-4 py-4 align-top">
                   {item.errorMessage ? (
                     <span
-                      className="line-clamp-2 text-sm text-red-700"
+                      className="line-clamp-2 break-all text-sm text-red-700"
                       title={item.errorMessage}
                     >
                       {item.errorMessage}
@@ -196,7 +196,7 @@ function AttemptsTable({
                       disabled={isRetrying}
                       onClick={() => onRetryAttempt(item)}
                     >
-                      {isRetrying ? 'Ponawiam...' : 'Ponow'}
+                      {isRetrying ? 'Ponawiam...' : 'Ponów'}
                     </Button>
                   ) : (
                     <span className="text-xs text-ink-500">
@@ -261,7 +261,7 @@ export function InternalNotificationAttemptsPage() {
         setOffset(lastPageOffset)
       }
     } catch {
-      setError('Nie udalo sie pobrac globalnej listy prob notyfikacji.')
+      setError('Nie udało się pobrać globalnej listy prób notyfikacji.')
     } finally {
       if (showLoading) {
         setIsLoading(false)
@@ -325,37 +325,31 @@ export function InternalNotificationAttemptsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-        <div className="min-w-0">
-          <p className="text-xs font-semibold uppercase text-brand-700">Notyfikacje wewnetrzne</p>
-          <h1 className="mt-1 text-3xl font-semibold text-ink-900">
-            Globalna lista prob dostarczenia
-          </h1>
-          <p className="mt-2 max-w-3xl text-sm leading-6 text-ink-500">
-            Administracyjny ledger internal notification attempts i technicznej diagnostyki transportu.
-          </p>
-        </div>
-      </div>
+      <PageHeader
+        eyebrow="Notyfikacje wewnętrzne"
+        title="Próby dostarczenia"
+        description="Rejestr wszystkich prób wysyłki notyfikacji wewnętrznych. Filtruj według wyniku i kanału, ponów nieudane próby."
+      />
 
       <div className="grid gap-4 md:grid-cols-3">
         <MetricCard
-          title="Wszystkie proby"
+          title="Wszystkie próby"
           value={isLoading ? '--' : total}
-          detail="Liczba rekordow zwrocona przez backend"
+          detail="Liczba rekordów zwrócona przez backend"
         />
         <MetricCard
           title="Na stronie"
           value={isLoading ? '--' : items.length}
-          detail={isLoading ? 'Ladowanie danych' : getVisibleRange(offset, items.length, total)}
+          detail={isLoading ? 'Ładowanie danych' : getVisibleRange(offset, items.length, total)}
         />
         <MetricCard
           title="Tryb widoku"
           value="Admin"
-          detail="Ledger z akcja ponowienia dla administratora"
+          detail="Widok administracyjny z akcją ponowienia"
         />
       </div>
 
-      <div className="rounded-panel border border-line bg-surface p-4 shadow-soft">
+      <SectionCard title="Filtry" padding="sm">
         <div className="flex flex-wrap items-end gap-3">
           <label className="flex flex-col gap-1 text-xs font-semibold uppercase text-ink-500">
             Wynik
@@ -375,14 +369,14 @@ export function InternalNotificationAttemptsPage() {
           </label>
 
           <label className="flex flex-col gap-1 text-xs font-semibold uppercase text-ink-500">
-            Kanal
+            Kanał
             <select
               value={channelFilter}
               onChange={(event) => handleChannelChange(event.target.value)}
               className="input-field h-10 min-w-[160px]"
               aria-label="Filtr kanal"
             >
-              <option value="">Wszystkie kanaly</option>
+              <option value="">Wszystkie kanały</option>
               {CHANNEL_FILTER_OPTIONS.map((value) => (
                 <option key={value} value={value}>
                   {getChannelLabel(value)}
@@ -398,7 +392,7 @@ export function InternalNotificationAttemptsPage() {
               checked={retryableOnly}
               onChange={(event) => handleRetryableOnlyChange(event.target.checked)}
             />
-            Tylko mozliwe do ponowienia
+            Tylko możliwe do ponowienia
           </label>
 
           {hasActiveFilters && (
@@ -409,25 +403,21 @@ export function InternalNotificationAttemptsPage() {
               size="sm"
               className="h-10"
             >
-              Wyczysc filtry
+              Wyczyść filtry
             </Button>
           )}
         </div>
-      </div>
+      </SectionCard>
 
       {retrySuccessMessage && (
-        <div className="rounded-ui border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-          {retrySuccessMessage}
-        </div>
+        <AlertBanner tone="success" title={retrySuccessMessage} />
       )}
 
       {retryErrorMessage && (
-        <div className="rounded-ui border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {retryErrorMessage}
-        </div>
+        <AlertBanner tone="danger" title={retryErrorMessage} />
       )}
 
-      <div className="overflow-hidden rounded-panel border border-line bg-surface shadow-soft">
+      <SectionCard padding="none">
         <AttemptsTable
           items={items}
           isLoading={isLoading}
@@ -435,7 +425,7 @@ export function InternalNotificationAttemptsPage() {
           retryingAttemptIds={retryingAttemptIds}
           onRetryAttempt={(item) => void handleRetryAttempt(item)}
         />
-      </div>
+      </SectionCard>
 
       {!isLoading && !error && total > PAGE_SIZE && (
         <div className="flex items-center justify-between text-sm text-ink-600">
@@ -456,7 +446,7 @@ export function InternalNotificationAttemptsPage() {
             size="sm"
             variant="ghost"
           >
-            Nastepna
+            Następna
           </Button>
         </div>
       )}

--- a/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx
+++ b/apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx
@@ -14,6 +14,7 @@ import {
   type GetGlobalNotificationFailureQueueParams,
 } from '@/services/portingRequests.api'
 import { NotificationFailureQueueTable } from '@/components/NotificationFailureQueueTable/NotificationFailureQueueTable'
+import { AlertBanner, Button, PageHeader, SectionCard } from '@/components/ui'
 
 const PAGE_SIZE = 50
 
@@ -106,53 +107,51 @@ export function NotificationFailureQueuePage() {
   const hasNext = offset + PAGE_SIZE < total
 
   return (
-    <div className="p-6">
-      <div className="mb-6">
-        <h1 className="text-xl font-semibold text-gray-900">Kolejka błędów notyfikacji</h1>
-        <p className="mt-1 text-sm text-gray-500">
-          Administracyjna lista spraw z ostatnio nieudanymi próbami dostarczenia notyfikacji.
-        </p>
-      </div>
+    <div className="space-y-6">
+      <PageHeader
+        eyebrow="Notyfikacje wewnętrzne"
+        title="Kolejka błędów notyfikacji"
+        description="Sprawy z ostatnio nieudanymi próbami dostarczenia. Ponów wysyłkę lub skieruj sprawę do interwencji ręcznej."
+      />
 
-      <div className="mb-4 flex items-center justify-between">
-        <label className="flex items-center gap-2 text-sm text-gray-700">
-          <span>Filtr operacyjny</span>
-          <select
-            value={operationalStatus}
-            onChange={(e) => {
-              setOperationalStatus(e.target.value as NotificationFailureQueueOperationalStatusFilter)
-              setOffset(0)
-            }}
-            className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700"
-          >
-            {NOTIFICATION_FAILURE_QUEUE_OPERATIONAL_STATUS_OPTIONS.map((option) => (
-              <option key={option.value || 'ALL'} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
-        </label>
+      <SectionCard padding="sm">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <label className="flex flex-col gap-1 text-xs font-semibold uppercase text-ink-500">
+            Status operacyjny
+            <select
+              value={operationalStatus}
+              onChange={(e) => {
+                setOperationalStatus(e.target.value as NotificationFailureQueueOperationalStatusFilter)
+                setOffset(0)
+              }}
+              aria-label="Filtr operacyjny"
+              className="input-field h-9 min-w-[220px]"
+            >
+              {NOTIFICATION_FAILURE_QUEUE_OPERATIONAL_STATUS_OPTIONS.map((option) => (
+                <option key={option.value || 'ALL'} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
 
-        {!isLoading && !error && (
-          <span className="text-xs text-gray-400">
-            {total === 0 ? 'Brak wyników' : `${total} ${total === 1 ? 'wynik' : 'wyników'}`}
-          </span>
-        )}
-      </div>
+          {!isLoading && !error && (
+            <span className="text-xs text-ink-400">
+              {total === 0 ? 'Brak wyników' : `${total} ${total === 1 ? 'wynik' : 'wyników'}`}
+            </span>
+          )}
+        </div>
+      </SectionCard>
 
       {retrySuccessMessage && (
-        <div className="mb-4 rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-          {retrySuccessMessage}
-        </div>
+        <AlertBanner tone="success" title={retrySuccessMessage} />
       )}
 
       {retryErrorMessage && (
-        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-          {retryErrorMessage}
-        </div>
+        <AlertBanner tone="danger" title={retryErrorMessage} />
       )}
 
-      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+      <SectionCard padding="none">
         <NotificationFailureQueueTable
           items={items}
           isLoading={isLoading}
@@ -160,27 +159,29 @@ export function NotificationFailureQueuePage() {
           retryingAttemptIds={retryingAttemptIds}
           onRetryAttempt={(item) => void handleRetryAttempt(item)}
         />
-      </div>
+      </SectionCard>
 
       {!isLoading && !error && total > PAGE_SIZE && (
-        <div className="mt-4 flex items-center justify-between text-sm text-gray-600">
-          <button
+        <div className="flex items-center justify-between text-sm text-ink-600">
+          <Button
             onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
             disabled={!hasPrev}
-            className="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 hover:bg-gray-100 disabled:cursor-not-allowed"
+            size="sm"
+            variant="ghost"
           >
             Poprzednia
-          </button>
-          <span className="text-xs text-gray-400">
+          </Button>
+          <span className="text-xs text-ink-400">
             Strona {currentPage} z {totalPages}
           </span>
-          <button
+          <Button
             onClick={() => setOffset(offset + PAGE_SIZE)}
             disabled={!hasNext}
-            className="rounded-lg px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-40 hover:bg-gray-100 disabled:cursor-not-allowed"
+            size="sm"
+            variant="ghost"
           >
             Następna
-          </button>
+          </Button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
Etap 4H: Polish notification operations UI screens to match design system established in phases 4B-4G. Improve visual consistency and operational copy across notification failure queue and internal attempts pages.

## Scope
**Modified files:**
- `apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.tsx`
- `apps/frontend/src/pages/Notifications/InternalNotificationAttemptsPage.test.tsx`
- `apps/frontend/src/pages/Notifications/NotificationFailureQueuePage.tsx`
- `apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx`
- `apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.tsx`
- `apps/frontend/src/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel.test.tsx`
- `apps/frontend/src/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.tsx`

## Key changes
- PageHeader, SectionCard wrappers for pages
- AlertBanner for success/error messages
- Badge component for outcome status indicators
- Button component for all actions (retry, pagination)
- Polish diacritics fixes and copy improvements
- Tailwind tokens: ink-*/brand-* replacing gray-*

## Preserved Logic
- Retry logic unchanged
- Operational status filter intact
- All 327 tests pass
- No API/DTO/backend changes

## Validation
✅ Type-check: PASS | ✅ Tests: 327/327 PASS | ✅ Build: PASS