### PR TITLE
fix(frontend): remove duplicate port-date entry, elevate number/client in hero (fix5c1b)

### DIFF
--- a/apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx
@@ -93,10 +93,23 @@ describe('RequestCommandCenter', () => {
       </MemoryRouter>,
     )
 
-    expect(screen.getByText('NP-2026-0007')).toBeDefined()
-    expect(screen.getAllByText('Acme Sp. z o.o.').length).toBeGreaterThan(0)
-    expect(screen.getByText('500123456')).toBeDefined()
-    expect(screen.getAllByText(/Operator Dawca/).length).toBeGreaterThan(0)
+    // Primary hero: number as h1, client as prominent subtitle
+    const heroNumber = screen.getByTestId('hero-number')
+    expect(heroNumber.tagName).toBe('H1')
+    expect(heroNumber.textContent).toBe('500123456')
+
+    const heroClient = screen.getByTestId('hero-client')
+    expect(heroClient.textContent).toBe('Acme Sp. z o.o.')
+
+    // Meta line: caseNumber + operator route still visible
+    const heroMeta = screen.getByTestId('hero-meta')
+    expect(heroMeta.textContent).toContain('NP-2026-0007')
+    expect(heroMeta.textContent).toContain('Operator Dawca')
+
+    // Mode badge visible (DAY label appears in badges and in Portowanie group)
+    expect(screen.getAllByText(/DAY/).length).toBeGreaterThan(0)
+
+    // Owners in groups below
     expect(screen.getByText('Anna BOK')).toBeDefined()
     expect(screen.getByText('Jan Sales')).toBeDefined()
   })

--- a/apps/frontend/src/pages/Requests/RequestCommandCenter.tsx
+++ b/apps/frontend/src/pages/Requests/RequestCommandCenter.tsx
@@ -253,12 +253,28 @@ export function RequestCaseHero({
         </div>
 
         <div className="mt-4 max-w-4xl min-w-0">
-          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-ink-400">Sprawa</p>
-          <h1 className="mt-1 break-words font-mono text-3xl font-semibold tracking-tight text-ink-950 md:text-4xl">
-            {request.caseNumber}
+          <p className="text-xs font-semibold uppercase tracking-[0.12em] text-ink-400">
+            Numer przenoszony
+          </p>
+          <h1
+            data-testid="hero-number"
+            className="mt-1 break-all font-mono text-3xl font-bold tracking-tight text-ink-950 md:text-4xl"
+          >
+            {request.numberDisplay}
           </h1>
-          <p className="mt-3 break-words text-2xl font-semibold tracking-tight text-ink-900">
+          <p
+            data-testid="hero-client"
+            className="mt-2 break-words text-2xl font-semibold tracking-tight text-ink-900"
+          >
             {request.client.displayName}
+          </p>
+          <p
+            data-testid="hero-meta"
+            className="mt-2 flex flex-wrap items-center gap-x-2 text-sm text-ink-500"
+          >
+            <span className="font-mono">{request.caseNumber}</span>
+            <span className="select-none text-ink-300" aria-hidden>·</span>
+            <span>{donorToRecipient}</span>
           </p>
         </div>
       </div>

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -1874,9 +1874,9 @@ export function RequestDetailPage() {
   const urgency = getPortingUrgency(request.confirmedPortDate)
   const hasProcessPortDateConfirm =
     canUseManualPortDateAction && canUseManualPortDateForCurrentStatus && !isRequestClosed
-  // Inline edycja zostaje tylko tam, gdzie nie ma akcji procesowej (np. inny status w trybie
-  // manualnym) — w przeciwnym razie ekran pokazywalby dwa formularze ustawienia daty.
-  const showInlinePortDateForm = isManualMode && !hasProcessPortDateConfirm
+  // Inline edycja ukryta gdy uzytkownik ma dostep do akcji procesowej potwierdzenia daty
+  // (niezaleznie od statusu) — zapobiega pokazywaniu dwoch miejsc do ustawienia daty.
+  const showInlinePortDateForm = isManualMode && !canUseManualPortDateAction
   const assignedUserLabel = request.assignedUser
     ? `${request.assignedUser.displayName} (${request.assignedUser.email})`
     : 'Nieprzypisana'
@@ -2270,7 +2270,7 @@ export function RequestDetailPage() {
                 <Field label="Data od dawcy" value={request.donorAssignedPortDate} mono />
                 <Field label="Godzina od dawcy" value={request.donorAssignedPortTime} mono />
 
-                {hasProcessPortDateConfirm && !request.confirmedPortDate && (
+                {canUseManualPortDateAction && !request.confirmedPortDate && (
                   <div className="sm:col-span-2" data-testid="terminy-process-confirm-hint">
                     <AlertBanner
                       tone="info"
@@ -2287,7 +2287,7 @@ export function RequestDetailPage() {
                           variant="secondary"
                           size="sm"
                         >
-                          Przejdz do potwierdzenia daty
+                          Przejdź do potwierdzenia daty
                         </Button>
                       }
                     />


### PR DESCRIPTION
## Summary

Fix-pack for PR #86 (`claude/distracted-taussig-45a7e6`). Two targeted UI fixes — no backend, DTO, API, workflow, seed, or routing changes.

### Problem 1 — duplicate date entry point

**Root cause:** `showInlinePortDateForm = isManualMode && !hasProcessPortDateConfirm` leaked the inline `RequestPortDatePanel` when `canUseManualPortDateAction=true` but `canUseManualPortDateForCurrentStatus=false` (status outside the allowed set). The formal "Potwierdź datę" section in *Akcje statusu* was visible simultaneously with the inline form in *Terminy*.

**Fix:**
- `showInlinePortDateForm = isManualMode && !canUseManualPortDateAction` — hides inline form whenever the role has access to the process action, regardless of current status
- Terminy hint condition changed from `hasProcessPortDateConfirm` → `canUseManualPortDateAction && !confirmedPortDate` — link "Przejdź do potwierdzenia daty" now visible even when status doesn't match `canUseManualPortDateForCurrentStatus`
- Fixed diacritics on button: `Przejdź do potwierdzenia daty`

### Problem 2 — hero hierarchy

**Before:** `h1` = `caseNumber` (dominant, 3xl/4xl mono), client name below it.

**After:**
- `h1 [data-testid="hero-number"]` = `numberDisplay` — porting number as primary visual anchor
- `p [data-testid="hero-client"]` = `client.displayName` — client as prominent subtitle
- `p [data-testid="hero-meta"]` = `caseNumber · donor → recipient` — secondary metadata line

Top badges (status, porting mode DAY/EOP/END, urgency, notifications) unchanged. Four data groups below unchanged.

## Unchanged

| Area | Status |
|---|---|
| `updatePortingRequestPortDate` handler | Untouched |
| `confirmPortingRequestPortDateManual` handler | Untouched |
| `availableStatusActions` | Untouched |
| workflow / routing | Untouched |
| assignment / commercialOwner | Untouched |
| PLI CBD gates | Untouched |
| notification retry | Untouched |
| backend / DTO / shared / seed / admin screens | Not touched |

## Test plan

- [x] `npm run type-check --workspace apps/frontend` — 0 errors
- [x] `npm run test --workspace apps/frontend` — 327/327 passed
- [x] `npm run build --workspace apps/frontend` — clean build
- [ ] Manual: FNP-SEED-NO-DATE-001 — no inline date in Terminy, link "Przejdź do potwierdzenia daty" visible, formal action only in Akcje statusu
- [ ] Manual: FNP-SEED-LONG-DATA-001 — hero shows number as h1, client as subtitle, long data doesn't break layout
- [ ] Manual: FNP-SEED-NO-ASSIGNEE-001 — confirmed date shown read-only, no second date form
- [ ] Manual: FNP-SEED-E18-001/PORTED — no unexpected date edit UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)