### PR TITLE
test(seed): add QA fixtures for porting edge cases (etap 5A)

### DIFF
--- a/apps/backend/prisma/__tests__/seed.qa-porting-fixtures.test.ts
+++ b/apps/backend/prisma/__tests__/seed.qa-porting-fixtures.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import {
+  COMMUNICATION_TEMPLATE_SEED_DATA,
+  QA_ETAP5A_DRAFT_SMS_TEMPLATE_FIXTURE,
+  QA_ETAP5A_LONG_DATA_CLIENT,
+  QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT,
+  QA_ETAP5A_PORTING_FIXTURES,
+} from '../seed'
+
+describe('Etap 5A QA porting seed fixtures', () => {
+  it('exposes the six new QA case numbers required by audit issue #82', () => {
+    const caseNumbers = QA_ETAP5A_PORTING_FIXTURES.map((fx) => fx.caseNumber)
+    expect(caseNumbers).toEqual([
+      'FNP-SEED-DRAFT-001',
+      'FNP-SEED-ERROR-001',
+      'FNP-SEED-LONG-DATA-001',
+      'FNP-SEED-NO-ASSIGNEE-001',
+      'FNP-SEED-NO-DATE-001',
+      'FNP-SEED-NOTIFICATION-FAILED-001',
+    ])
+  })
+
+  it('uses unique primaryNumber and requestDocumentNumber across QA fixtures', () => {
+    const numbers = QA_ETAP5A_PORTING_FIXTURES.map((fx) => fx.primaryNumber)
+    const docs = QA_ETAP5A_PORTING_FIXTURES.map((fx) => fx.requestDocumentNumber)
+    expect(new Set(numbers).size).toBe(numbers.length)
+    expect(new Set(docs).size).toBe(docs.length)
+  })
+
+  it('marks DRAFT fixture with statusInternal=DRAFT and no assignee', () => {
+    const fx = QA_ETAP5A_PORTING_FIXTURES.find(
+      (f) => f.caseNumber === 'FNP-SEED-DRAFT-001',
+    )
+    expect(fx?.statusInternal).toBe('DRAFT')
+    expect(fx?.assigneeEmail).toBeNull()
+    expect(fx?.confirmedPortDate).toBeNull()
+  })
+
+  it('marks ERROR fixture with rejectionCode and rejectionReason', () => {
+    const fx = QA_ETAP5A_PORTING_FIXTURES.find(
+      (f) => f.caseNumber === 'FNP-SEED-ERROR-001',
+    )
+    expect(fx?.statusInternal).toBe('ERROR')
+    expect(fx?.rejectionCode).toBe('E06_REJECTED')
+    expect(fx?.rejectionReason).toContain('PLI CBD')
+  })
+
+  it('routes LONG-DATA fixture to dedicated long client with overflow-friendly values', () => {
+    const fx = QA_ETAP5A_PORTING_FIXTURES.find(
+      (f) => f.caseNumber === 'FNP-SEED-LONG-DATA-001',
+    )
+    expect(fx?.useLongClient).toBe(true)
+    expect(QA_ETAP5A_LONG_DATA_CLIENT.email.length).toBeGreaterThan(60)
+    expect(QA_ETAP5A_LONG_DATA_CLIENT.firstName).toContain('-')
+    expect(QA_ETAP5A_LONG_DATA_CLIENT.lastName.split('-').length).toBeGreaterThanOrEqual(3)
+    expect(QA_ETAP5A_LONG_DATA_CLIENT.addressStreet.length).toBeGreaterThan(40)
+  })
+
+  it('NO-ASSIGNEE fixture has confirmedPortDate but no assignee (pure missing-BOK case)', () => {
+    const fx = QA_ETAP5A_PORTING_FIXTURES.find(
+      (f) => f.caseNumber === 'FNP-SEED-NO-ASSIGNEE-001',
+    )
+    expect(fx?.assigneeEmail).toBeNull()
+    expect(fx?.confirmedPortDate).not.toBeNull()
+  })
+
+  it('NO-DATE fixture resolves BOK assignee via email lookup, not hardcoded UUID', () => {
+    const fx = QA_ETAP5A_PORTING_FIXTURES.find(
+      (f) => f.caseNumber === 'FNP-SEED-NO-DATE-001',
+    )
+    expect(fx?.assigneeEmail).toBe('bok@np-manager.local')
+    expect(fx?.confirmedPortDate).toBeNull()
+    expect(fx?.requestedPortDate).toBe('2026-05-20T00:00:00.000Z')
+  })
+
+  it('exposes the QA notification failure attempt fixture with required ID and metadata', () => {
+    expect(QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.id).toBe(
+      '00000000-0000-4000-8000-000000000753',
+    )
+    expect(QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.requestCaseNumber).toBe(
+      'FNP-SEED-NOTIFICATION-FAILED-001',
+    )
+    expect(QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.outcome).toBe('FAILED')
+    expect(QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.failureKind).toBe('DELIVERY')
+    expect(QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.errorCode).toBe('SMTP_TIMEOUT')
+  })
+
+  it('exposes a draft-only SMS communication template fixture without altering runtime length', () => {
+    expect(QA_ETAP5A_DRAFT_SMS_TEMPLATE_FIXTURE.channel).toBe('SMS')
+    expect(QA_ETAP5A_DRAFT_SMS_TEMPLATE_FIXTURE.status).toBe('DRAFT')
+    expect(QA_ETAP5A_DRAFT_SMS_TEMPLATE_FIXTURE.code).toBe('REQUEST_RECEIVED')
+    expect(COMMUNICATION_TEMPLATE_SEED_DATA).toHaveLength(4)
+    expect(
+      COMMUNICATION_TEMPLATE_SEED_DATA.some(
+        (t) => t.templateId === QA_ETAP5A_DRAFT_SMS_TEMPLATE_FIXTURE.templateId,
+      ),
+    ).toBe(false)
+  })
+})

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -165,6 +165,167 @@ export const QA_NOTIFICATION_FAILURE_QUEUE_SEED_FIXTURES = [
 ] as const
 
 // ============================================================
+// ETAP 5A — fixture'y QA: dodatkowe sprawy do scenariuszy edge-case
+// (audyt issue #82). Trzymane oddzielnie od istniejących fixture'ów,
+// żeby nie psuć asercji length === 4 dla COMMUNICATION_TEMPLATE_SEED_DATA.
+// ============================================================
+
+export type Etap5aPortingFixture = {
+  caseNumber: string
+  statusInternal:
+    | 'DRAFT'
+    | 'SUBMITTED'
+    | 'PENDING_DONOR'
+    | 'CONFIRMED'
+    | 'REJECTED'
+    | 'CANCELLED'
+    | 'PORTED'
+    | 'ERROR'
+  donorRouting: 'ORANGE' | 'PLAY' | 'TMOBILE'
+  primaryNumber: string
+  requestDocumentNumber: string
+  confirmedPortDate: string | null
+  requestedPortDate?: string
+  assigneeEmail: string | null
+  useLongClient: boolean
+  rejectionCode: string | null
+  rejectionReason: string | null
+  internalNotes: string
+}
+
+export const QA_ETAP5A_LONG_DATA_CLIENT = {
+  pesel: '85060512345',
+  firstName: 'Bartłomiej-Konstanty',
+  lastName: 'Wiśniewski-Kowalczyk-Dąbrowski',
+  email:
+    'bartlomiej.konstanty.wisniewski-kowalczyk@bardzo-dluga-nazwa-domeny.example.com',
+  phoneContact: '600700800',
+  addressStreet: 'ul. Aleja Bardzo Długich Nazw Ulic z Numerem 1234/5678',
+  addressCity: 'Warszawa-Centrum-Śródmieście',
+  addressZip: '00-001',
+} as const
+
+export const QA_ETAP5A_PORTING_FIXTURES: readonly Etap5aPortingFixture[] = [
+  {
+    caseNumber: 'FNP-SEED-DRAFT-001',
+    statusInternal: 'DRAFT',
+    donorRouting: 'ORANGE',
+    primaryNumber: '221234574',
+    requestDocumentNumber: 'DOC-SEED-DRF-001',
+    confirmedPortDate: null,
+    assigneeEmail: null,
+    useLongClient: false,
+    rejectionCode: null,
+    rejectionReason: null,
+    internalNotes: 'Seed QA: status DRAFT do testu listy/detalu.',
+  },
+  {
+    caseNumber: 'FNP-SEED-ERROR-001',
+    statusInternal: 'ERROR',
+    donorRouting: 'PLAY',
+    primaryNumber: '221234575',
+    requestDocumentNumber: 'DOC-SEED-ERR-001',
+    confirmedPortDate: null,
+    assigneeEmail: null,
+    useLongClient: false,
+    rejectionCode: 'E06_REJECTED',
+    rejectionReason:
+      'Seed QA: PLI CBD odrzuciło wniosek — brak zgodności danych abonenta.',
+    internalNotes: 'Seed QA: status ERROR + attention strip + komunikat odrzucenia.',
+  },
+  {
+    caseNumber: 'FNP-SEED-LONG-DATA-001',
+    statusInternal: 'SUBMITTED',
+    donorRouting: 'ORANGE',
+    primaryNumber: '221234576',
+    requestDocumentNumber: 'DOC-SEED-LNG-001',
+    confirmedPortDate: null,
+    assigneeEmail: null,
+    useLongClient: true,
+    rejectionCode: null,
+    rejectionReason: null,
+    internalNotes: 'Seed QA: long text / overflow / responsive.',
+  },
+  {
+    caseNumber: 'FNP-SEED-NO-ASSIGNEE-001',
+    statusInternal: 'SUBMITTED',
+    donorRouting: 'ORANGE',
+    primaryNumber: '221234577',
+    requestDocumentNumber: 'DOC-SEED-NOA-001',
+    confirmedPortDate: '2026-05-15T00:00:00.000Z',
+    assigneeEmail: null,
+    useLongClient: false,
+    rejectionCode: null,
+    rejectionReason: null,
+    internalNotes:
+      'Seed QA: brak BOK przy ustalonej dacie portowania (bez mieszania z brakiem daty).',
+  },
+  {
+    caseNumber: 'FNP-SEED-NO-DATE-001',
+    statusInternal: 'SUBMITTED',
+    donorRouting: 'ORANGE',
+    primaryNumber: '221234578',
+    requestDocumentNumber: 'DOC-SEED-NOD-001',
+    confirmedPortDate: null,
+    requestedPortDate: '2026-05-20T00:00:00.000Z',
+    assigneeEmail: 'bok@np-manager.local',
+    useLongClient: false,
+    rejectionCode: null,
+    rejectionReason: null,
+    internalNotes:
+      'Seed QA: brak confirmedPortDate przy istniejącym przypisaniu BOK (lookup po emailu).',
+  },
+  {
+    caseNumber: 'FNP-SEED-NOTIFICATION-FAILED-001',
+    statusInternal: 'SUBMITTED',
+    donorRouting: 'TMOBILE',
+    primaryNumber: '221234579',
+    requestDocumentNumber: 'DOC-SEED-NFF-001',
+    confirmedPortDate: null,
+    assigneeEmail: null,
+    useLongClient: false,
+    rejectionCode: null,
+    rejectionReason: null,
+    internalNotes:
+      'Seed QA: dedykowana sprawa do listy /notifications/failures.',
+  },
+]
+
+export const QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT = {
+  id: '00000000-0000-4000-8000-000000000753',
+  requestCaseNumber: 'FNP-SEED-NOTIFICATION-FAILED-001',
+  eventCode: 'STATUS_CHANGED',
+  eventLabel: 'Zmiana statusu sprawy',
+  attemptOrigin: 'PRIMARY',
+  channel: 'EMAIL',
+  recipient: 'bok.qa@np-manager.local',
+  mode: 'REAL',
+  outcome: 'FAILED',
+  failureKind: 'DELIVERY',
+  retryCount: 2,
+  isLatestForChain: true,
+  errorCode: 'SMTP_TIMEOUT',
+  errorMessage:
+    'Seed QA: symulowany timeout SMTP — 3 nieudane próby dostarczenia.',
+  createdAt: '2026-04-12T08:10:00.000Z',
+} as const
+
+export const QA_ETAP5A_DRAFT_SMS_TEMPLATE_FIXTURE = {
+  templateId: '00000000-0000-4000-8000-000000000805',
+  versionId: '00000000-0000-4000-9000-000000000805',
+  code: 'REQUEST_RECEIVED',
+  channel: 'SMS',
+  versionNumber: 1,
+  status: 'DRAFT',
+  name: 'Potwierdzenie przyjęcia sprawy (SMS, draft QA)',
+  description:
+    'QA fixture — szablon SMS bez opublikowanej wersji do testu CommunicationTemplatesAdmin (publishedVersionId = null).',
+  subjectTemplate: 'Sprawa {{caseNumber}} - potwierdzenie przyjęcia (SMS)',
+  bodyTemplate:
+    'Potwierdzamy przyjęcie Pana/i sprawy {{caseNumber}}. Operator biorca: {{recipientOperatorName}}. Kontakt: {{contactPhone}}.',
+} as const
+
+// ============================================================
 // DANE STATUSÓW
 // ============================================================
 
@@ -1666,6 +1827,221 @@ export async function seedMain() {
 
   console.info(
     'Dodano klienta QA oraz 6 spraw portowania (aktywna + zakonczona po E18 + READY_TO_PORT/E18 + komunikacja create-draft + komunikacja duplicate-block + komunikacja failed-retry) + 2 rekordy QA kolejki bledow notyfikacji',
+  )
+
+  // ----------------------------------------------------------
+  // 6b. ETAP 5A — fixture'y QA dla scenariuszy edge-case (issue #82)
+  // ----------------------------------------------------------
+  console.info('Tworzenie fixture\'ów Etap 5A...')
+
+  const playOperator = await prisma.operator.findUniqueOrThrow({
+    where: { routingNumber: 'PLAY' },
+  })
+  const tmobileOperator = await prisma.operator.findUniqueOrThrow({
+    where: { routingNumber: 'TMOBILE' },
+  })
+
+  const donorOperatorByRouting: Record<
+    Etap5aPortingFixture['donorRouting'],
+    { id: string; routingNumber: string }
+  > = {
+    ORANGE: donorOperator,
+    PLAY: playOperator,
+    TMOBILE: tmobileOperator,
+  }
+
+  const longDataClient = await prisma.client.upsert({
+    where: { pesel: QA_ETAP5A_LONG_DATA_CLIENT.pesel },
+    update: {
+      clientType: 'INDIVIDUAL',
+      firstName: QA_ETAP5A_LONG_DATA_CLIENT.firstName,
+      lastName: QA_ETAP5A_LONG_DATA_CLIENT.lastName,
+      pesel: QA_ETAP5A_LONG_DATA_CLIENT.pesel,
+      email: QA_ETAP5A_LONG_DATA_CLIENT.email,
+      phoneContact: QA_ETAP5A_LONG_DATA_CLIENT.phoneContact,
+      addressStreet: QA_ETAP5A_LONG_DATA_CLIENT.addressStreet,
+      addressCity: QA_ETAP5A_LONG_DATA_CLIENT.addressCity,
+      addressZip: QA_ETAP5A_LONG_DATA_CLIENT.addressZip,
+      createdById: adminUser.id,
+    },
+    create: {
+      clientType: 'INDIVIDUAL',
+      firstName: QA_ETAP5A_LONG_DATA_CLIENT.firstName,
+      lastName: QA_ETAP5A_LONG_DATA_CLIENT.lastName,
+      pesel: QA_ETAP5A_LONG_DATA_CLIENT.pesel,
+      email: QA_ETAP5A_LONG_DATA_CLIENT.email,
+      phoneContact: QA_ETAP5A_LONG_DATA_CLIENT.phoneContact,
+      addressStreet: QA_ETAP5A_LONG_DATA_CLIENT.addressStreet,
+      addressCity: QA_ETAP5A_LONG_DATA_CLIENT.addressCity,
+      addressZip: QA_ETAP5A_LONG_DATA_CLIENT.addressZip,
+      createdById: adminUser.id,
+    },
+  })
+
+  const requestIdByCaseNumberEtap5a = new Map<string, string>()
+  const longCorrespondenceAddress = `${QA_ETAP5A_LONG_DATA_CLIENT.addressStreet}, ${QA_ETAP5A_LONG_DATA_CLIENT.addressZip} ${QA_ETAP5A_LONG_DATA_CLIENT.addressCity}`
+
+  for (const fx of QA_ETAP5A_PORTING_FIXTURES) {
+    const donor = donorOperatorByRouting[fx.donorRouting]
+    const useLong = fx.useLongClient
+    const clientForCase = useLong ? longDataClient : qaClient
+    const subscriberFirstName = useLong
+      ? QA_ETAP5A_LONG_DATA_CLIENT.firstName
+      : 'Jan'
+    const subscriberLastName = useLong
+      ? QA_ETAP5A_LONG_DATA_CLIENT.lastName
+      : 'Testowy'
+    const correspondenceAddress = useLong
+      ? longCorrespondenceAddress
+      : 'ul. Testowa 10/5, 00-001 Warszawa'
+    const identityValue = useLong
+      ? QA_ETAP5A_LONG_DATA_CLIENT.pesel
+      : '90010112345'
+    const assignedUserId = fx.assigneeEmail
+      ? (
+          await prisma.user.findUniqueOrThrow({
+            where: { email: fx.assigneeEmail },
+          })
+        ).id
+      : null
+    const confirmedPortDate = fx.confirmedPortDate
+      ? new Date(fx.confirmedPortDate)
+      : null
+    const requestedPortDate = fx.requestedPortDate
+      ? new Date(fx.requestedPortDate)
+      : new Date('2026-05-01T00:00:00.000Z')
+
+    const sharedData = {
+      clientId: clientForCase.id,
+      numberType: 'FIXED_LINE' as const,
+      numberRangeKind: 'SINGLE' as const,
+      primaryNumber: fx.primaryNumber,
+      requestDocumentNumber: fx.requestDocumentNumber,
+      donorOperatorId: donor.id,
+      recipientOperatorId: recipientOperator.id,
+      donorRoutingNumber: donor.routingNumber,
+      recipientRoutingNumber: recipientOperator.routingNumber,
+      requestRegisteredAt: new Date('2026-04-10T08:00:00.000Z'),
+      requestedPortDate,
+      requestedPortTime: '00:00',
+      confirmedPortDate,
+      portingMode: 'DAY' as const,
+      statusInternal: fx.statusInternal,
+      pliCbdExportStatus: 'NOT_EXPORTED' as const,
+      rejectionCode: fx.rejectionCode,
+      rejectionReason: fx.rejectionReason,
+      subscriberKind: 'INDIVIDUAL' as const,
+      subscriberFirstName,
+      subscriberLastName,
+      identityType: 'PESEL' as const,
+      identityValue,
+      correspondenceAddress,
+      hasPowerOfAttorney: false,
+      linkedWholesaleServiceOnRecipientSide: false,
+      contactChannel: 'EMAIL' as const,
+      internalNotes: fx.internalNotes,
+      assignedUserId,
+      commercialOwnerUserId: null,
+    }
+
+    const result = await prisma.portingRequest.upsert({
+      where: { caseNumber: fx.caseNumber },
+      update: sharedData,
+      create: {
+        caseNumber: fx.caseNumber,
+        ...sharedData,
+        createdByUserId: adminUser.id,
+      },
+    })
+    requestIdByCaseNumberEtap5a.set(fx.caseNumber, result.id)
+  }
+
+  // Notification failure attempt — własny ID (delete + create dla idempotencji)
+  await prisma.internalNotificationDeliveryAttempt.deleteMany({
+    where: { id: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.id },
+  })
+  const etap5aNotifRequestId = requestIdByCaseNumberEtap5a.get(
+    QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.requestCaseNumber,
+  )
+  if (!etap5aNotifRequestId) {
+    throw new Error(
+      `Brak sprawy seed dla Etap5A notification attempt: ${QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.requestCaseNumber}`,
+    )
+  }
+  await prisma.internalNotificationDeliveryAttempt.create({
+    data: {
+      id: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.id,
+      requestId: etap5aNotifRequestId,
+      eventCode: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.eventCode,
+      eventLabel: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.eventLabel,
+      attemptOrigin: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.attemptOrigin,
+      channel: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.channel,
+      recipient: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.recipient,
+      mode: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.mode,
+      outcome: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.outcome,
+      failureKind: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.failureKind,
+      retryCount: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.retryCount,
+      isLatestForChain: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.isLatestForChain,
+      errorCode: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.errorCode,
+      errorMessage: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.errorMessage,
+      triggeredByUserId: adminUser.id,
+      createdAt: new Date(QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.createdAt),
+    },
+  })
+
+  // Draft-only SMS template — separate od COMMUNICATION_TEMPLATE_SEED_DATA (length === 4 zachowane)
+  const draftTpl = QA_ETAP5A_DRAFT_SMS_TEMPLATE_FIXTURE
+  const draftFamily = await prisma.communicationTemplate.upsert({
+    where: { code_channel: { code: draftTpl.code, channel: draftTpl.channel } },
+    update: {
+      name: draftTpl.name,
+      description: draftTpl.description,
+      createdByUserId: adminUser.id,
+      updatedByUserId: adminUser.id,
+    },
+    create: {
+      id: draftTpl.templateId,
+      code: draftTpl.code,
+      channel: draftTpl.channel,
+      name: draftTpl.name,
+      description: draftTpl.description,
+      createdByUserId: adminUser.id,
+      updatedByUserId: adminUser.id,
+    },
+  })
+  const existingDraftVersion = await prisma.communicationTemplateVersion.findFirst({
+    where: { templateId: draftFamily.id, versionNumber: draftTpl.versionNumber },
+    select: { id: true },
+  })
+  if (existingDraftVersion) {
+    await prisma.communicationTemplateVersion.update({
+      where: { id: existingDraftVersion.id },
+      data: {
+        status: draftTpl.status,
+        subjectTemplate: draftTpl.subjectTemplate,
+        bodyTemplate: draftTpl.bodyTemplate,
+        publishedAt: null,
+        publishedByUserId: null,
+        createdByUserId: adminUser.id,
+        updatedByUserId: adminUser.id,
+      },
+    })
+  } else {
+    await prisma.communicationTemplateVersion.create({
+      data: {
+        id: draftTpl.versionId,
+        templateId: draftFamily.id,
+        versionNumber: draftTpl.versionNumber,
+        status: draftTpl.status,
+        subjectTemplate: draftTpl.subjectTemplate,
+        bodyTemplate: draftTpl.bodyTemplate,
+        createdByUserId: adminUser.id,
+        updatedByUserId: adminUser.id,
+      },
+    })
+  }
+  console.info(
+    '   ✓ Etap 5A: 6 spraw QA + notification attempt + draft SMS template gotowe',
   )
 
   // ----------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add deterministic QA seed fixtures for porting workflow edge cases per audit issue #82.
- 6 new PortingRequest fixtures covering DRAFT, ERROR, long-data, no-assignee, no-date, and notification-failed scenarios.
- 1 dedicated long-data client with overflow-friendly values.
- 1 QA notification failure attempt for /notifications/failures testing.
- 1 draft-only SMS communication template (REQUEST_RECEIVED + SMS / DRAFT) without published version.
- Full test coverage (9 assertions) validating exported constants and fixture properties.

## Scope
- Backend Prisma seed/test-data only.
- No schema/migration changes.
- No API/DTO changes.
- No workflow changes.
- No frontend changes.

## Added fixtures
- `FNP-SEED-DRAFT-001` — DRAFT status for list/detail
- `FNP-SEED-ERROR-001` — ERROR + E06_REJECTED rejection code/reason
- `FNP-SEED-LONG-DATA-001` — Long name/email/address for overflow testing
- `FNP-SEED-NO-ASSIGNEE-001` — SUBMITTED + confirmedPortDate, no BOK
- `FNP-SEED-NO-DATE-001` — SUBMITTED + BOK (email lookup), no confirmedPortDate
- `FNP-SEED-NOTIFICATION-FAILED-001` — SUBMITTED case for failure queue
- QA draft SMS template: REQUEST_RECEIVED + SMS / DRAFT (no published version)

## Idempotency
All fixtures use upsert-based seeding:
- Client upsert by PESEL.
- PortingRequest upsert by caseNumber.
- BOK assignment resolves user by email (\`bok@np-manager.local\`) — no hardcoded UUID.
- Operators resolve by routingNumber.
- Notification failure attempt: deleteMany(id) + create.
- SMS template: upsert by code/channel + conditional version create/update.

## Preserved behavior
- COMMUNICATION_TEMPLATE_SEED_DATA length remains 4 (existing runtime assertion unchanged).
- All existing FNP-SEED-* fixtures and QA_NOTIFICATION_FAILURE_QUEUE_SEED_FIXTURES untouched.
- No model/schema modifications.

## Validation
- \`npx vitest run prisma/__tests__\` → PASS: 3 files / 14 tests
- \`npx tsc --noEmit\` → PASS
- \`npm run build\` → PASS

## Seed runtime
Not executed (local DATABASE_URL does not point to working Postgres instance).
Recommend running seed twice in local environment to verify idempotency before/after merge.

## Manual/runtime QA focus
- [ ] Run \`npm run db:seed\` twice; confirm no errors.
- [ ] Verify all 6 new case numbers appear in requests list.
- [ ] Open DRAFT and ERROR detail pages; confirm no crashes.
- [ ] Confirm long-data case layout does not break/overflow.
- [ ] Verify notification-failed fixture in /notifications/failures queue.
- [ ] Confirm REQUEST_RECEIVED + SMS template has no published version in CommunicationTemplatesAdmin.

---
Closes/relates to issue #82.