### PR TITLE
fix(frontend): improve request hero and status-aware urgency

### DIFF
--- a/apps/frontend/src/lib/portingUrgency.test.ts
+++ b/apps/frontend/src/lib/portingUrgency.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { calculateDaysDiff, getPortingUrgency, getWorkPriorityBadge } from './portingUrgency'
+import {
+  calculateDaysDiff,
+  getPortingUrgency,
+  getStatusAwarePortingUrgency,
+  getStatusAwareWorkPriorityBadge,
+  getWorkPriorityBadge,
+} from './portingUrgency'
 
 // NOW = wtorek 2026-04-21, godz. 11:00 Warsaw (09:00 UTC)
 // ISO week: pon 2026-04-20 - ndz 2026-04-26
@@ -153,5 +159,72 @@ describe('getWorkPriorityBadge', () => {
     expect(badge?.label).toBe('W tym tygodniu')
     expect(badge?.tone).toBe('amber')
     expect(badge?.emphasized).toBe(false)
+  })
+})
+
+describe('getStatusAwarePortingUrgency', () => {
+  it('active status + past date => OVERDUE red', () => {
+    const urgency = getStatusAwarePortingUrgency('2026-04-20', 'SUBMITTED', NOW)
+    expect(urgency.level).toBe('OVERDUE')
+    expect(urgency.tone).toBe('red')
+    expect(urgency.emphasized).toBe(true)
+    expect(urgency.label).toContain('Po terminie')
+  })
+
+  it('PORTED + past date => not OVERDUE, emerald, not emphasized', () => {
+    const urgency = getStatusAwarePortingUrgency('2026-04-20', 'PORTED', NOW)
+    expect(urgency.level).not.toBe('OVERDUE')
+    expect(urgency.tone).toBe('emerald')
+    expect(urgency.emphasized).toBe(false)
+    expect(urgency.label).not.toContain('Po terminie')
+  })
+
+  it('CANCELLED + past date => not red OVERDUE', () => {
+    const urgency = getStatusAwarePortingUrgency('2026-04-15', 'CANCELLED', NOW)
+    expect(urgency.tone).not.toBe('red')
+    expect(urgency.label).not.toContain('Po terminie')
+  })
+
+  it('REJECTED + past date => not red OVERDUE', () => {
+    const urgency = getStatusAwarePortingUrgency('2026-04-10', 'REJECTED', NOW)
+    expect(urgency.tone).not.toBe('red')
+    expect(urgency.label).not.toContain('Po terminie')
+  })
+
+  it('PENDING_DONOR + past date => still OVERDUE', () => {
+    const urgency = getStatusAwarePortingUrgency('2026-04-19', 'PENDING_DONOR', NOW)
+    expect(urgency.level).toBe('OVERDUE')
+    expect(urgency.tone).toBe('red')
+  })
+
+  it('CONFIRMED + past date => still OVERDUE', () => {
+    const urgency = getStatusAwarePortingUrgency('2026-04-18', 'CONFIRMED', NOW)
+    expect(urgency.level).toBe('OVERDUE')
+    expect(urgency.tone).toBe('red')
+  })
+})
+
+describe('getStatusAwareWorkPriorityBadge', () => {
+  it('active status + past date => OVERDUE badge', () => {
+    const badge = getStatusAwareWorkPriorityBadge('2026-04-20', 'SUBMITTED', NOW)
+    expect(badge?.bucket).toBe('OVERDUE')
+    expect(badge?.tone).toBe('red')
+  })
+
+  it('PORTED + past date => null (no badge)', () => {
+    expect(getStatusAwareWorkPriorityBadge('2026-04-20', 'PORTED', NOW)).toBeNull()
+  })
+
+  it('CANCELLED + past date => null', () => {
+    expect(getStatusAwareWorkPriorityBadge('2026-04-15', 'CANCELLED', NOW)).toBeNull()
+  })
+
+  it('REJECTED + past date => null', () => {
+    expect(getStatusAwareWorkPriorityBadge('2026-04-10', 'REJECTED', NOW)).toBeNull()
+  })
+
+  it('PENDING_DONOR + past date => OVERDUE badge', () => {
+    const badge = getStatusAwareWorkPriorityBadge('2026-04-19', 'PENDING_DONOR', NOW)
+    expect(badge?.bucket).toBe('OVERDUE')
   })
 })

--- a/apps/frontend/src/lib/portingUrgency.ts
+++ b/apps/frontend/src/lib/portingUrgency.ts
@@ -3,9 +3,9 @@ import {
   calculatePortingDaysDiff,
   getPortingUrgencyLevel,
   getPortingWorkPriorityBucket,
+  type PortingCaseStatus,
   type PortingUrgencyLevel,
   type PortingWorkPriorityBucket,
-  type PortingCaseStatus,
 } from '@np-manager/shared'
 
 export type { PortingUrgencyLevel, PortingWorkPriorityBucket }
@@ -66,6 +66,18 @@ export function getWorkPriorityBadge(
   return config[bucket]
 }
 
+export function getStatusAwareWorkPriorityBadge(
+  portDateIso: string | null | undefined,
+  status: PortingCaseStatus | null | undefined,
+  now: Date = new Date(),
+): WorkPriorityBadge | null {
+  if (isClosedPortingStatus(status)) {
+    return null
+  }
+
+  return getWorkPriorityBadge(portDateIso, now)
+}
+
 export function getPortingUrgency(
   portDateIso: string | null | undefined,
   now: Date = new Date(),
@@ -106,4 +118,24 @@ export function getPortingUrgency(
     emphasized: config.emphasized,
     daysDiff,
   }
+}
+
+export function getStatusAwarePortingUrgency(
+  portDateIso: string | null | undefined,
+  status: PortingCaseStatus | null | undefined,
+  now: Date = new Date(),
+): PortingUrgency {
+  const urgency = getPortingUrgency(portDateIso, now)
+
+  if (isClosedPortingStatus(status) && urgency.level === 'OVERDUE') {
+    return {
+      ...urgency,
+      level: 'LATER',
+      label: 'Zakonczona',
+      tone: 'emerald',
+      emphasized: false,
+    }
+  }
+
+  return urgency
 }

--- a/apps/frontend/src/lib/portingUrgency.ts
+++ b/apps/frontend/src/lib/portingUrgency.ts
@@ -5,9 +5,12 @@ import {
   getPortingWorkPriorityBucket,
   type PortingUrgencyLevel,
   type PortingWorkPriorityBucket,
+  type PortingCaseStatus,
 } from '@np-manager/shared'
 
 export type { PortingUrgencyLevel, PortingWorkPriorityBucket }
+
+const CLOSED_PORTING_STATUSES: PortingCaseStatus[] = ['PORTED', 'CANCELLED', 'REJECTED']
 
 export interface PortingUrgency {
   level: PortingUrgencyLevel
@@ -15,6 +18,10 @@ export interface PortingUrgency {
   tone: BadgeTone
   emphasized: boolean
   daysDiff: number | null
+}
+
+export function isClosedPortingStatus(status: PortingCaseStatus | null | undefined): boolean {
+  return status ? CLOSED_PORTING_STATUSES.includes(status) : false
 }
 
 export function calculateDaysDiff(

--- a/apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx
@@ -144,4 +144,48 @@ describe('RequestCommandCenter', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Sprawdz notyfikacje' }))
     expect(onScrollToNotifications).toHaveBeenCalledTimes(1)
   })
+
+  it('hero-number has large font and mode chip shows "Tryb: DAY"', () => {
+    render(
+      <MemoryRouter>
+        <RequestCaseHero
+          request={BASE_REQUEST}
+          urgency={URGENCY}
+          copyLinkDone={false}
+          onBackToList={vi.fn()}
+          onCopyLink={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+
+    const heroNumber = screen.getByTestId('hero-number')
+    expect(heroNumber.className).toContain('text-4xl')
+
+    expect(screen.getByText('Tryb: DAY')).toBeDefined()
+  })
+
+  it('PORTED with past date: urgency shows emerald not red Po terminie', () => {
+    const portedUrgency: PortingUrgency = {
+      level: 'LATER',
+      label: 'Zakonczona',
+      tone: 'emerald',
+      emphasized: false,
+      daysDiff: -5,
+    }
+
+    render(
+      <MemoryRouter>
+        <RequestCaseHero
+          request={{ ...BASE_REQUEST, statusInternal: 'PORTED' as const }}
+          urgency={portedUrgency}
+          copyLinkDone={false}
+          onBackToList={vi.fn()}
+          onCopyLink={vi.fn()}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.queryByText(/Po terminie/)).toBeNull()
+    expect(screen.getByText(/Zakonczona/)).toBeDefined()
+  })
 })

--- a/apps/frontend/src/pages/Requests/RequestCommandCenter.tsx
+++ b/apps/frontend/src/pages/Requests/RequestCommandCenter.tsx
@@ -241,7 +241,7 @@ export function RequestCaseHero({
           <Badge tone={getStatusTone(statusMeta.tone)} leadingDot>
             {statusMeta.label}
           </Badge>
-          <Badge tone="brand">{PORTING_MODE_LABELS[request.portingMode]}</Badge>
+          <Badge tone="brand">Tryb: {request.portingMode}</Badge>
           <Badge
             tone={urgency.tone}
             className={urgency.emphasized ? 'ring-2' : undefined}
@@ -258,7 +258,7 @@ export function RequestCaseHero({
           </p>
           <h1
             data-testid="hero-number"
-            className="mt-1 break-all font-mono text-3xl font-bold tracking-tight text-ink-950 md:text-4xl"
+            className="mt-1 break-all font-mono text-4xl font-bold tracking-tight text-ink-950 md:text-5xl"
           >
             {request.numberDisplay}
           </h1>

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -103,7 +103,7 @@ import { RequestDetailsHistoryPanel } from '@/components/RequestDetailsHistoryPa
 import { WhatsNextPanel } from '@/components/WhatsNextPanel/WhatsNextPanel'
 import { InternalNotificationAttemptsPanel } from '@/components/InternalNotificationAttemptsPanel/InternalNotificationAttemptsPanel'
 import { NotificationFailureHistoryPanel } from '@/components/NotificationFailureHistoryPanel/NotificationFailureHistoryPanel'
-import { getPortingUrgency } from '@/lib/portingUrgency'
+import { getStatusAwarePortingUrgency } from '@/lib/portingUrgency'
 import {
   getInternalNotificationRetryErrorMessage,
   getInternalNotificationRetrySuccessMessage,
@@ -1872,7 +1872,7 @@ export function RequestDetailPage() {
     )
   }
 
-  const urgency = getPortingUrgency(request.confirmedPortDate)
+  const urgency = getStatusAwarePortingUrgency(request.confirmedPortDate, request.statusInternal)
   const hasProcessPortDateConfirm =
     canUseManualPortDateAction && canUseManualPortDateForCurrentStatus && !isRequestClosed
   // Inline edycja ukryta gdy uzytkownik ma dostep do akcji procesowej potwierdzenia daty

--- a/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
@@ -340,6 +340,29 @@ describe('RequestRow', () => {
     expect(html).toContain('Po terminie')
   })
 
+  it('does not show "Po terminie" for PORTED request with past date', () => {
+    const html = renderToStaticMarkup(
+      <table>
+        <tbody>
+          <RequestRow
+            request={makeRequest({
+              statusInternal: 'PORTED',
+              confirmedPortDate: '2020-01-01T00:00:00.000Z',
+            })}
+            onClick={() => undefined}
+            requestPath="/requests/FNP-20260409-ABC123"
+            formatDate={() => '01.01.2020'}
+            currentUserId={null}
+            canAssign={false}
+            onAssignToMe={noop}
+          />
+        </tbody>
+      </table>,
+    )
+
+    expect(html).not.toContain('Po terminie')
+  })
+
   it('shows "Bez daty" hint when confirmedPortDate is missing', () => {
     const html = renderToStaticMarkup(
       <table>

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/lib/portingOwnership'
 import { getPortingOperationalHint } from '@/lib/portingOperationalHint'
 import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
-import { getWorkPriorityBadge } from '@/lib/portingUrgency'
+import { getStatusAwareWorkPriorityBadge } from '@/lib/portingUrgency'
 import {
   assignPortingRequestToMe,
   getPortingRequests,
@@ -248,7 +248,7 @@ export function RequestRow({
   const portingDateLabel = request.confirmedPortDate
     ? formatDateValue(request.confirmedPortDate)
     : null
-  const workPriority = getWorkPriorityBadge(request.confirmedPortDate)
+  const workPriority = getStatusAwareWorkPriorityBadge(request.confirmedPortDate, request.statusInternal)
   const operationalHint = getPortingOperationalHint({
     statusInternal: request.statusInternal,
     confirmedPortDate: request.confirmedPortDate,


### PR DESCRIPTION
## Summary
- Emphasize the transferred phone number in the request hero.
- Show short porting mode chip in hero, e.g. `Tryb: DAY`.
- Make urgency display status-aware for closed cases.
- Prevent `PORTED`, `CANCELLED`, and `REJECTED` requests from showing red `Po terminie` when the port date is in the past.
- Keep active overdue cases showing `Po terminie`.

## Scope
- Frontend-only fix.
- No backend changes.
- No DTO/API changes.
- No Prisma/seed changes.
- No workflow/status transition changes.
- No notification/PLI CBD/admin changes.

## Changed files
- `apps/frontend/src/lib/portingUrgency.ts`
- `apps/frontend/src/lib/portingUrgency.test.ts`
- `apps/frontend/src/pages/Requests/RequestDetailPage.tsx`
- `apps/frontend/src/pages/Requests/RequestCommandCenter.tsx`
- `apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx`
- `apps/frontend/src/pages/Requests/RequestsPage.tsx`
- `apps/frontend/src/pages/Requests/RequestsPage.test.tsx`

## Validation
- `npm run test --workspace apps/frontend -- portingUrgency` — PASS
- `npm run test --workspace apps/frontend -- RequestCommandCenter` — PASS
- `npm run test --workspace apps/frontend -- RequestsPage` — PASS
- `npm run type-check --workspace apps/frontend` — PASS
- `npm run test --workspace apps/frontend` — PASS, 356/356
- `npm run build --workspace apps/frontend` — PASS

## Manual QA
- `FNP-SEED-LONG-DATA-001`: transferred number is much stronger in hero and short mode chip is visible.
- `PORTED` request with past date: no red `Po terminie` in hero/snapshot/list.
- Active overdue request: still shows red `Po terminie`.