### PR TITLE
refactor(frontend): extract request workflow actions section

### DIFF
--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -98,6 +98,7 @@ import { PliCbdXmlPreview } from '@/components/PliCbdXmlPreview/PliCbdXmlPreview
 import { PortingInternalNotificationsPanel } from '@/components/PortingInternalNotificationsPanel/PortingInternalNotificationsPanel'
 import { RequestOperationalDetailsPanel } from '@/components/RequestOperationalDetailsPanel/RequestOperationalDetailsPanel'
 import { RequestPortDatePanel } from '@/components/RequestPortDatePanel/RequestPortDatePanel'
+import { RequestWorkflowActionsSection } from './RequestWorkflowActionsSection'
 import { RequestDetailsHistoryPanel } from '@/components/RequestDetailsHistoryPanel/RequestDetailsHistoryPanel'
 import { WhatsNextPanel } from '@/components/WhatsNextPanel/WhatsNextPanel'
 import { InternalNotificationAttemptsPanel } from '@/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel'
@@ -1888,240 +1889,56 @@ export function RequestDetailPage() {
     quickStatusActions.length > 0 || canManageAssignment || availableCommunicationActions.length > 0
   const workflowErrorMessage = getWorkflowErrorEmptyStateMessage(canUsePliCbdExternalActions)
   const workflowActionsSection = (
-    <SectionCard
-      id="workflow-actions"
-      title="Akcje statusu"
-      description="Dostępne przejścia wynikają z aktualnego statusu sprawy i uprawnień operatora."
-      compact
-    >
-      {canManageStatus ? (
-        <div className="space-y-4">
-          {availableStatusActions.length > 0 ? (
-            <div className="space-y-3">
-              <div className="flex flex-wrap gap-2">
-                {availableStatusActions.map((action) => (
-                  <button
-                    key={`${action.actionId}-${action.targetStatus}`}
-                    type="button"
-                    onClick={() => handleSelectStatusAction(action)}
-                    className={
-                      selectedStatusAction?.actionId === action.actionId &&
-                      selectedStatusAction.targetStatus === action.targetStatus
-                        ? 'btn-primary'
-                        : 'btn-secondary'
-                    }
-                    disabled={isUpdatingStatus || isExporting || isSyncing}
-                  >
-                    {action.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-          ) : TERMINAL_CLOSED_STATUSES.includes(request.statusInternal) ? (
-            <div className="rounded-panel border border-line bg-ink-50 px-4 py-3 text-sm text-ink-500">
-              Sprawa zakoĹ„czona â€” brak dostÄ™pnych akcji statusowych.
-            </div>
-          ) : request.statusInternal === 'ERROR' ? (
-            <div className="rounded-panel border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-              {getWorkflowErrorEmptyStateMessage(canUsePliCbdExternalActions)}
-            </div>
-          ) : (
-            <div className="rounded-panel border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
-              Brak akcji dostÄ™pnych dla Twojej roli w tym statusie sprawy.
-            </div>
-          )}
-
-          {selectedStatusAction ? (
-            <div className="space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
-              <div>
-                <h3 className="text-sm font-semibold text-gray-800">{selectedStatusAction.label}</h3>
-                <p className="mt-1 text-sm text-gray-500">{selectedStatusAction.description}</p>
-              </div>
-
-              {selectedStatusAction.requiresReason && (
-                <label className="block">
-                  <span className="mb-1 block text-xs font-medium text-gray-600">
-                    {selectedStatusAction.reasonLabel ?? 'Powod'}
-                  </span>
-                  <input
-                    type="text"
-                    value={statusReason}
-                    onChange={(event) => setStatusReason(event.target.value)}
-                    className="input-field"
-                    placeholder={selectedStatusAction.reasonLabel ?? 'Podaj powod'}
-                  />
-                </label>
-              )}
-
-              <label className="block">
-                <span className="mb-1 block text-xs font-medium text-gray-600">
-                  {selectedStatusAction.commentLabel ??
-                    (selectedStatusAction.requiresComment ? 'Komentarz' : 'Komentarz (opcjonalnie)')}
-                </span>
-                <textarea
-                  value={statusComment}
-                  onChange={(event) => setStatusComment(event.target.value)}
-                  rows={selectedStatusAction.requiresComment ? 4 : 3}
-                  className="input-field"
-                  placeholder={
-                    selectedStatusAction.requiresComment
-                      ? 'Dodaj wymagany komentarz'
-                      : 'Opcjonalny komentarz operacyjny'
-                  }
-                />
-              </label>
-
-              <div className="flex flex-wrap gap-2">
-                <button
-                  type="button"
-                  onClick={() => void handleSubmitStatusAction()}
-                  className="btn-primary"
-                  disabled={isUpdatingStatus || isExporting || isSyncing}
-                >
-                  {isUpdatingStatus ? 'Zapis statusu' : selectedStatusAction.label}
-                </button>
-                <button
-                  type="button"
-                  onClick={resetStatusActionForm}
-                  className="btn-secondary"
-                  disabled={isUpdatingStatus}
-                >
-                  Wyczysc
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
-              Wybierz akcje, aby zmienic status sprawy.
-            </div>
-          )}
-
-          {statusActionSuccess && (
-            <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-              {statusActionSuccess}
-            </div>
-          )}
-
-          {statusActionError && (
-            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-              {statusActionError}
-            </div>
-          )}
-
-          {canUseManualPortDateAction && (
-            <div className="space-y-3 rounded-lg border border-sky-200 bg-sky-50/60 p-4">
-              <div>
-                <h3 className="text-sm font-semibold text-sky-900">Potwierdz date przeniesienia</h3>
-                <p className="mt-1 text-sm text-sky-800">
-                  To zapisuje krok procesu i dodaje zdarzenie w historii sprawy. To nie jest
-                  zwykla edycja pola daty — daty pokazane w sekcji Terminy sa read-only i
-                  zmienia je dopiero ta akcja procesowa.
-                </p>
-              </div>
-
-              {canUseManualPortDateForCurrentStatus ? (
-                <>
-                  <label className="block">
-                    <span className="mb-1 block text-xs font-medium text-sky-900">
-                      Data przeniesienia
-                    </span>
-                    <input
-                      type="date"
-                      value={manualConfirmedPortDate}
-                      onChange={(event) => setManualConfirmedPortDate(event.target.value)}
-                      className="input-field"
-                      disabled={
-                        isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
-                      }
-                    />
-                  </label>
-
-                  <label className="block">
-                    <span className="mb-1 block text-xs font-medium text-sky-900">
-                      Komentarz operacyjny (opcjonalnie)
-                    </span>
-                    <textarea
-                      value={manualPortDateComment}
-                      onChange={(event) => setManualPortDateComment(event.target.value)}
-                      rows={3}
-                      className="input-field"
-                      placeholder="Dodaj komentarz do historii operacyjnej"
-                      disabled={
-                        isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
-                      }
-                    />
-                  </label>
-
-                  <div className="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      onClick={() => void handleConfirmManualPortDate()}
-                      className="btn-primary"
-                      disabled={
-                        isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
-                      }
-                    >
-                      {isSubmittingManualPortDate
-                        ? 'Zapisywanie potwierdzenia'
-                        : 'Potwierdz date przeniesienia'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setManualPortDateComment('')}
-                      className="btn-secondary"
-                      disabled={isSubmittingManualPortDate}
-                    >
-                      Wyczysc komentarz
-                    </button>
-                  </div>
-                </>
-              ) : (
-                <div className="rounded-panel border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
-                  Akcja dostepna tylko dla statusow: Zlozona, Oczekuje na dawce, Potwierdzona.
-                </div>
-              )}
-
-              {manualPortDateSuccess && (
-                <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
-                  {manualPortDateSuccess}
-                </div>
-              )}
-
-              {manualPortDateError && (
-                <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
-                  {manualPortDateError}
-                </div>
-              )}
-            </div>
-          )}
-
-          {canUsePliCbdExternalActions && (
-            <PortingExternalActionsPanel
-              availableActions={availableExternalActions}
-              selectedAction={selectedExternalAction}
-              scheduledPortDate={externalScheduledPortDate}
-              rejectionReason={externalRejectionReason}
-              comment={externalActionComment}
-              createDraft={externalCreateDraft}
-              isSubmitting={isSubmittingExternalAction}
-              successMessage={externalActionSuccess}
-              errorMessage={externalActionError}
-              onSelectAction={handleSelectExternalAction}
-              onScheduledPortDateChange={setExternalScheduledPortDate}
-              onRejectionReasonChange={setExternalRejectionReason}
-              onCommentChange={setExternalActionComment}
-              onCreateDraftChange={setExternalCreateDraft}
-              onSubmit={() => void handleSubmitExternalAction()}
-              onReset={resetExternalActionForm}
-            />
-          )}
-        </div>
-      ) : (
-        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
-          Twoja rola ma dostep tylko do podgladu sprawy.
-        </div>
-      )}
-    </SectionCard>
+    <RequestWorkflowActionsSection
+      canManageStatus={canManageStatus}
+      statusInternal={request.statusInternal}
+      canUsePliCbdExternalActions={canUsePliCbdExternalActions}
+      workflowErrorEmptyStateMessage={workflowErrorMessage}
+      availableStatusActions={availableStatusActions}
+      selectedStatusAction={selectedStatusAction}
+      statusReason={statusReason}
+      statusComment={statusComment}
+      isUpdatingStatus={isUpdatingStatus}
+      isExporting={isExporting}
+      isSyncing={isSyncing}
+      statusActionSuccess={statusActionSuccess}
+      statusActionError={statusActionError}
+      onSelectStatusAction={handleSelectStatusAction}
+      onStatusReasonChange={setStatusReason}
+      onStatusCommentChange={setStatusComment}
+      onSubmitStatusAction={() => void handleSubmitStatusAction()}
+      onResetStatusActionForm={resetStatusActionForm}
+      canUseManualPortDateAction={canUseManualPortDateAction}
+      canUseManualPortDateForCurrentStatus={canUseManualPortDateForCurrentStatus}
+      manualConfirmedPortDate={manualConfirmedPortDate}
+      manualPortDateComment={manualPortDateComment}
+      isSubmittingManualPortDate={isSubmittingManualPortDate}
+      manualPortDateSuccess={manualPortDateSuccess}
+      manualPortDateError={manualPortDateError}
+      onManualConfirmedPortDateChange={setManualConfirmedPortDate}
+      onManualPortDateCommentChange={setManualPortDateComment}
+      onConfirmManualPortDate={() => void handleConfirmManualPortDate()}
+      pliCbdExternalActionsSlot={
+        <PortingExternalActionsPanel
+          availableActions={availableExternalActions}
+          selectedAction={selectedExternalAction}
+          scheduledPortDate={externalScheduledPortDate}
+          rejectionReason={externalRejectionReason}
+          comment={externalActionComment}
+          createDraft={externalCreateDraft}
+          isSubmitting={isSubmittingExternalAction}
+          successMessage={externalActionSuccess}
+          errorMessage={externalActionError}
+          onSelectAction={handleSelectExternalAction}
+          onScheduledPortDateChange={setExternalScheduledPortDate}
+          onRejectionReasonChange={setExternalRejectionReason}
+          onCommentChange={setExternalActionComment}
+          onCreateDraftChange={setExternalCreateDraft}
+          onSubmit={() => void handleSubmitExternalAction()}
+          onReset={resetExternalActionForm}
+        />
+      }
+    />
   )
 
   return (

--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.test.tsx
@@ -1,0 +1,282 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PortingRequestStatusActionDto } from '@np-manager/shared'
+import {
+  RequestWorkflowActionsSection,
+  type RequestWorkflowActionsSectionProps,
+} from './RequestWorkflowActionsSection'
+
+const ACTION_CONFIRM: PortingRequestStatusActionDto = {
+  actionId: 'CONFIRM',
+  label: 'Potwierdz przez dawce',
+  targetStatus: 'CONFIRMED',
+  requiresReason: false,
+  requiresComment: false,
+  reasonLabel: null,
+  commentLabel: null,
+  description: 'Dawca potwierdza date przeniesienia',
+}
+
+const ACTION_REJECT: PortingRequestStatusActionDto = {
+  actionId: 'REJECT',
+  label: 'Odrzuc',
+  targetStatus: 'REJECTED',
+  requiresReason: true,
+  requiresComment: true,
+  reasonLabel: 'Powod odrzucenia',
+  commentLabel: 'Komentarz odrzucenia',
+  description: 'Odrzucenie wniosku przez dawce',
+}
+
+function buildProps(
+  overrides: Partial<RequestWorkflowActionsSectionProps> = {},
+): RequestWorkflowActionsSectionProps {
+  return {
+    canManageStatus: true,
+    statusInternal: 'SUBMITTED',
+    canUsePliCbdExternalActions: false,
+    workflowErrorEmptyStateMessage: 'Workflow error empty state.',
+    availableStatusActions: [],
+    selectedStatusAction: null,
+    statusReason: '',
+    statusComment: '',
+    isUpdatingStatus: false,
+    isExporting: false,
+    isSyncing: false,
+    statusActionSuccess: null,
+    statusActionError: null,
+    onSelectStatusAction: vi.fn(),
+    onStatusReasonChange: vi.fn(),
+    onStatusCommentChange: vi.fn(),
+    onSubmitStatusAction: vi.fn(),
+    onResetStatusActionForm: vi.fn(),
+    canUseManualPortDateAction: false,
+    canUseManualPortDateForCurrentStatus: false,
+    manualConfirmedPortDate: '',
+    manualPortDateComment: '',
+    isSubmittingManualPortDate: false,
+    manualPortDateSuccess: null,
+    manualPortDateError: null,
+    onManualConfirmedPortDateChange: vi.fn(),
+    onManualPortDateCommentChange: vi.fn(),
+    onConfirmManualPortDate: vi.fn(),
+    pliCbdExternalActionsSlot: null,
+    ...overrides,
+  }
+}
+
+describe('RequestWorkflowActionsSection', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders read-only message when canManageStatus is false', () => {
+    render(<RequestWorkflowActionsSection {...buildProps({ canManageStatus: false })} />)
+
+    expect(screen.getByText(/Twoja rola ma dostep tylko do podgladu/)).toBeDefined()
+    expect(screen.queryByRole('button')).toBeNull()
+  })
+
+  it('renders terminal closed empty state when no actions and status is closed', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({ statusInternal: 'PORTED', availableStatusActions: [] })}
+      />,
+    )
+
+    expect(screen.getByText(/Sprawa zako/)).toBeDefined()
+  })
+
+  it('renders ERROR empty state with workflow error message', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          statusInternal: 'ERROR',
+          availableStatusActions: [],
+          workflowErrorEmptyStateMessage: 'Custom workflow error.',
+        })}
+      />,
+    )
+
+    expect(screen.getByText('Custom workflow error.')).toBeDefined()
+  })
+
+  it('renders available status actions and triggers onSelectStatusAction on click', () => {
+    const onSelectStatusAction = vi.fn()
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          availableStatusActions: [ACTION_CONFIRM, ACTION_REJECT],
+          onSelectStatusAction,
+        })}
+      />,
+    )
+
+    const confirmButton = screen.getByRole('button', { name: 'Potwierdz przez dawce' })
+    fireEvent.click(confirmButton)
+    expect(onSelectStatusAction).toHaveBeenCalledWith(ACTION_CONFIRM)
+  })
+
+  it('shows reason and comment fields when selected action requires them', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          availableStatusActions: [ACTION_REJECT],
+          selectedStatusAction: ACTION_REJECT,
+        })}
+      />,
+    )
+
+    expect(screen.getByText('Powod odrzucenia')).toBeDefined()
+    expect(screen.getByText('Komentarz odrzucenia')).toBeDefined()
+    expect(screen.getByPlaceholderText('Powod odrzucenia')).toBeDefined()
+    expect(screen.getByPlaceholderText('Dodaj wymagany komentarz')).toBeDefined()
+  })
+
+  it('hides reason field when selected action does not require it', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          availableStatusActions: [ACTION_CONFIRM],
+          selectedStatusAction: ACTION_CONFIRM,
+        })}
+      />,
+    )
+
+    expect(screen.queryByPlaceholderText('Podaj powod')).toBeNull()
+    expect(screen.getByPlaceholderText('Opcjonalny komentarz operacyjny')).toBeDefined()
+  })
+
+  it('triggers onSubmitStatusAction when submit button clicked', () => {
+    const onSubmitStatusAction = vi.fn()
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          availableStatusActions: [ACTION_CONFIRM],
+          selectedStatusAction: ACTION_CONFIRM,
+          onSubmitStatusAction,
+        })}
+      />,
+    )
+
+    const submitButtons = screen.getAllByRole('button', { name: 'Potwierdz przez dawce' })
+    // First button = action selector, second button = submit
+    fireEvent.click(submitButtons[submitButtons.length - 1]!)
+    expect(onSubmitStatusAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders manual confirm port date block when allowed', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          canUseManualPortDateAction: true,
+          canUseManualPortDateForCurrentStatus: true,
+        })}
+      />,
+    )
+
+    expect(screen.getAllByText('Potwierdz date przeniesienia').length).toBeGreaterThan(0)
+    expect(screen.getByText(/zapisuje krok procesu/)).toBeDefined()
+  })
+
+  it('shows status-restricted hint when manual port date action available but status disallows it', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          canUseManualPortDateAction: true,
+          canUseManualPortDateForCurrentStatus: false,
+        })}
+      />,
+    )
+
+    expect(screen.getByText(/Akcja dostepna tylko dla statusow/)).toBeDefined()
+  })
+
+  it('renders manual port date success and error feedback', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          canUseManualPortDateAction: true,
+          canUseManualPortDateForCurrentStatus: true,
+          manualPortDateSuccess: 'Saved OK',
+          manualPortDateError: 'Save failed',
+        })}
+      />,
+    )
+
+    expect(screen.getByText('Saved OK')).toBeDefined()
+    expect(screen.getByText('Save failed')).toBeDefined()
+  })
+
+  it('triggers onConfirmManualPortDate when manual confirm button clicked', () => {
+    const onConfirmManualPortDate = vi.fn()
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          canUseManualPortDateAction: true,
+          canUseManualPortDateForCurrentStatus: true,
+          onConfirmManualPortDate,
+        })}
+      />,
+    )
+
+    const buttons = screen.getAllByRole('button', { name: 'Potwierdz date przeniesienia' })
+    fireEvent.click(buttons[buttons.length - 1]!)
+    expect(onConfirmManualPortDate).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders status action success and error feedback', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          statusActionSuccess: 'Status updated',
+          statusActionError: 'Status error',
+        })}
+      />,
+    )
+
+    expect(screen.getByText('Status updated')).toBeDefined()
+    expect(screen.getByText('Status error')).toBeDefined()
+  })
+
+  it('renders pliCbdExternalActionsSlot when canUsePliCbdExternalActions is true', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          canUsePliCbdExternalActions: true,
+          pliCbdExternalActionsSlot: <div data-testid="external-slot">EXTERNAL</div>,
+        })}
+      />,
+    )
+
+    expect(screen.getByTestId('external-slot')).toBeDefined()
+  })
+
+  it('does not render pliCbdExternalActionsSlot when canUsePliCbdExternalActions is false', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          canUsePliCbdExternalActions: false,
+          pliCbdExternalActionsSlot: <div data-testid="external-slot">EXTERNAL</div>,
+        })}
+      />,
+    )
+
+    expect(screen.queryByTestId('external-slot')).toBeNull()
+  })
+
+  it('disables status action buttons when isUpdatingStatus is true', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          availableStatusActions: [ACTION_CONFIRM],
+          isUpdatingStatus: true,
+        })}
+      />,
+    )
+
+    const button = screen.getByRole('button', { name: 'Potwierdz przez dawce' })
+    expect((button as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
@@ -1,0 +1,295 @@
+import type {
+  PortingCaseStatus,
+  PortingRequestStatusActionDto,
+} from '@np-manager/shared'
+
+const TERMINAL_CLOSED_STATUSES: PortingCaseStatus[] = ['REJECTED', 'CANCELLED', 'PORTED']
+
+export interface RequestWorkflowActionsSectionProps {
+  canManageStatus: boolean
+  statusInternal: PortingCaseStatus
+  canUsePliCbdExternalActions: boolean
+  workflowErrorEmptyStateMessage: string
+
+  availableStatusActions: PortingRequestStatusActionDto[]
+  selectedStatusAction: PortingRequestStatusActionDto | null
+  statusReason: string
+  statusComment: string
+  isUpdatingStatus: boolean
+  isExporting: boolean
+  isSyncing: boolean
+  statusActionSuccess: string | null
+  statusActionError: string | null
+  onSelectStatusAction: (action: PortingRequestStatusActionDto) => void
+  onStatusReasonChange: (value: string) => void
+  onStatusCommentChange: (value: string) => void
+  onSubmitStatusAction: () => void
+  onResetStatusActionForm: () => void
+
+  canUseManualPortDateAction: boolean
+  canUseManualPortDateForCurrentStatus: boolean
+  manualConfirmedPortDate: string
+  manualPortDateComment: string
+  isSubmittingManualPortDate: boolean
+  manualPortDateSuccess: string | null
+  manualPortDateError: string | null
+  onManualConfirmedPortDateChange: (value: string) => void
+  onManualPortDateCommentChange: (value: string) => void
+  onConfirmManualPortDate: () => void
+
+  pliCbdExternalActionsSlot?: React.ReactNode
+}
+
+export function RequestWorkflowActionsSection({
+  canManageStatus,
+  statusInternal,
+  canUsePliCbdExternalActions,
+  workflowErrorEmptyStateMessage,
+  availableStatusActions,
+  selectedStatusAction,
+  statusReason,
+  statusComment,
+  isUpdatingStatus,
+  isExporting,
+  isSyncing,
+  statusActionSuccess,
+  statusActionError,
+  onSelectStatusAction,
+  onStatusReasonChange,
+  onStatusCommentChange,
+  onSubmitStatusAction,
+  onResetStatusActionForm,
+  canUseManualPortDateAction,
+  canUseManualPortDateForCurrentStatus,
+  manualConfirmedPortDate,
+  manualPortDateComment,
+  isSubmittingManualPortDate,
+  manualPortDateSuccess,
+  manualPortDateError,
+  onManualConfirmedPortDateChange,
+  onManualPortDateCommentChange,
+  onConfirmManualPortDate,
+  pliCbdExternalActionsSlot,
+}: RequestWorkflowActionsSectionProps) {
+  return (
+    <section id="workflow-actions" className="panel scroll-mt-6 p-4">
+      <div className="mb-3 flex items-start gap-3">
+        <div className="min-w-0">
+          <h2 className="break-words text-sm font-semibold text-ink-900">Akcje statusu</h2>
+          <p className="mt-1 break-words text-sm leading-6 text-ink-500">
+            Dostępne przejścia wynikają z aktualnego statusu sprawy i uprawnień operatora.
+          </p>
+        </div>
+      </div>
+
+      {canManageStatus ? (
+        <div className="space-y-4">
+          {availableStatusActions.length > 0 ? (
+            <div className="space-y-3">
+              <div className="flex flex-wrap gap-2">
+                {availableStatusActions.map((action) => (
+                  <button
+                    key={`${action.actionId}-${action.targetStatus}`}
+                    type="button"
+                    onClick={() => onSelectStatusAction(action)}
+                    className={
+                      selectedStatusAction?.actionId === action.actionId &&
+                      selectedStatusAction.targetStatus === action.targetStatus
+                        ? 'btn-primary'
+                        : 'btn-secondary'
+                    }
+                    disabled={isUpdatingStatus || isExporting || isSyncing}
+                  >
+                    {action.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : TERMINAL_CLOSED_STATUSES.includes(statusInternal) ? (
+            <div className="rounded-panel border border-line bg-ink-50 px-4 py-3 text-sm text-ink-500">
+              Sprawa zakoĹ„czona â€” brak dostÄ™pnych akcji statusowych.
+            </div>
+          ) : statusInternal === 'ERROR' ? (
+            <div className="rounded-panel border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {workflowErrorEmptyStateMessage}
+            </div>
+          ) : (
+            <div className="rounded-panel border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+              Brak akcji dostÄ™pnych dla Twojej roli w tym statusie sprawy.
+            </div>
+          )}
+
+          {selectedStatusAction ? (
+            <div className="space-y-3 rounded-lg border border-gray-200 bg-gray-50 p-4">
+              <div>
+                <h3 className="text-sm font-semibold text-gray-800">{selectedStatusAction.label}</h3>
+                <p className="mt-1 text-sm text-gray-500">{selectedStatusAction.description}</p>
+              </div>
+
+              {selectedStatusAction.requiresReason && (
+                <label className="block">
+                  <span className="mb-1 block text-xs font-medium text-gray-600">
+                    {selectedStatusAction.reasonLabel ?? 'Powod'}
+                  </span>
+                  <input
+                    type="text"
+                    value={statusReason}
+                    onChange={(event) => onStatusReasonChange(event.target.value)}
+                    className="input-field"
+                    placeholder={selectedStatusAction.reasonLabel ?? 'Podaj powod'}
+                  />
+                </label>
+              )}
+
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-gray-600">
+                  {selectedStatusAction.commentLabel ??
+                    (selectedStatusAction.requiresComment ? 'Komentarz' : 'Komentarz (opcjonalnie)')}
+                </span>
+                <textarea
+                  value={statusComment}
+                  onChange={(event) => onStatusCommentChange(event.target.value)}
+                  rows={selectedStatusAction.requiresComment ? 4 : 3}
+                  className="input-field"
+                  placeholder={
+                    selectedStatusAction.requiresComment
+                      ? 'Dodaj wymagany komentarz'
+                      : 'Opcjonalny komentarz operacyjny'
+                  }
+                />
+              </label>
+
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => onSubmitStatusAction()}
+                  className="btn-primary"
+                  disabled={isUpdatingStatus || isExporting || isSyncing}
+                >
+                  {isUpdatingStatus ? 'Zapis statusu' : selectedStatusAction.label}
+                </button>
+                <button
+                  type="button"
+                  onClick={onResetStatusActionForm}
+                  className="btn-secondary"
+                  disabled={isUpdatingStatus}
+                >
+                  Wyczysc
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+              Wybierz akcje, aby zmienic status sprawy.
+            </div>
+          )}
+
+          {statusActionSuccess && (
+            <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+              {statusActionSuccess}
+            </div>
+          )}
+
+          {statusActionError && (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {statusActionError}
+            </div>
+          )}
+
+          {canUseManualPortDateAction && (
+            <div className="space-y-3 rounded-lg border border-sky-200 bg-sky-50/60 p-4">
+              <div>
+                <h3 className="text-sm font-semibold text-sky-900">Potwierdz date przeniesienia</h3>
+                <p className="mt-1 text-sm text-sky-800">
+                  To zapisuje krok procesu i dodaje zdarzenie w historii sprawy. To nie jest
+                  zwykla edycja pola daty — daty pokazane w sekcji Terminy sa read-only i
+                  zmienia je dopiero ta akcja procesowa.
+                </p>
+              </div>
+
+              {canUseManualPortDateForCurrentStatus ? (
+                <>
+                  <label className="block">
+                    <span className="mb-1 block text-xs font-medium text-sky-900">
+                      Data przeniesienia
+                    </span>
+                    <input
+                      type="date"
+                      value={manualConfirmedPortDate}
+                      onChange={(event) => onManualConfirmedPortDateChange(event.target.value)}
+                      className="input-field"
+                      disabled={
+                        isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
+                      }
+                    />
+                  </label>
+
+                  <label className="block">
+                    <span className="mb-1 block text-xs font-medium text-sky-900">
+                      Komentarz operacyjny (opcjonalnie)
+                    </span>
+                    <textarea
+                      value={manualPortDateComment}
+                      onChange={(event) => onManualPortDateCommentChange(event.target.value)}
+                      rows={3}
+                      className="input-field"
+                      placeholder="Dodaj komentarz do historii operacyjnej"
+                      disabled={
+                        isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
+                      }
+                    />
+                  </label>
+
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onConfirmManualPortDate()}
+                      className="btn-primary"
+                      disabled={
+                        isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
+                      }
+                    >
+                      {isSubmittingManualPortDate
+                        ? 'Zapisywanie potwierdzenia'
+                        : 'Potwierdz date przeniesienia'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onManualPortDateCommentChange('')}
+                      className="btn-secondary"
+                      disabled={isSubmittingManualPortDate}
+                    >
+                      Wyczysc komentarz
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <div className="rounded-panel border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+                  Akcja dostepna tylko dla statusow: Zlozona, Oczekuje na dawce, Potwierdzona.
+                </div>
+              )}
+
+              {manualPortDateSuccess && (
+                <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+                  {manualPortDateSuccess}
+                </div>
+              )}
+
+              {manualPortDateError && (
+                <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                  {manualPortDateError}
+                </div>
+              )}
+            </div>
+          )}
+
+          {canUsePliCbdExternalActions && pliCbdExternalActionsSlot}
+        </div>
+      ) : (
+        <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+          Twoja rola ma dostep tylko do podgladu sprawy.
+        </div>
+      )}
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- Extract RequestDetailPage workflow/status actions section into a dedicated presentational component.
- Keep workflow state, handlers and API calls in RequestDetailPage.
- Add focused component tests for workflow actions rendering and interactions.
- Preserve current UI behavior and copy.

## Scope
- Frontend-only refactor.
- No backend changes.
- No DTO changes.
- No API service changes.
- No routing changes.
- No workflow/status logic changes.
- No seed changes.
- No RequestsPage or admin screens touched.

## Changed files
- RequestDetailPage.tsx
- RequestWorkflowActionsSection.tsx
- RequestWorkflowActionsSection.test.tsx

## Preserved logic
- availableStatusActions unchanged.
- selectedStatusAction state remains in parent.
- reason/comment state remains in parent.
- status submit handler unchanged.
- manual confirm port date handler unchanged.
- updatePortingRequestPortDate unchanged.
- assignment/commercial owner unchanged.
- communication actions unchanged.
- notification retry unchanged.
- PLI CBD gates unchanged.
- routing by caseNumber unchanged.

## Validation
- npm run type-check --workspace apps/frontend — PASS
- npm run test --workspace apps/frontend — PASS, 46 files / 342 tests
- npm run build --workspace apps/frontend — PASS

## Manual QA focus
- FNP-SEED-NO-DATE-001: manual confirm port date section still renders and works.
- FNP-SEED-PORTED-001: terminal closed empty state still renders.
- FNP-SEED-ERROR-001: ERROR workflow message still renders.
- A PLI CBD case: external actions slot still renders inside workflow section.
- Scroll to workflow-actions still works.