### PR TITLE
fix(frontend): popraw polskie znaki w komunikatach notyfikacji

### DIFF
--- a/apps/frontend/src/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.test.tsx
+++ b/apps/frontend/src/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.test.tsx
@@ -33,11 +33,11 @@ describe('NotificationFailureHistoryPanel', () => {
     )
 
     expect(html).toContain('Ostatnie problemy notyfikacji')
-    expect(html).toContain('Blad wysylki')
-    expect(html).toContain('Blad konfiguracji')
+    expect(html).toContain('Błąd wysyłki')
+    expect(html).toContain('Błąd konfiguracji')
     expect(html).toContain('FAILED')
     expect(html).toContain('MISCONFIGURED')
-    expect(html).toContain('Szczegoly techniczne: Tryb: REAL | HTTP 500')
+    expect(html).toContain('Szczegóły techniczne: Tryb: REAL | HTTP 500')
   })
 
   it('renders empty state when no failures exist', () => {
@@ -45,6 +45,6 @@ describe('NotificationFailureHistoryPanel', () => {
       <NotificationFailureHistoryPanel items={[]} isLoading={false} error={null} />,
     )
 
-    expect(html).toContain('Brak zarejestrowanych problemow notyfikacji.')
+    expect(html).toContain('Brak zarejestrowanych problemów notyfikacji.')
   })
 })

--- a/apps/frontend/src/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.tsx
+++ b/apps/frontend/src/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel.tsx
@@ -19,9 +19,9 @@ function formatDateTime(value: string): string {
 
 function getIssueLabel(item: NotificationFailureHistoryItemDto): string {
   if (item.isConfigurationIssue) {
-    return 'Blad konfiguracji'
+    return 'Błąd konfiguracji'
   }
-  return 'Blad wysylki'
+  return 'Błąd wysyłki'
 }
 
 function getIssueTone(item: NotificationFailureHistoryItemDto): BadgeTone {
@@ -63,7 +63,7 @@ export function NotificationFailureHistoryPanel({
         </div>
       ) : items.length === 0 ? (
         <div className="rounded-panel border border-dashed border-line bg-ink-50 px-4 py-3 text-sm text-ink-600">
-          Brak zarejestrowanych problemow notyfikacji.
+          Brak zarejestrowanych problemów notyfikacji.
         </div>
       ) : (
         <div className="space-y-3">
@@ -92,7 +92,7 @@ export function NotificationFailureHistoryPanel({
 
               {item.technicalDetailsPreview && (
                 <p className="mt-3 rounded-panel border border-line bg-ink-50 px-3 py-2 text-sm text-ink-700">
-                  Szczegoly techniczne: {item.technicalDetailsPreview}
+                  Szczegóły techniczne: {item.technicalDetailsPreview}
                 </p>
               )}
             </article>

--- a/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.test.tsx
+++ b/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.test.tsx
@@ -120,7 +120,7 @@ describe('NotificationFailureQueueTable', () => {
       ],
     })
 
-    expect(html).toContain('Tego typu proby nie mozna ponowic')
+    expect(html).toContain('Tego typu próby nie można ponowić')
   })
 
   it('renders RETRY_LIMIT_REACHED as Limit wyczerpany', () => {

--- a/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx
+++ b/apps/frontend/src/components/NotificationFailureQueueTable/NotificationFailureQueueTable.tsx
@@ -46,10 +46,10 @@ function getChannelLabel(channel: GlobalNotificationFailureQueueItemDto['channel
 }
 
 const RETRY_BLOCKED_REASON_LABELS: Record<InternalNotificationRetryBlockedReasonCodeDto, string> = {
-  RETRY_LIMIT_REACHED: 'Limit ponowien osiagniety',
-  NOT_LATEST_IN_CHAIN: 'Istnieje nowsza proba',
-  ORIGIN_NOT_RETRYABLE: 'Tego typu proby nie mozna ponowic',
-  OUTCOME_NOT_RETRYABLE: 'Ten wynik nie kwalifikuje sie do ponowienia',
+  RETRY_LIMIT_REACHED: 'Limit ponowień osiągnięty',
+  NOT_LATEST_IN_CHAIN: 'Istnieje nowsza próba',
+  ORIGIN_NOT_RETRYABLE: 'Tego typu próby nie można ponowić',
+  OUTCOME_NOT_RETRYABLE: 'Ten wynik nie kwalifikuje się do ponowienia',
 }
 
 function getRetryBlockedReasonLabel(


### PR DESCRIPTION
## Summary
- Fix remaining Polish diacritics in notification failure history and retry blocked reason labels.
- Keep retry logic and notification mappings unchanged.

## Scope
- Frontend-only copy fix.
- No backend changes.
- No DTO changes.
- No API service changes.
- No routing changes.
- No retry logic changes.
- No filter/query param changes.

## Preserved logic
- canRetry unchanged.
- retryBlockedReasonCode keys unchanged.
- Retry endpoint unchanged.
- Outcome/status mapping unchanged.
- Filters/query params unchanged.
- API calls unchanged.

## Validation
- npm run type-check --workspace apps/frontend — PASS
- npm run test --workspace apps/frontend — PASS, 327/327
- npm run build --workspace apps/frontend — PASS

## Manual QA focus
- Notification failure history shows: Błąd wysyłki / Błąd konfiguracji.
- Technical details label shows: Szczegóły techniczne.
- Retry blocked labels show correct Polish diacritics.