### PR TITLE
chore(claude): Etap 5B QA — local permissions + smoke report

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,20 @@
       "Bash(git commit -m ' *)",
       "Bash(npm install *)",
       "Bash(npx vitest *)",
-      "Bash(npx tsc *)"
+      "Bash(npx tsc *)",
+      "Bash(git fetch *)",
+      "Bash(npm run *)",
+      "Read(//d/Projekt/np-manager/apps/backend/**)",
+      "Read(//d/Projekt/np-manager/**)",
+      "Bash(DATABASE_URL=\"postgresql://np_user:np_password@localhost:5432/np_manager\" npx tsx prisma/seed.ts)",
+      "Bash(PGPASSWORD=np_password psql -h localhost -U np_user -d np_manager -c \"SELECT \\\\\"caseNumber\\\\\", status, \\\\\"assignedUserId\\\\\", \\\\\"confirmedPortDate\\\\\", \\\\\"rejectionCode\\\\\" FROM \\\\\"PortingCase\\\\\" WHERE \\\\\"caseNumber\\\\\" LIKE 'FNP-SEED-%' ORDER BY \\\\\"caseNumber\\\\\";\")",
+      "Bash(cp /tmp/check.ts ./check-fixtures.ts)",
+      "Bash(DATABASE_URL=\"postgresql://np_user:np_password@localhost:5432/np_manager\" npx tsx check-fixtures.ts)",
+      "Bash(DATABASE_URL=\"postgresql://np_user:np_password@localhost:5432/np_manager\" npx vitest run prisma/__tests__ --reporter=basic)",
+      "Bash(DATABASE_URL=\"postgresql://np_user:np_password@localhost:5432/np_manager\" npx vitest run prisma/__tests__)",
+      "Bash(wait)",
+      "Bash(echo \"EXIT=$?\")",
+      "Bash(git commit -m 'chore\\(claude\\): expand local permission allowlist for Etap 5B QA *)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Etap 5B runtime smoke QA fixtures z PR #84 po merge na main. **Code not touched** — tylko zmiana w `.claude/settings.local.json` (lokalny allowlist permissions użyty podczas QA).

## QA — Status: PASS (data + build/test layer)

Worktree HEAD = origin/main HEAD (commit `614a08e`).

**db:seed x2:** PASS (idempotent).

**Tests / build:**
- `apps/backend` prisma/__tests__: 15/15
- `apps/frontend` vitest: 327/327
- backend `tsc --noEmit`: PASS
- frontend `type-check`: PASS
- `npm run build`: PASS

**Per caseNumber (Prisma query verification):**
| caseNumber | Wynik |
|---|---|
| FNP-SEED-DRAFT-001 | DRAFT, no assignee, no date ✅ |
| FNP-SEED-ERROR-001 | ERROR, rejectionCode=E06_REJECTED ✅ |
| FNP-SEED-LONG-DATA-001 | long subscriber present ✅ |
| FNP-SEED-NO-ASSIGNEE-001 | confirmedPortDate=2026-05-15, no assignee ✅ |
| FNP-SEED-NO-DATE-001 | no date, BOK assigned ✅ |
| FNP-SEED-NOTIF-FAILED-001 | 1 attempt, id ends `...753`, FAILED/SMTP_TIMEOUT ✅ |

**Communication template REQUEST_RECEIVED/SMS:** 1 DRAFT version, no published ✅

## Not verified (browser required)
- RequestsPage rendering / search / "Bez daty" filter
- Detail screens layout (LONG-DATA overflow)
- /notifications/failures retry UI
- Admin templates UI for family without published version

## Recommendation
Merge-ready od strony danych/typów/testów. Manual UI smoke (~10 min) zalecany przed Etap 5C dla LONG-DATA layout i notifications/failures retry.

## Test plan
- [ ] Manual UI smoke for 6 fixtures
- [ ] Verify Bez daty filter on FNP-SEED-NO-DATE-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)