### PR TITLE
refactor(frontend): RequestDetail jako ekran roboczy BOK (etap 5C)

### DIFF
--- a/apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx
@@ -72,6 +72,7 @@ const BASE_REQUEST = {
     role: 'SALES' as const,
   },
   notificationHealth: HEALTH_OK,
+  contactChannel: 'EMAIL' as const,
 }
 
 describe('RequestCommandCenter', () => {
@@ -95,7 +96,7 @@ describe('RequestCommandCenter', () => {
     expect(screen.getByText('NP-2026-0007')).toBeDefined()
     expect(screen.getAllByText('Acme Sp. z o.o.').length).toBeGreaterThan(0)
     expect(screen.getByText('500123456')).toBeDefined()
-    expect(screen.getByText(/Operator Dawca/)).toBeDefined()
+    expect(screen.getAllByText(/Operator Dawca/).length).toBeGreaterThan(0)
     expect(screen.getByText('Anna BOK')).toBeDefined()
     expect(screen.getByText('Jan Sales')).toBeDefined()
   })

--- a/apps/frontend/src/pages/Requests/RequestCommandCenter.tsx
+++ b/apps/frontend/src/pages/Requests/RequestCommandCenter.tsx
@@ -1,8 +1,9 @@
-import { AlertBanner, Badge, Button, ButtonLink, DataField, SectionCard, type BadgeTone, cx } from '@/components/ui'
+import { AlertBanner, Badge, Button, ButtonLink, DataField, type BadgeTone, cx } from '@/components/ui'
 import { ROUTES } from '@/constants/routes'
 import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
 import type { PortingUrgency } from '@/lib/portingUrgency'
 import {
+  CONTACT_CHANNEL_LABELS,
   PORTING_MODE_LABELS,
   type NotificationHealthDiagnosticsDto,
   type PortingRequestDetailDto,
@@ -25,6 +26,7 @@ type CommandCenterRequest = Pick<
   | 'assignedUser'
   | 'commercialOwner'
   | 'notificationHealth'
+  | 'contactChannel'
 >
 
 interface RequestCaseHeroProps {
@@ -47,11 +49,6 @@ interface RequestAttentionStripProps {
   onScrollToNotifications: () => void
   onScrollToPortingDates: () => void
   onScrollToStatusActions: () => void
-}
-
-interface RequestMetaGridProps {
-  request: CommandCenterRequest
-  urgency: PortingUrgency
 }
 
 type AttentionTone = 'warning' | 'danger' | 'neutral'
@@ -191,6 +188,21 @@ function OwnerValue({
   )
 }
 
+function CaseGroup({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="min-w-0 rounded-ui border border-line bg-ink-50/40 p-4">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-ink-500">{title}</p>
+      <dl className="mt-3 space-y-3">{children}</dl>
+    </div>
+  )
+}
+
 export function RequestCaseHero({
   copyLinkDone,
   request,
@@ -200,6 +212,10 @@ export function RequestCaseHero({
 }: RequestCaseHeroProps) {
   const statusMeta = getPortingStatusMeta(request.statusInternal)
   const healthBadge = getNotificationHealthBadge(request.notificationHealth)
+  const donorToRecipient = `${request.donorOperator.name} -> ${request.recipientOperator.name}`
+  const donorDateTime = request.donorAssignedPortDate
+    ? `${request.donorAssignedPortDate}${request.donorAssignedPortTime ? ` ${request.donorAssignedPortTime}` : ''}`
+    : null
 
   return (
     <section className="min-w-0 overflow-hidden rounded-panel border border-line bg-surface shadow-sm">
@@ -220,90 +236,126 @@ export function RequestCaseHero({
         </div>
       </div>
 
-      <div className="grid min-w-0 gap-0 xl:grid-cols-[minmax(0,1.45fr)_minmax(360px,0.75fr)]">
-        <div className="min-w-0 px-5 py-5">
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge tone={getStatusTone(statusMeta.tone)} leadingDot>
-              {statusMeta.label}
-            </Badge>
-            <Badge tone="brand">{PORTING_MODE_LABELS[request.portingMode]}</Badge>
-            <Badge
-              tone={urgency.tone}
-              className={urgency.emphasized ? 'ring-2' : undefined}
-              aria-label={`Pilnosc sprawy: ${urgency.label}`}
-            >
-              Pilnosc: {urgency.label}
-            </Badge>
-            <Badge tone={healthBadge.tone}>Notyfikacje: {healthBadge.label}</Badge>
-          </div>
-
-          <div className="mt-4 max-w-4xl min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-ink-400">
-              Sprawa
-            </p>
-            <h1 className="mt-1 break-words font-mono text-3xl font-semibold tracking-tight text-ink-950 md:text-4xl">
-              {request.caseNumber}
-            </h1>
-            <p className="mt-3 break-words text-2xl font-semibold tracking-tight text-ink-900">
-              {request.client.displayName}
-            </p>
-            <p className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-sm font-medium text-ink-500">
-              <span className="min-w-0 break-all font-mono text-ink-800">{request.numberDisplay}</span>
-              <span className="min-w-0 break-words">{request.subscriberDisplayName}</span>
-              <span className="min-w-0 break-words">
-                {request.donorOperator.name} {'->'} {request.recipientOperator.name}
-              </span>
-            </p>
-          </div>
+      <div className="min-w-0 border-b border-line px-5 py-5">
+        <div className="flex flex-wrap items-center gap-2">
+          <Badge tone={getStatusTone(statusMeta.tone)} leadingDot>
+            {statusMeta.label}
+          </Badge>
+          <Badge tone="brand">{PORTING_MODE_LABELS[request.portingMode]}</Badge>
+          <Badge
+            tone={urgency.tone}
+            className={urgency.emphasized ? 'ring-2' : undefined}
+            aria-label={`Pilnosc sprawy: ${urgency.label}`}
+          >
+            Pilnosc: {urgency.label}
+          </Badge>
+          <Badge tone={healthBadge.tone}>Notyfikacje: {healthBadge.label}</Badge>
         </div>
 
-        <div className="border-t border-line bg-ink-50/70 px-5 py-5 xl:border-l xl:border-t-0">
-          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-ink-400">
-            Sygnały operacyjne
+        <div className="mt-4 max-w-4xl min-w-0">
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-ink-400">Sprawa</p>
+          <h1 className="mt-1 break-words font-mono text-3xl font-semibold tracking-tight text-ink-950 md:text-4xl">
+            {request.caseNumber}
+          </h1>
+          <p className="mt-3 break-words text-2xl font-semibold tracking-tight text-ink-900">
+            {request.client.displayName}
           </p>
-          <dl className="mt-4 divide-y divide-line">
-            <DataField
-              className="pb-3"
-              label="Data przeniesienia"
-              value={request.confirmedPortDate ?? request.donorAssignedPortDate}
-              emptyText="Brak daty"
-              mono
-              variant="compact"
-            />
-            <DataField
-              className="py-3"
-              label="Przypisanie BOK"
-              value={
-                <OwnerValue
-                  name={request.assignedUser?.displayName}
-                  email={request.assignedUser?.email}
-                  fallback="Nieprzypisana"
-                  warning
-                />
-              }
-              variant="compact"
-            />
-            <DataField
-              className="py-3"
-              label="Opiekun handlowy"
-              value={
-                <OwnerValue
-                  name={request.commercialOwner?.displayName}
-                  email={request.commercialOwner?.email}
-                  fallback="Brak opiekuna"
-                  warning
-                />
-              }
-              variant="compact"
-            />
-            <DataField
-              className="pt-3"
-              label="Status procesu"
-              value={statusMeta.label}
-              variant="compact"
-            />
-          </dl>
         </div>
+      </div>
+
+      <div className="grid min-w-0 gap-4 px-5 py-5 md:grid-cols-2 xl:grid-cols-4">
+        <CaseGroup title="Klient i kontakt">
+          <DataField
+            label="Klient"
+            value={<span className="break-words">{request.client.displayName}</span>}
+            variant="compact"
+          />
+          <DataField
+            label="Abonent"
+            value={<span className="break-words">{request.subscriberDisplayName}</span>}
+            variant="compact"
+          />
+          <DataField
+            label="Kanal kontaktu"
+            value={CONTACT_CHANNEL_LABELS[request.contactChannel]}
+            variant="compact"
+          />
+        </CaseGroup>
+
+        <CaseGroup title="Portowanie">
+          <DataField
+            label="Numer / zakres"
+            value={<span className="break-all">{request.numberDisplay}</span>}
+            mono
+            variant="compact"
+          />
+          <DataField
+            label="Operator dawca -> biorca"
+            value={<span className="break-words">{donorToRecipient}</span>}
+            variant="compact"
+          />
+          <DataField
+            label="Tryb portowania"
+            value={PORTING_MODE_LABELS[request.portingMode]}
+            variant="compact"
+          />
+        </CaseGroup>
+
+        <CaseGroup title="Terminy">
+          <DataField
+            label="Wnioskowana"
+            value={request.requestedPortDate}
+            emptyText="Brak"
+            mono
+            variant="compact"
+          />
+          <DataField
+            label="Potwierdzona"
+            value={request.confirmedPortDate}
+            emptyText="Brak daty"
+            mono
+            variant="compact"
+          />
+          <DataField
+            label="Od dawcy"
+            value={donorDateTime}
+            emptyText="Brak"
+            mono
+            variant="compact"
+          />
+        </CaseGroup>
+
+        <CaseGroup title="Obsluga">
+          <DataField
+            label="BOK"
+            value={
+              <OwnerValue
+                name={request.assignedUser?.displayName}
+                email={request.assignedUser?.email}
+                fallback="Nieprzypisana"
+                warning
+              />
+            }
+            variant="compact"
+          />
+          <DataField
+            label="Opiekun handlowy"
+            value={
+              <OwnerValue
+                name={request.commercialOwner?.displayName}
+                email={request.commercialOwner?.email}
+                fallback="Brak opiekuna"
+                warning
+              />
+            }
+            variant="compact"
+          />
+          <DataField
+            label="Notyfikacje"
+            value={<Badge tone={healthBadge.tone}>{healthBadge.label}</Badge>}
+            variant="compact"
+          />
+        </CaseGroup>
       </div>
     </section>
   )
@@ -343,24 +395,39 @@ export function RequestAttentionStrip(props: RequestAttentionStripProps) {
   )
 }
 
-export function RequestMetaGrid({ request, urgency }: RequestMetaGridProps) {
+interface RequestStatusSnapshotProps {
+  request: Pick<
+    CommandCenterRequest,
+    'statusInternal' | 'confirmedPortDate' | 'donorAssignedPortDate' | 'donorAssignedPortTime' | 'notificationHealth'
+  >
+  urgency: PortingUrgency
+}
+
+export function RequestStatusSnapshot({ request, urgency }: RequestStatusSnapshotProps) {
   const statusMeta = getPortingStatusMeta(request.statusInternal)
   const healthBadge = getNotificationHealthBadge(request.notificationHealth)
+  const portDate =
+    request.confirmedPortDate ??
+    (request.donorAssignedPortDate
+      ? `${request.donorAssignedPortDate}${request.donorAssignedPortTime ? ` ${request.donorAssignedPortTime}` : ''}`
+      : null)
 
   return (
-    <SectionCard
-      title="Operacyjny skrót"
-      description="Najważniejsze dane do szybkiej oceny sprawy."
-      padding="md"
+    <section
+      aria-label="Snapshot operacyjny"
+      className="rounded-panel border border-line bg-surface p-4 shadow-sm"
     >
-      <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+      <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-ink-500">
+        Snapshot operacyjny
+      </p>
+      <dl className="mt-3 grid grid-cols-2 gap-3">
         <DataField
           label="Status"
-          value={statusMeta.label}
+          value={<Badge tone={getStatusTone(statusMeta.tone)}>{statusMeta.label}</Badge>}
           variant="compact"
         />
         <DataField
-          label="Pilność"
+          label="Pilnosc"
           value={
             <Badge tone={urgency.tone} className={urgency.emphasized ? 'ring-2' : undefined}>
               {urgency.label}
@@ -369,33 +436,10 @@ export function RequestMetaGrid({ request, urgency }: RequestMetaGridProps) {
           variant="compact"
         />
         <DataField
-          label="Potwierdzona data"
-          value={request.confirmedPortDate}
+          label="Data przeniesienia"
+          value={portDate}
           emptyText="Brak daty"
           mono
-          variant="compact"
-        />
-        <DataField
-          label="Data od dawcy"
-          value={
-            request.donorAssignedPortDate
-              ? `${request.donorAssignedPortDate}${request.donorAssignedPortTime ? ` ${request.donorAssignedPortTime}` : ''}`
-              : null
-          }
-          emptyText="Brak"
-          mono
-          variant="compact"
-        />
-        <DataField
-          label="BOK"
-          value={request.assignedUser?.displayName ?? null}
-          emptyText="Nieprzypisana"
-          variant="compact"
-        />
-        <DataField
-          label="Handlowy"
-          value={request.commercialOwner?.displayName ?? null}
-          emptyText="Brak opiekuna"
           variant="compact"
         />
         <DataField
@@ -403,14 +447,7 @@ export function RequestMetaGrid({ request, urgency }: RequestMetaGridProps) {
           value={<Badge tone={healthBadge.tone}>{healthBadge.label}</Badge>}
           variant="compact"
         />
-        <DataField
-          label="Operatorzy"
-          value={`${request.donorOperator.shortName || request.donorOperator.name} -> ${
-            request.recipientOperator.shortName || request.recipientOperator.name
-          }`}
-          variant="compact"
-        />
       </dl>
-    </SectionCard>
+    </section>
   )
 }

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -6,7 +6,7 @@ import { Bell, ChevronDown, FileText, Info, TriangleAlert, Zap } from 'lucide-re
 import { buildPath, ROUTES } from '@/constants/routes'
 import { useAuthStore } from '@/stores/auth.store'
 import { useSystemCapabilities } from '@/hooks/useSystemCapabilities'
-import { AppIcon, Badge, Button, type BadgeTone, cx } from '@/components/ui'
+import { AlertBanner, AppIcon, Badge, Button, type BadgeTone, cx } from '@/components/ui'
 import {
   assignPortingRequestToMe,
   cancelPortingCommunication,
@@ -1872,6 +1872,11 @@ export function RequestDetailPage() {
   }
 
   const urgency = getPortingUrgency(request.confirmedPortDate)
+  const hasProcessPortDateConfirm =
+    canUseManualPortDateAction && canUseManualPortDateForCurrentStatus && !isRequestClosed
+  // Inline edycja zostaje tylko tam, gdzie nie ma akcji procesowej (np. inny status w trybie
+  // manualnym) — w przeciwnym razie ekran pokazywalby dwa formularze ustawienia daty.
+  const showInlinePortDateForm = isManualMode && !hasProcessPortDateConfirm
   const assignedUserLabel = request.assignedUser
     ? `${request.assignedUser.displayName} (${request.assignedUser.email})`
     : 'Nieprzypisana'
@@ -2008,9 +2013,9 @@ export function RequestDetailPage() {
               <div>
                 <h3 className="text-sm font-semibold text-sky-900">Potwierdz date przeniesienia</h3>
                 <p className="mt-1 text-sm text-sky-800">
-                  To potwierdza date jako krok procesu i zapisuje zdarzenie w historii. Zwykla
-                  edycja daty jako danej sprawy znajduje sie w sekcji „Najwazniejsze dane sprawy"
-                  → Terminy.
+                  To zapisuje krok procesu i dodaje zdarzenie w historii sprawy. To nie jest
+                  zwykla edycja pola daty — daty pokazane w sekcji Terminy sa read-only i
+                  zmienia je dopiero ta akcja procesowa.
                 </p>
               </div>
 
@@ -2205,7 +2210,7 @@ export function RequestDetailPage() {
           <SectionCard
             id="porting-terms-panel"
             title="Najważniejsze dane sprawy"
-            description="Dane domenowe pogrupowane wg potrzeby BOK. Edycja daty przeniesienia jako dana sprawy znajduje się w grupie Terminy. Procesowe potwierdzenie daty wykonujesz z sekcji Akcje statusu."
+            description="Dane szczegółowe sprawy — bez akcji procesowych. Akcje statusu i potwierdzenie daty znajdziesz w sekcji Akcje statusu poniżej."
             icon={FileText}
           >
             <div className="space-y-6">
@@ -2253,7 +2258,7 @@ export function RequestDetailPage() {
 
               <SubGroup
                 title="Terminy"
-                description="Edycja daty jako dana sprawy. Procesowe potwierdzenie znajdziesz w sekcji Akcje statusu."
+                description="Dane terminowe sprawy (read-only). Potwierdzenie daty jako krok procesu znajdziesz w sekcji Akcje statusu."
               >
                 <Field label="Wnioskowany dzien" value={request.requestedPortDate} mono />
                 <Field
@@ -2264,7 +2269,32 @@ export function RequestDetailPage() {
                 <Field label="Data potwierdzona" value={request.confirmedPortDate} mono />
                 <Field label="Data od dawcy" value={request.donorAssignedPortDate} mono />
                 <Field label="Godzina od dawcy" value={request.donorAssignedPortTime} mono />
-                {isManualMode && (
+
+                {hasProcessPortDateConfirm && !request.confirmedPortDate && (
+                  <div className="sm:col-span-2" data-testid="terminy-process-confirm-hint">
+                    <AlertBanner
+                      tone="info"
+                      title="Data nie zostala jeszcze potwierdzona jako krok procesu."
+                      description={
+                        <span>
+                          Potwierdzenie daty zapisuje krok procesu i zdarzenie w historii sprawy.
+                          Zwykla edycja pola daty nie jest tu dostepna.
+                        </span>
+                      }
+                      action={
+                        <Button
+                          onClick={() => scrollToSection('workflow-actions')}
+                          variant="secondary"
+                          size="sm"
+                        >
+                          Przejdz do potwierdzenia daty
+                        </Button>
+                      }
+                    />
+                  </div>
+                )}
+
+                {showInlinePortDateForm && (
                   <div className="sm:col-span-2 mt-2 border-t border-line pt-4">
                     <RequestPortDatePanel
                       confirmedPortDate={request.confirmedPortDate}
@@ -2276,10 +2306,7 @@ export function RequestDetailPage() {
                 )}
               </SubGroup>
 
-              <SubGroup
-                title="Dane operacyjne"
-                description="Adres korespondencyjny, kanał kontaktu, notatki, numer dokumentu."
-              >
+              <SubGroup title="Dane operacyjne">
                 <div className="sm:col-span-2">
                   <RequestOperationalDetailsPanel
                     correspondenceAddress={request.correspondenceAddress}

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import axios from 'axios'
 import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import type { LucideIcon } from 'lucide-react'
-import { Bell, CalendarClock, ChevronDown, FileText, Info, TriangleAlert, Zap } from 'lucide-react'
+import { Bell, ChevronDown, FileText, Info, TriangleAlert, Zap } from 'lucide-react'
 import { buildPath, ROUTES } from '@/constants/routes'
 import { useAuthStore } from '@/stores/auth.store'
 import { useSystemCapabilities } from '@/hooks/useSystemCapabilities'
@@ -120,7 +120,7 @@ import {
 import {
   RequestAttentionStrip,
   RequestCaseHero,
-  RequestMetaGrid,
+  RequestStatusSnapshot,
 } from './RequestCommandCenter'
 
 const TECHNICAL_PAYLOAD_MESSAGE_TYPES = ['E03', 'E12', 'E18', 'E23'] as const
@@ -345,6 +345,26 @@ function Field({
       <dd className={cx('text-sm font-medium text-ink-800', mono ? 'break-all font-mono' : 'break-words')}>
         {value ?? <span className="font-normal text-ink-400">-</span>}
       </dd>
+    </div>
+  )
+}
+
+function SubGroup({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description?: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="mb-3">
+        <h3 className="text-xs font-semibold uppercase tracking-[0.12em] text-ink-500">{title}</h3>
+        {description && <p className="mt-1 text-xs leading-5 text-ink-400">{description}</p>}
+      </div>
+      <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">{children}</dl>
     </div>
   )
 }
@@ -1988,7 +2008,9 @@ export function RequestDetailPage() {
               <div>
                 <h3 className="text-sm font-semibold text-sky-900">Potwierdz date przeniesienia</h3>
                 <p className="mt-1 text-sm text-sky-800">
-                  Dedykowana akcja biznesowa dla trybu manualnego.
+                  To potwierdza date jako krok procesu i zapisuje zdarzenie w historii. Zwykla
+                  edycja daty jako danej sprawy znajduje sie w sekcji „Najwazniejsze dane sprawy"
+                  → Terminy.
                 </p>
               </div>
 
@@ -2118,23 +2140,19 @@ export function RequestDetailPage() {
         onScrollToStatusActions={() => scrollToSection('workflow-actions')}
       />
 
-      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.1fr)_minmax(360px,0.9fr)] xl:items-start">
-        <WhatsNextPanel
-          status={request.statusInternal}
-          availableStatusActions={availableStatusActions}
-          availableCommunicationActions={availableCommunicationActions}
-          assignedUser={request.assignedUser}
-          notificationHealth={request.notificationHealth}
-          canManageStatus={canManageStatus}
-          canManageAssignment={canManageAssignment}
-          onScrollToStatusActions={() => scrollToSection('workflow-actions')}
-          onScrollToCommunication={() => scrollToSection('communication-panel')}
-          onScrollToAssignment={() => scrollToSection('assignment-panel')}
-          onScrollToNotifications={() => scrollToSection('notification-panel')}
-        />
-
-        <RequestMetaGrid request={request} urgency={urgency} />
-      </div>
+      <WhatsNextPanel
+        status={request.statusInternal}
+        availableStatusActions={availableStatusActions}
+        availableCommunicationActions={availableCommunicationActions}
+        assignedUser={request.assignedUser}
+        notificationHealth={request.notificationHealth}
+        canManageStatus={canManageStatus}
+        canManageAssignment={canManageAssignment}
+        onScrollToStatusActions={() => scrollToSection('workflow-actions')}
+        onScrollToCommunication={() => scrollToSection('communication-panel')}
+        onScrollToAssignment={() => scrollToSection('assignment-panel')}
+        onScrollToNotifications={() => scrollToSection('notification-panel')}
+      />
 
       {hasQuickActions && (
         <section className="panel p-4">
@@ -2186,34 +2204,96 @@ export function RequestDetailPage() {
         <div className="space-y-5">
           <SectionCard
             id="porting-terms-panel"
-            title="Dane portowania i terminy"
-            description="Daty i parametry potrzebne do obsługi przeniesienia numeru."
-            icon={CalendarClock}
+            title="Najważniejsze dane sprawy"
+            description="Dane domenowe pogrupowane wg potrzeby BOK. Edycja daty przeniesienia jako dana sprawy znajduje się w grupie Terminy. Procesowe potwierdzenie daty wykonujesz z sekcji Akcje statusu."
+            icon={FileText}
           >
-            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Field label="Wnioskowany dzien przeniesienia" value={request.requestedPortDate} mono />
-              <Field label="Najwczesniejsza akceptowalna data" value={request.earliestAcceptablePortDate} mono />
-              <Field label="Data potwierdzona" value={request.confirmedPortDate} mono />
-              <Field label="Data od dawcy" value={request.donorAssignedPortDate} mono />
-              <Field label="Godzina od dawcy" value={request.donorAssignedPortTime} mono />
-              <Field label="Pelnomocnictwo" value={request.hasPowerOfAttorney ? 'Tak' : 'Nie'} />
-            </dl>
-          </SectionCard>
+            <div className="space-y-6">
+              <SubGroup title="Klient i kontakt">
+                <Field label="Klient" value={request.client.displayName} />
+                <Field label="Abonent" value={request.subscriberDisplayName} />
+                <Field
+                  label="Kanal kontaktu"
+                  value={CONTACT_CHANNEL_LABELS[request.contactChannel]}
+                />
+                <Field
+                  label="Typ identyfikatora"
+                  value={SUBSCRIBER_IDENTITY_TYPE_LABELS[request.identityType]}
+                />
+                <Field label="Wartosc identyfikatora" value={request.identityValue} mono />
+                <WideField
+                  label="Adres korespondencyjny"
+                  value={request.correspondenceAddress}
+                />
+              </SubGroup>
 
-          {isManualMode && (
-            <SectionCard
-              title="Dane portowania"
-              description="Ręczne uzupełnienie potwierdzonej daty przeniesienia w trybie manualnym."
-              icon={CalendarClock}
-            >
-              <RequestPortDatePanel
-                confirmedPortDate={request.confirmedPortDate}
-                canEdit={canEditPortDate}
-                disabledReason={operationalDetailsDisabledReason}
-                onSave={handleUpdatePortDate}
-              />
-            </SectionCard>
-          )}
+              <SubGroup title="Portowanie">
+                <Field label="Numer / zakres" value={request.numberDisplay} mono />
+                <Field label="Typ uslugi" value={NUMBER_TYPE_LABELS[request.numberType]} />
+                <Field
+                  label="Typ numeracji"
+                  value={PORTED_NUMBER_KIND_LABELS[request.numberRangeKind]}
+                />
+                <Field label="Numer dokumentu" value={request.requestDocumentNumber} mono />
+                <Field label="Operator oddajacy" value={request.donorOperator.name} />
+                <Field label="Operator bioracy" value={request.recipientOperator.name} />
+                <Field
+                  label="Operator infrastrukturalny"
+                  value={request.infrastructureOperator?.name}
+                />
+                <Field
+                  label="Pelnomocnictwo"
+                  value={request.hasPowerOfAttorney ? 'Tak' : 'Nie'}
+                />
+                <Field
+                  label="Usluga hurtowa po stronie biorcy"
+                  value={request.linkedWholesaleServiceOnRecipientSide ? 'Tak' : 'Nie'}
+                />
+              </SubGroup>
+
+              <SubGroup
+                title="Terminy"
+                description="Edycja daty jako dana sprawy. Procesowe potwierdzenie znajdziesz w sekcji Akcje statusu."
+              >
+                <Field label="Wnioskowany dzien" value={request.requestedPortDate} mono />
+                <Field
+                  label="Najwczesniejsza akceptowalna"
+                  value={request.earliestAcceptablePortDate}
+                  mono
+                />
+                <Field label="Data potwierdzona" value={request.confirmedPortDate} mono />
+                <Field label="Data od dawcy" value={request.donorAssignedPortDate} mono />
+                <Field label="Godzina od dawcy" value={request.donorAssignedPortTime} mono />
+                {isManualMode && (
+                  <div className="sm:col-span-2 mt-2 border-t border-line pt-4">
+                    <RequestPortDatePanel
+                      confirmedPortDate={request.confirmedPortDate}
+                      canEdit={canEditPortDate}
+                      disabledReason={operationalDetailsDisabledReason}
+                      onSave={handleUpdatePortDate}
+                    />
+                  </div>
+                )}
+              </SubGroup>
+
+              <SubGroup
+                title="Dane operacyjne"
+                description="Adres korespondencyjny, kanał kontaktu, notatki, numer dokumentu."
+              >
+                <div className="sm:col-span-2">
+                  <RequestOperationalDetailsPanel
+                    correspondenceAddress={request.correspondenceAddress}
+                    contactChannel={request.contactChannel}
+                    internalNotes={request.internalNotes}
+                    requestDocumentNumber={request.requestDocumentNumber}
+                    canEdit={canEditOperationalDetails}
+                    disabledReason={operationalDetailsDisabledReason}
+                    onSave={handleUpdateOperationalDetails}
+                  />
+                </div>
+              </SubGroup>
+            </div>
+          </SectionCard>
 
           {workflowActionsSection}
 
@@ -2244,47 +2324,6 @@ export function RequestDetailPage() {
               onLoadDeliveryAttempts={(communicationId) => void handleLoadDeliveryAttempts(communicationId)}
             />
           </div>
-
-          <SectionCard
-            title="Dane kontaktowe i operacyjne"
-            description="Adres korespondencyjny, kanał kontaktu, notatki i numer dokumentu sprawy."
-          >
-            <RequestOperationalDetailsPanel
-              correspondenceAddress={request.correspondenceAddress}
-              contactChannel={request.contactChannel}
-              internalNotes={request.internalNotes}
-              requestDocumentNumber={request.requestDocumentNumber}
-              canEdit={canEditOperationalDetails}
-              disabledReason={operationalDetailsDisabledReason}
-              onSave={handleUpdateOperationalDetails}
-            />
-          </SectionCard>
-
-          <SectionCard
-            title="Dane klienta i operatorów"
-            description="Identyfikacja abonenta, zakres numeracji oraz operatorzy procesu."
-            icon={FileText}
-          >
-            <dl className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Field label="Klient" value={request.client.displayName} />
-              <Field label="Abonent" value={request.subscriberDisplayName} />
-              <Field label="Typ uslugi" value={NUMBER_TYPE_LABELS[request.numberType]} />
-              <Field label="Typ numeracji" value={PORTED_NUMBER_KIND_LABELS[request.numberRangeKind]} />
-              <Field label="Numer / zakres" value={request.numberDisplay} mono />
-              <Field label="Status sprawy" value={PORTING_CASE_STATUS_LABELS[request.statusInternal]} />
-              <Field label="Operator oddajacy" value={request.donorOperator.name} />
-              <Field label="Operator bioracy" value={request.recipientOperator.name} />
-              <Field label="Numer dokumentu" value={request.requestDocumentNumber} mono />
-              <Field label="Kanal kontaktu" value={CONTACT_CHANNEL_LABELS[request.contactChannel]} />
-              <Field label="Typ identyfikatora" value={SUBSCRIBER_IDENTITY_TYPE_LABELS[request.identityType]} />
-              <Field label="Wartosc identyfikatora" value={request.identityValue} mono />
-              <Field
-                label="Usluga hurtowa po stronie biorcy"
-                value={request.linkedWholesaleServiceOnRecipientSide ? 'Tak' : 'Nie'}
-              />
-              <Field label="Operator infrastrukturalny" value={request.infrastructureOperator?.name} />
-            </dl>
-          </SectionCard>
 
           <RequestDetailsHistoryPanel
             items={detailsHistoryItems}
@@ -2555,6 +2594,8 @@ export function RequestDetailPage() {
         </div>
 
         <div className="space-y-4">
+          <RequestStatusSnapshot request={request} urgency={urgency} />
+
           <div id="assignment-panel" className="scroll-mt-6">
             <PortingAssignmentPanel
               assignedUser={request.assignedUser}


### PR DESCRIPTION
## Summary
- Hero przebudowane w "centrum sprawy" — 4 grupy (Klient i kontakt, Portowanie, Terminy, Obsługa) widoczne bez scrollowania.
- WhatsNextPanel pełna szerokość bezpośrednio pod centrum sprawy — sekcja decyzyjna nie ginie.
- Cztery rozproszone karty danych scalone w jedną sekcję "Najważniejsze dane sprawy" z 4 podgrupami.
- Edycja daty (RequestPortDatePanel) wbudowana w grupę Terminy; "Potwierdz date przeniesienia" zostaje akcją procesową w sekcji Akcje statusu z nowym copy o zapisie zdarzenia w historii.
- Prawa kolumna ograniczona do skrótu operacyjnego (nowy RequestStatusSnapshot) + ownership (PortingAssignmentPanel, opiekun, Meta). RequestMetaGrid zlikwidowany.

## Scope
Frontend-only. Zero zmian w: backend, DTO, API, schema.prisma, seedach, workflow/statusach, logice notyfikacji/przypisań.

## Files
- `apps/frontend/src/pages/Requests/RequestCommandCenter.tsx` — nowy hero + RequestStatusSnapshot, usunięty RequestMetaGrid
- `apps/frontend/src/pages/Requests/RequestDetailPage.tsx` — nowa struktura (Hero → Attention → WhatsNext full-width → QuickActions → 2-kol grid), nowy SubGroup helper, zaktualizowane copy procesowe daty
- `apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx` — `contactChannel` w fixture, `getAllByText` dla powtarzanej nazwy operatora

## Long data
FNP-SEED-LONG-DATA-001: każda komórka ma `min-w-0` + `break-words`/`break-all`, kontener hero `overflow-hidden`. Brak fixed widths poza max-w-4xl na <h1> z break-words.

## Validation
- `npx tsc -p tsconfig.json --noEmit` → clean
- `npx vitest run` → **45 plików, 327 testów PASS**
- `npm run build` → OK (1961 modules, 6.78s)

## Test plan
- [ ] Manual QA w przeglądarce na: FNP-SEED-LONG-DATA-001, FNP-SEED-NO-DATE-001, FNP-SEED-NO-ASSIGNEE-001, FNP-SEED-ERROR-001
- [ ] Sprawdzić, czy najważniejsze dane są widoczne bez scrollowania
- [ ] Sprawdzić, że długie dane (mail, adres) nie psują layoutu
- [ ] Zweryfikować, że "Potwierdz date przeniesienia" nie myli się ze zwykłą edycją daty (różne sekcje, różne copy)
- [ ] Spójność admin vs zwykły użytkownik (admin ma diagnostykę niżej, ale to samo centrum sprawy)

## Notes for reviewer
- Funkcje `updatePortingRequestPortDate` i `confirmPortingRequestPortDateManual` nienaruszone — zmieniona tylko prezentacja UI.
- `RequestMetaGrid` usunięty z exportu — duplikował dane hero. Funkcjonalność (status/pilność/data/notyfikacje/BOK/opiekun) pokryta przez hero + nowy `RequestStatusSnapshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)