### PR TITLE
Etap 5H: dodaj fixture aktywnej sprawy po terminie

### DIFF
--- a/apps/backend/prisma/__tests__/seed.qa-porting-fixtures.test.ts
+++ b/apps/backend/prisma/__tests__/seed.qa-porting-fixtures.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../seed'
 
 describe('Etap 5A QA porting seed fixtures', () => {
-  it('exposes the six new QA case numbers required by audit issue #82', () => {
+  it('exposes the QA case numbers required by audit issue #82 and issue #100', () => {
     const caseNumbers = QA_ETAP5A_PORTING_FIXTURES.map((fx) => fx.caseNumber)
     expect(caseNumbers).toEqual([
       'FNP-SEED-DRAFT-001',
@@ -17,6 +17,7 @@ describe('Etap 5A QA porting seed fixtures', () => {
       'FNP-SEED-NO-ASSIGNEE-001',
       'FNP-SEED-NO-DATE-001',
       'FNP-SEED-NOTIF-FAILED-001',
+      'FNP-SEED-ACTIVE-OVERDUE-001',
     ])
   })
 
@@ -75,6 +76,22 @@ describe('Etap 5A QA porting seed fixtures', () => {
     // seed-main derives assignedAt + assignedByUserId from assigneeEmail != null
     // (regression guard: fixture must have assigneeEmail to trigger consistent assignment block)
     expect(fx?.assigneeEmail).not.toBeNull()
+  })
+
+  it('ACTIVE-OVERDUE fixture stays active and qualifies for the URGENT quick work date window', () => {
+    const fx = QA_ETAP5A_PORTING_FIXTURES.find(
+      (f) => f.caseNumber === 'FNP-SEED-ACTIVE-OVERDUE-001',
+    )
+    const closedStatuses = ['PORTED', 'CANCELLED', 'REJECTED']
+    const urgentBoundary = new Date('2026-04-27T00:00:00.000Z')
+
+    expect(fx).toBeDefined()
+    expect(fx?.statusInternal).toBe('CONFIRMED')
+    expect(fx?.confirmedPortDate).toBe('2026-04-14T00:00:00.000Z')
+    expect(closedStatuses).not.toContain(fx?.statusInternal)
+    expect(new Date(fx!.confirmedPortDate!).getTime()).toBeLessThan(
+      urgentBoundary.getTime(),
+    )
   })
 
   it('seed-main assignment block is deterministic: non-null assigneeEmail implies assignedAt + assignedByUserId', () => {

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -12,6 +12,7 @@
  *
  * Sprawy testowe:
  *  - FNP-SEED-ACTIVE-001: aktywna, pre-export (SUBMITTED)
+ *  - FNP-SEED-ACTIVE-OVERDUE-001: aktywna, CONFIRMED z data w przeszlosci do QA pilnosci
  *  - FNP-SEED-PORTED-001: zakończona po E18 (blocked)
  *  - FNP-SEED-E18-001: etap READY_TO_PORT, happy path Draft E18
  *  - FNP-SEED-COMM-DRAFT-001: detail z dostepnym "Utworz draft" dla komunikacji
@@ -288,6 +289,20 @@ export const QA_ETAP5A_PORTING_FIXTURES: readonly Etap5aPortingFixture[] = [
     rejectionReason: null,
     internalNotes:
       'Seed QA: dedykowana sprawa do listy /notifications/failures.',
+  },
+  {
+    caseNumber: 'FNP-SEED-ACTIVE-OVERDUE-001',
+    statusInternal: 'CONFIRMED',
+    donorRouting: 'PLAY',
+    primaryNumber: '221234580',
+    requestDocumentNumber: 'DOC-SEED-AOD-001',
+    confirmedPortDate: '2026-04-14T00:00:00.000Z',
+    assigneeEmail: null,
+    useLongClient: false,
+    rejectionCode: null,
+    rejectionReason: null,
+    internalNotes:
+      'Seed QA: aktywna sprawa CONFIRMED po terminie do testu czerwonego badge Po terminie i filtra Pilne.',
   },
 ]
 


### PR DESCRIPTION
1. Cel
Dodać stabilny seed/test fixture aktywnej sprawy po terminie dla QA pilności z issue #100.

2. Zakres zmian
- Dodano fixture `FNP-SEED-ACTIVE-OVERDUE-001` w istniejącej tablicy QA seedów.
- Fixture ma aktywny status `CONFIRMED` i `confirmedPortDate` w przeszłości względem przyjętych dat testowych.
- Rozszerzono test seedów o obecność fixture, status aktywny, datę oraz kwalifikację do okna `URGENT`.

3. Zmienione pliki / obszary
- `apps/backend/prisma/seed.ts`
- `apps/backend/prisma/__tests__/seed.qa-porting-fixtures.test.ts`

4. Testy i walidacja
Uruchomione:
- `npm run test --workspace apps/backend -- seed.qa-porting-fixtures` — PASS, 11/11
- `npm run type-check --workspace apps/backend` — FAIL: brak skryptu `type-check` w `apps/backend/package.json`
- `npx tsc --noEmit` w `apps/backend` — PASS
- `npm run test --workspace apps/backend` — PASS, 540/540
- `npm run build --workspace apps/backend` — PASS
- `npm run test --workspace apps/frontend` — PASS, 365/365
- `npx tsc --noEmit` w `apps/frontend` — PASS

`npm run db:seed`:
- pierwsza próba: FAIL przed wykonaniem seedów, `spawn EPERM` w esbuild/tsx
- druga próba: kod seeda wystartował, ale FAIL z powodu braku `DATABASE_URL`

5. Ryzyka / otwarte punkty
- Nie zweryfikowano realnej idempotencji na lokalnej bazie, bo środowisko nie miało `DATABASE_URL`.
- Manual QA listy/detailu wymaga uruchomienia aplikacji z bazą po `db:seed`.

6. Checklist przed merge
- [x] Minimalny diff: seed + seed tests
- [x] Bez zmian quickWorkFilter
- [x] Bez zmian frontend UI
- [x] Bez migracji
- [x] Backend test/type/build wykonane
- [x] Frontend test/type wykonane
- [ ] `db:seed` x2 na środowisku z `DATABASE_URL`
- [ ] Manual QA `/requests` i detail po seedzie