### PR TITLE
test(porting): MARK_PORTED workflow test coverage - etap5f (#96)

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-request-workflow.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-request-workflow.test.ts
@@ -66,4 +66,47 @@ describe('porting-request-workflow', () => {
       ),
     ).toThrowError(/Szczegoly bledu jest wymagany/)
   })
+
+  it('MARK_PORTED is available from CONFIRMED for REVIEW_ROLES', () => {
+    for (const role of ['ADMIN', 'BACK_OFFICE', 'MANAGER'] as const) {
+      const actions = getAvailableStatusActions('CONFIRMED', role)
+      expect(actions.map((a) => a.actionId)).toContain('MARK_PORTED')
+    }
+  })
+
+  it('MARK_PORTED is not available from CONFIRMED for BOK_CONSULTANT', () => {
+    const actions = getAvailableStatusActions('CONFIRMED', 'BOK_CONSULTANT')
+    expect(actions.map((a) => a.actionId)).not.toContain('MARK_PORTED')
+  })
+
+  it('MARK_PORTED is not available from terminal statuses', () => {
+    for (const status of ['PORTED', 'CANCELLED', 'REJECTED'] as const) {
+      const actions = getAvailableStatusActions(status, 'ADMIN')
+      expect(actions.map((a) => a.actionId)).not.toContain('MARK_PORTED')
+    }
+  })
+
+  it('resolves CONFIRMED to PORTED transition for ADMIN', () => {
+    const result = resolveWorkflowTransition(
+      'CONFIRMED',
+      { targetStatus: 'PORTED' },
+      'ADMIN',
+    )
+    expect(result.config.actionId).toBe('MARK_PORTED')
+    expect(result.config.targetStatus).toBe('PORTED')
+    expect(result.reason).toBeNull()
+    expect(result.comment).toBeNull()
+  })
+
+  it('blocks CONFIRMED to PORTED for BOK_CONSULTANT', () => {
+    expect(() =>
+      resolveWorkflowTransition('CONFIRMED', { targetStatus: 'PORTED' }, 'BOK_CONSULTANT'),
+    ).toThrowError(/Twoja rola nie moze wykonac tej zmiany statusu/)
+  })
+
+  it('blocks already-PORTED request from being ported again', () => {
+    expect(() =>
+      resolveWorkflowTransition('PORTED', { targetStatus: 'PORTED' }, 'ADMIN'),
+    ).toThrowError(/Sprawa ma juz wskazany status/)
+  })
 })

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.status.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.status.service.test.ts
@@ -128,4 +128,86 @@ describe('changePortingRequestStatus', () => {
     expect(mockTransaction).not.toHaveBeenCalled()
     expect(mockLogAuditEvent).not.toHaveBeenCalled()
   })
+
+  it('MARK_PORTED sets statusInternal=PORTED and creates case history entry', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'req-1',
+      caseNumber: 'FNP-TEST-002',
+      statusInternal: 'CONFIRMED',
+    })
+
+    await changePortingRequestStatus(
+      'req-1',
+      { targetStatus: 'PORTED' },
+      'user-admin',
+      'ADMIN',
+    )
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'req-1' },
+        data: { statusInternal: 'PORTED' },
+      }),
+    )
+
+    expect(mockCaseHistoryCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          eventType: 'STATUS_CHANGED',
+          statusBefore: 'CONFIRMED',
+          statusAfter: 'PORTED',
+          metadata: {
+            actionId: 'MARK_PORTED',
+            actionLabel: 'Oznacz jako przeniesiona',
+          },
+        }),
+      }),
+    )
+
+    expect(mockLogAuditEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'STATUS_CHANGE',
+        oldValue: 'CONFIRMED',
+        newValue: 'PORTED',
+      }),
+    )
+  })
+
+  it('blocks MARK_PORTED when role is BOK_CONSULTANT', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'req-1',
+      caseNumber: 'FNP-TEST-003',
+      statusInternal: 'CONFIRMED',
+    })
+
+    await expect(
+      changePortingRequestStatus(
+        'req-1',
+        { targetStatus: 'PORTED' },
+        'user-bok',
+        'BOK_CONSULTANT',
+      ),
+    ).rejects.toThrow(/Twoja rola nie moze wykonac tej zmiany statusu/)
+
+    expect(mockTransaction).not.toHaveBeenCalled()
+  })
+
+  it('blocks MARK_PORTED when request is already PORTED', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: 'req-1',
+      caseNumber: 'FNP-TEST-004',
+      statusInternal: 'PORTED',
+    })
+
+    await expect(
+      changePortingRequestStatus(
+        'req-1',
+        { targetStatus: 'PORTED' },
+        'user-admin',
+        'ADMIN',
+      ),
+    ).rejects.toThrow(/Sprawa ma juz wskazany status/)
+
+    expect(mockTransaction).not.toHaveBeenCalled()
+  })
 })

--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.test.tsx
@@ -29,6 +29,17 @@ const ACTION_REJECT: PortingRequestStatusActionDto = {
   description: 'Odrzucenie wniosku przez dawce',
 }
 
+const ACTION_MARK_PORTED: PortingRequestStatusActionDto = {
+  actionId: 'MARK_PORTED',
+  label: 'Oznacz jako przeniesiona',
+  targetStatus: 'PORTED',
+  requiresReason: false,
+  requiresComment: false,
+  reasonLabel: null,
+  commentLabel: 'Komentarz operacyjny',
+  description: 'Zamknij sprawe jako zrealizowana.',
+}
+
 function buildProps(
   overrides: Partial<RequestWorkflowActionsSectionProps> = {},
 ): RequestWorkflowActionsSectionProps {
@@ -264,6 +275,52 @@ describe('RequestWorkflowActionsSection', () => {
     )
 
     expect(screen.queryByTestId('external-slot')).toBeNull()
+  })
+
+  it('renders MARK_PORTED action and triggers onSelectStatusAction', () => {
+    const onSelectStatusAction = vi.fn()
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          statusInternal: 'CONFIRMED',
+          availableStatusActions: [ACTION_MARK_PORTED],
+          onSelectStatusAction,
+        })}
+      />,
+    )
+
+    const button = screen.getByRole('button', { name: 'Oznacz jako przeniesiona' })
+    fireEvent.click(button)
+    expect(onSelectStatusAction).toHaveBeenCalledWith(ACTION_MARK_PORTED)
+  })
+
+  it('MARK_PORTED action shows no reason field and optional comment', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          statusInternal: 'CONFIRMED',
+          availableStatusActions: [ACTION_MARK_PORTED],
+          selectedStatusAction: ACTION_MARK_PORTED,
+        })}
+      />,
+    )
+
+    expect(screen.queryByPlaceholderText('Podaj powod')).toBeNull()
+    expect(screen.getByPlaceholderText('Opcjonalny komentarz operacyjny')).toBeDefined()
+  })
+
+  it('PORTED status shows terminal closed empty state, no action buttons', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          statusInternal: 'PORTED',
+          availableStatusActions: [],
+        })}
+      />,
+    )
+
+    expect(screen.getByText(/Sprawa zako/)).toBeDefined()
+    expect(screen.queryByRole('button', { name: 'Oznacz jako przeniesiona' })).toBeNull()
   })
 
   it('disables status action buttons when isUpdatingStatus is true', () => {


### PR DESCRIPTION
## Summary

- MARK_PORTED transition (`CONFIRMED → PORTED`) już był zaimplementowany w backendzie i frontendzie — brakowało wyłącznie pokrycia testami
- Dodano 6 testów backendowych (workflow + service) i 3 testy frontendowe (komponent)

## Decyzja architektoniczna

Funkcjonalność nie wymagała żadnych zmian kodu produkcyjnego — cały przepływ działa przez istniejące mechanizmy:
- `WORKFLOW_TRANSITIONS` ma już `MARK_PORTED` (`CONFIRMED → PORTED`, `REVIEW_ROLES`)
- `changePortingRequestStatus` obsługuje każde przejście z workflow + case history + audit
- `PATCH /:id/status` w routerze obsługuje tę akcję
- `RequestWorkflowActionsSection` renderuje `availableStatusActions` zwracane przez backend

## Testy

**Backend** (`porting-request-workflow.test.ts`):
- MARK_PORTED dostępny z CONFIRMED dla REVIEW_ROLES (ADMIN, BACK_OFFICE, MANAGER)
- MARK_PORTED niedostępny dla BOK_CONSULTANT
- MARK_PORTED niedostępny dla terminal statuses (PORTED/CANCELLED/REJECTED)
- resolveWorkflowTransition CONFIRMED→PORTED sukces dla ADMIN
- blokada BOK_CONSULTANT dla CONFIRMED→PORTED
- blokada już-PORTED sprawy

**Backend** (`porting-requests.status.service.test.ts`):
- MARK_PORTED ustawia statusInternal=PORTED i tworzy case history z metadata
- blokada BOK_CONSULTANT
- blokada już-PORTED

**Frontend** (`RequestWorkflowActionsSection.test.tsx`):
- renderuje przycisk MARK_PORTED i wywołuje onSelectStatusAction
- brak pola reason, opcjonalny komentarz
- PORTED status → terminal empty state, brak przycisku

## Manual QA checklist

- [ ] Sprawa CONFIRMED: przycisk "Oznacz jako przeniesiona" widoczny
- [ ] Kliknięcie → formularz bez reason, opcjonalny komentarz
- [ ] Po submit: statusInternal = PORTED
- [ ] Historia sprawy: wpis STATUS_CHANGED CONFIRMED→PORTED
- [ ] Hero/lista: brak czerwonego "Po terminie" dla PORTED (PR #94/#95)
- [ ] Akcja niedostępna ponownie po PORTED
- [ ] PORTED nie pojawia się w Pilne (PR #95)

## Ryzyka

Brak — żaden kod produkcyjny nie zmieniony. Testy pokrywają istniejące zachowanie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)