### PR TITLE
feat(backend): confirmedPortDate filter + column sort for porting list (#102)

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
@@ -724,20 +724,30 @@ describe('listPortingRequests - column sorting (Etap 5I-A)', () => {
     expect(findManyOrderBy()).toEqual({ createdAt: 'desc' })
   })
 
-  it('NUMBER_ASC sorts by caseNumber asc with stable id tiebreaker', async () => {
+  it('NUMBER_ASC sorts by ported number (primaryNumber/rangeStart/rangeEnd) asc, nulls last', async () => {
     await listPortingRequests(
       { sort: 'NUMBER_ASC', page: 1, pageSize: 20 },
       CURRENT_USER_ID,
     )
-    expect(findManyOrderBy()).toEqual([{ caseNumber: 'asc' }, { id: 'asc' }])
+    expect(findManyOrderBy()).toEqual([
+      { primaryNumber: { sort: 'asc', nulls: 'last' } },
+      { rangeStart: { sort: 'asc', nulls: 'last' } },
+      { rangeEnd: { sort: 'asc', nulls: 'last' } },
+      { id: 'asc' },
+    ])
   })
 
-  it('NUMBER_DESC sorts by caseNumber desc', async () => {
+  it('NUMBER_DESC sorts by ported number desc, nulls last', async () => {
     await listPortingRequests(
       { sort: 'NUMBER_DESC', page: 1, pageSize: 20 },
       CURRENT_USER_ID,
     )
-    expect(findManyOrderBy()).toEqual([{ caseNumber: 'desc' }, { id: 'asc' }])
+    expect(findManyOrderBy()).toEqual([
+      { primaryNumber: { sort: 'desc', nulls: 'last' } },
+      { rangeStart: { sort: 'desc', nulls: 'last' } },
+      { rangeEnd: { sort: 'desc', nulls: 'last' } },
+      { id: 'asc' },
+    ])
   })
 
   it('STATUS_ASC sorts by statusInternal asc', async () => {

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
@@ -573,6 +573,291 @@ describe('listPortingRequests - WORK_PRIORITY sort (PR50B)', () => {
   })
 })
 
+describe('listPortingRequests - confirmedPortDate filter (Etap 5I-A)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockPrismaTransaction.mockImplementation(async (arg: unknown) => {
+      if (Array.isArray(arg)) return Promise.all(arg)
+      return undefined
+    })
+
+    mockPortingRequestCount.mockResolvedValue(0)
+    mockPortingRequestFindMany.mockResolvedValue([])
+  })
+
+  it('confirmedPortDateFrom builds AND with gte', async () => {
+    await listPortingRequests(
+      { confirmedPortDateFrom: '2026-04-15', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    const where = (mockPortingRequestCount.mock.calls[0]?.[0] as { where: Record<string, unknown> }).where
+    const andClauses = where.AND as Array<Record<string, unknown>>
+    expect(andClauses).toContainEqual({
+      confirmedPortDate: { gte: new Date('2026-04-15T00:00:00.000Z') },
+    })
+  })
+
+  it('confirmedPortDateTo builds AND with lte', async () => {
+    await listPortingRequests(
+      { confirmedPortDateTo: '2026-04-30', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    const where = (mockPortingRequestCount.mock.calls[0]?.[0] as { where: Record<string, unknown> }).where
+    const andClauses = where.AND as Array<Record<string, unknown>>
+    expect(andClauses).toContainEqual({
+      confirmedPortDate: { lte: new Date('2026-04-30T00:00:00.000Z') },
+    })
+  })
+
+  it('confirmedPortDateFrom + confirmedPortDateTo builds AND with gte+lte range', async () => {
+    await listPortingRequests(
+      {
+        confirmedPortDateFrom: '2026-04-15',
+        confirmedPortDateTo: '2026-04-30',
+        page: 1,
+        pageSize: 20,
+      },
+      CURRENT_USER_ID,
+    )
+
+    const where = (mockPortingRequestCount.mock.calls[0]?.[0] as { where: Record<string, unknown> }).where
+    const andClauses = where.AND as Array<Record<string, unknown>>
+    expect(andClauses).toContainEqual({
+      confirmedPortDate: {
+        gte: new Date('2026-04-15T00:00:00.000Z'),
+        lte: new Date('2026-04-30T00:00:00.000Z'),
+      },
+    })
+  })
+
+  it('confirmedPortDateFrom == confirmedPortDateTo filters single day', async () => {
+    await listPortingRequests(
+      {
+        confirmedPortDateFrom: '2026-04-22',
+        confirmedPortDateTo: '2026-04-22',
+        page: 1,
+        pageSize: 20,
+      },
+      CURRENT_USER_ID,
+    )
+
+    const where = (mockPortingRequestCount.mock.calls[0]?.[0] as { where: Record<string, unknown> }).where
+    const andClauses = where.AND as Array<Record<string, unknown>>
+    expect(andClauses).toContainEqual({
+      confirmedPortDate: {
+        gte: new Date('2026-04-22T00:00:00.000Z'),
+        lte: new Date('2026-04-22T00:00:00.000Z'),
+      },
+    })
+  })
+
+  it('confirmedPortDate filter composes with quickWorkFilter without overwriting', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-21T09:00:00.000Z'))
+
+    try {
+      await listPortingRequests(
+        {
+          quickWorkFilter: 'NEEDS_ACTION_TODAY',
+          confirmedPortDateFrom: '2026-04-15',
+          page: 1,
+          pageSize: 20,
+        },
+        CURRENT_USER_ID,
+      )
+
+      const where = (mockPortingRequestCount.mock.calls[0]?.[0] as {
+        where: Record<string, unknown>
+      }).where
+
+      // quickWorkFilter sets where.confirmedPortDate directly
+      expect(where).toMatchObject({
+        confirmedPortDate: { lt: new Date('2026-04-22T00:00:00.000Z') },
+      })
+
+      const andClauses = where.AND as Array<Record<string, unknown>>
+      // quickWorkFilter pushes status exclusion
+      expect(andClauses).toContainEqual({
+        statusInternal: { notIn: ['REJECTED', 'CANCELLED', 'PORTED'] },
+      })
+      // date filter pushed in AND alongside
+      expect(andClauses).toContainEqual({
+        confirmedPortDate: { gte: new Date('2026-04-15T00:00:00.000Z') },
+      })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('listPortingRequests - column sorting (Etap 5I-A)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockPrismaTransaction.mockImplementation(async (arg: unknown) => {
+      if (Array.isArray(arg)) return Promise.all(arg)
+      return undefined
+    })
+
+    mockPortingRequestCount.mockResolvedValue(0)
+    mockPortingRequestFindMany.mockResolvedValue([])
+  })
+
+  function findManyOrderBy(): unknown {
+    const call = mockPortingRequestFindMany.mock.calls[0]?.[0] as { orderBy: unknown }
+    return call.orderBy
+  }
+
+  it('default sort (no sort param) is createdAt desc', async () => {
+    await listPortingRequests({ page: 1, pageSize: 20 }, CURRENT_USER_ID)
+    expect(findManyOrderBy()).toEqual({ createdAt: 'desc' })
+  })
+
+  it('CREATED_AT_DESC sort is createdAt desc', async () => {
+    await listPortingRequests(
+      { sort: 'CREATED_AT_DESC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual({ createdAt: 'desc' })
+  })
+
+  it('NUMBER_ASC sorts by caseNumber asc with stable id tiebreaker', async () => {
+    await listPortingRequests(
+      { sort: 'NUMBER_ASC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([{ caseNumber: 'asc' }, { id: 'asc' }])
+  })
+
+  it('NUMBER_DESC sorts by caseNumber desc', async () => {
+    await listPortingRequests(
+      { sort: 'NUMBER_DESC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([{ caseNumber: 'desc' }, { id: 'asc' }])
+  })
+
+  it('STATUS_ASC sorts by statusInternal asc', async () => {
+    await listPortingRequests(
+      { sort: 'STATUS_ASC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([{ statusInternal: 'asc' }, { id: 'asc' }])
+  })
+
+  it('STATUS_DESC sorts by statusInternal desc', async () => {
+    await listPortingRequests(
+      { sort: 'STATUS_DESC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([{ statusInternal: 'desc' }, { id: 'asc' }])
+  })
+
+  it('CONFIRMED_PORT_DATE_ASC sorts by confirmedPortDate asc with nulls last', async () => {
+    await listPortingRequests(
+      { sort: 'CONFIRMED_PORT_DATE_ASC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([
+      { confirmedPortDate: { sort: 'asc', nulls: 'last' } },
+      { createdAt: 'desc' },
+      { id: 'asc' },
+    ])
+  })
+
+  it('CONFIRMED_PORT_DATE_DESC sorts by confirmedPortDate desc with nulls last', async () => {
+    await listPortingRequests(
+      { sort: 'CONFIRMED_PORT_DATE_DESC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([
+      { confirmedPortDate: { sort: 'desc', nulls: 'last' } },
+      { createdAt: 'desc' },
+      { id: 'asc' },
+    ])
+  })
+
+  it('DONOR_OPERATOR_ASC sorts by donorOperator name asc', async () => {
+    await listPortingRequests(
+      { sort: 'DONOR_OPERATOR_ASC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([{ donorOperator: { name: 'asc' } }, { id: 'asc' }])
+  })
+
+  it('PORTING_MODE_DESC sorts by portingMode desc', async () => {
+    await listPortingRequests(
+      { sort: 'PORTING_MODE_DESC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([{ portingMode: 'desc' }, { id: 'asc' }])
+  })
+
+  it('ASSIGNED_USER_ASC sorts by assignedUser lastName then firstName asc', async () => {
+    await listPortingRequests(
+      { sort: 'ASSIGNED_USER_ASC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([
+      { assignedUser: { lastName: 'asc' } },
+      { assignedUser: { firstName: 'asc' } },
+      { id: 'asc' },
+    ])
+  })
+
+  it('COMMERCIAL_OWNER_DESC sorts by commercialOwner lastName then firstName desc', async () => {
+    await listPortingRequests(
+      { sort: 'COMMERCIAL_OWNER_DESC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([
+      { commercialOwner: { lastName: 'desc' } },
+      { commercialOwner: { firstName: 'desc' } },
+      { id: 'asc' },
+    ])
+  })
+
+  it('CLIENT_ASC sorts by client companyName then lastName then firstName asc', async () => {
+    await listPortingRequests(
+      { sort: 'CLIENT_ASC', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+    expect(findManyOrderBy()).toEqual([
+      { client: { companyName: 'asc' } },
+      { client: { lastName: 'asc' } },
+      { client: { firstName: 'asc' } },
+      { id: 'asc' },
+    ])
+  })
+
+  it('WORK_PRIORITY sort uses candidates select shape, not column orderBy', async () => {
+    mockPortingRequestFindMany.mockResolvedValueOnce([
+      { id: 'r-1', confirmedPortDate: null, createdAt: new Date('2026-04-01T10:00:00.000Z') },
+    ])
+    mockPortingRequestFindMany.mockResolvedValueOnce([makeListRow({ id: 'r-1' })])
+
+    await listPortingRequests(
+      { sort: 'WORK_PRIORITY', page: 1, pageSize: 20 },
+      CURRENT_USER_ID,
+    )
+
+    expect(mockPortingRequestFindMany).toHaveBeenCalledTimes(2)
+    const candidatesCall = mockPortingRequestFindMany.mock.calls[0]?.[0] as {
+      select: Record<string, unknown>
+      orderBy?: unknown
+    }
+    expect(candidatesCall.select).toMatchObject({
+      id: true,
+      confirmedPortDate: true,
+      createdAt: true,
+    })
+    expect(candidatesCall.orderBy).toBeUndefined()
+  })
+})
+
 describe('getPortingRequestsOperationalSummary', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.schema.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.schema.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  portingRequestListQuerySchema,
+  portingRequestSummaryQuerySchema,
+} from '../porting-requests.schema'
+
+describe('portingRequestListQuerySchema - confirmedPortDate range validation', () => {
+  it('accepts valid range (from < to)', () => {
+    expect(() =>
+      portingRequestListQuerySchema.parse({
+        confirmedPortDateFrom: '2026-04-15',
+        confirmedPortDateTo: '2026-04-30',
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts same-day range (from === to)', () => {
+    expect(() =>
+      portingRequestListQuerySchema.parse({
+        confirmedPortDateFrom: '2026-04-22',
+        confirmedPortDateTo: '2026-04-22',
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts from only', () => {
+    expect(() =>
+      portingRequestListQuerySchema.parse({ confirmedPortDateFrom: '2026-04-15' }),
+    ).not.toThrow()
+  })
+
+  it('accepts to only', () => {
+    expect(() =>
+      portingRequestListQuerySchema.parse({ confirmedPortDateTo: '2026-04-30' }),
+    ).not.toThrow()
+  })
+
+  it('rejects inverted range (from > to) with expected message', () => {
+    const result = portingRequestListQuerySchema.safeParse({
+      confirmedPortDateFrom: '2026-04-30',
+      confirmedPortDateTo: '2026-04-15',
+    })
+    expect(result.success).toBe(false)
+    const issue = result.error?.issues.find((i) => i.path.includes('confirmedPortDateTo'))
+    expect(issue?.message).toBe('Data koncowa nie moze byc wczesniejsza niz data poczatkowa.')
+  })
+})
+
+describe('portingRequestSummaryQuerySchema - confirmedPortDate range validation', () => {
+  it('accepts valid range (from < to)', () => {
+    expect(() =>
+      portingRequestSummaryQuerySchema.parse({
+        confirmedPortDateFrom: '2026-04-15',
+        confirmedPortDateTo: '2026-04-30',
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts same-day range (from === to)', () => {
+    expect(() =>
+      portingRequestSummaryQuerySchema.parse({
+        confirmedPortDateFrom: '2026-04-22',
+        confirmedPortDateTo: '2026-04-22',
+      }),
+    ).not.toThrow()
+  })
+
+  it('rejects inverted range (from > to) with expected message', () => {
+    const result = portingRequestSummaryQuerySchema.safeParse({
+      confirmedPortDateFrom: '2026-04-30',
+      confirmedPortDateTo: '2026-04-15',
+    })
+    expect(result.success).toBe(false)
+    const issue = result.error?.issues.find((i) => i.path.includes('confirmedPortDateTo'))
+    expect(issue?.message).toBe('Data koncowa nie moze byc wczesniejsza niz data poczatkowa.')
+  })
+})

--- a/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
@@ -58,6 +58,20 @@ const statusEnum = z.enum([
   'ERROR',
 ])
 
+function refineDateRange(
+  data: { confirmedPortDateFrom?: string; confirmedPortDateTo?: string },
+  ctx: z.RefinementCtx,
+): void {
+  if (data.confirmedPortDateFrom && data.confirmedPortDateTo &&
+      data.confirmedPortDateFrom > data.confirmedPortDateTo) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['confirmedPortDateTo'],
+      message: 'Data koncowa nie moze byc wczesniejsza niz data poczatkowa.',
+    })
+  }
+}
+
 const ownershipFilterEnum = z.enum(['ALL', 'MINE', 'UNASSIGNED'])
 const commercialOwnerFilterEnum = z.enum(['ALL', 'WITH_OWNER', 'WITHOUT_OWNER', 'MINE'])
 const notificationHealthFilterEnum = z.enum(['ALL', 'HAS_FAILURES', 'NO_FAILURES'])
@@ -444,16 +458,7 @@ export const portingRequestListQuerySchema = z.object({
   sort: listSortEnum.optional().default('CREATED_AT_DESC'),
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(100).default(20),
-}).superRefine((data, ctx) => {
-  if (data.confirmedPortDateFrom && data.confirmedPortDateTo &&
-      data.confirmedPortDateFrom > data.confirmedPortDateTo) {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ['confirmedPortDateTo'],
-      message: 'Data koncowa nie moze byc wczesniejsza niz data poczatkowa.',
-    })
-  }
-})
+}).superRefine(refineDateRange)
 
 export type PortingRequestListQuery = z.input<typeof portingRequestListQuerySchema>
 
@@ -467,7 +472,7 @@ export const portingRequestSummaryQuerySchema = z.object({
   notificationHealthFilter: notificationHealthFilterEnum.optional().default('ALL'),
   confirmedPortDateFrom: optionalDateOnlySchema,
   confirmedPortDateTo: optionalDateOnlySchema,
-})
+}).superRefine(refineDateRange)
 
 export type PortingRequestSummaryQuery = z.input<typeof portingRequestSummaryQuerySchema>
 

--- a/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
@@ -62,7 +62,26 @@ const ownershipFilterEnum = z.enum(['ALL', 'MINE', 'UNASSIGNED'])
 const commercialOwnerFilterEnum = z.enum(['ALL', 'WITH_OWNER', 'WITHOUT_OWNER', 'MINE'])
 const notificationHealthFilterEnum = z.enum(['ALL', 'HAS_FAILURES', 'NO_FAILURES'])
 const quickWorkFilterEnum = z.enum(['URGENT', 'NO_DATE', 'NEEDS_ACTION_TODAY'])
-const listSortEnum = z.enum(['CREATED_AT_DESC', 'WORK_PRIORITY'])
+const listSortEnum = z.enum([
+  'CREATED_AT_DESC',
+  'WORK_PRIORITY',
+  'NUMBER_ASC',
+  'NUMBER_DESC',
+  'CLIENT_ASC',
+  'CLIENT_DESC',
+  'STATUS_ASC',
+  'STATUS_DESC',
+  'CONFIRMED_PORT_DATE_ASC',
+  'CONFIRMED_PORT_DATE_DESC',
+  'DONOR_OPERATOR_ASC',
+  'DONOR_OPERATOR_DESC',
+  'PORTING_MODE_ASC',
+  'PORTING_MODE_DESC',
+  'ASSIGNED_USER_ASC',
+  'ASSIGNED_USER_DESC',
+  'COMMERCIAL_OWNER_ASC',
+  'COMMERCIAL_OWNER_DESC',
+])
 
 function validateDeferredEarliestDate(
   value: string | undefined,
@@ -420,18 +439,34 @@ export const portingRequestListQuerySchema = z.object({
   quickWorkFilter: quickWorkFilterEnum.optional(),
   commercialOwnerFilter: commercialOwnerFilterEnum.optional().default('ALL'),
   notificationHealthFilter: notificationHealthFilterEnum.optional().default('ALL'),
+  confirmedPortDateFrom: optionalDateOnlySchema,
+  confirmedPortDateTo: optionalDateOnlySchema,
   sort: listSortEnum.optional().default('CREATED_AT_DESC'),
   page: z.coerce.number().int().min(1).default(1),
   pageSize: z.coerce.number().int().min(1).max(100).default(20),
+}).superRefine((data, ctx) => {
+  if (data.confirmedPortDateFrom && data.confirmedPortDateTo &&
+      data.confirmedPortDateFrom > data.confirmedPortDateTo) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['confirmedPortDateTo'],
+      message: 'Data koncowa nie moze byc wczesniejsza niz data poczatkowa.',
+    })
+  }
 })
 
 export type PortingRequestListQuery = z.input<typeof portingRequestListQuerySchema>
 
-export const portingRequestSummaryQuerySchema = portingRequestListQuerySchema.omit({
-  quickWorkFilter: true,
-  sort: true,
-  page: true,
-  pageSize: true,
+export const portingRequestSummaryQuerySchema = z.object({
+  search: z.string().trim().max(200).optional(),
+  status: statusEnum.optional(),
+  portingMode: z.enum(['DAY', 'END', 'EOP']).optional(),
+  donorOperatorId: z.string().uuid().optional(),
+  ownership: ownershipFilterEnum.optional().default('ALL'),
+  commercialOwnerFilter: commercialOwnerFilterEnum.optional().default('ALL'),
+  notificationHealthFilter: notificationHealthFilterEnum.optional().default('ALL'),
+  confirmedPortDateFrom: optionalDateOnlySchema,
+  confirmedPortDateTo: optionalDateOnlySchema,
 })
 
 export type PortingRequestSummaryQuery = z.input<typeof portingRequestSummaryQuerySchema>

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -382,8 +382,15 @@ function buildPortingRequestListOrderBy(
 
   switch (sort) {
     case 'NUMBER_ASC':
-    case 'NUMBER_DESC':
-      return [{ caseNumber: dirOf(sort) }, stable]
+    case 'NUMBER_DESC': {
+      const dir = dirOf(sort)
+      return [
+        { primaryNumber: { sort: dir, nulls: 'last' } },
+        { rangeStart: { sort: dir, nulls: 'last' } },
+        { rangeEnd: { sort: dir, nulls: 'last' } },
+        stable,
+      ]
+    }
     case 'CLIENT_ASC':
     case 'CLIENT_DESC': {
       const dir = dirOf(sort)

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -346,6 +346,93 @@ function toDateOnlyValue(value?: string): Date | undefined {
   return new Date(`${value}T00:00:00.000Z`)
 }
 
+function buildConfirmedPortDateFilterWhere(
+  query: PortingRequestListQuery | PortingRequestSummaryQuery,
+): Prisma.PortingRequestWhereInput | null {
+  const from = typeof query.confirmedPortDateFrom === 'string' ? query.confirmedPortDateFrom : undefined
+  const to = typeof query.confirmedPortDateTo === 'string' ? query.confirmedPortDateTo : undefined
+  if (!from && !to) {
+    return null
+  }
+  const constraint: Prisma.DateTimeNullableFilter = {}
+  if (from) {
+    const fromDate = toDateOnlyValue(from)
+    if (fromDate) constraint.gte = fromDate
+  }
+  if (to) {
+    const toDate = toDateOnlyValue(to)
+    if (toDate) constraint.lte = toDate
+  }
+  if (constraint.gte === undefined && constraint.lte === undefined) {
+    return null
+  }
+  return { confirmedPortDate: constraint }
+}
+
+type SortOrder = 'asc' | 'desc'
+
+function buildPortingRequestListOrderBy(
+  sort: PortingRequestListQuery['sort'],
+):
+  | Prisma.PortingRequestOrderByWithRelationInput
+  | Prisma.PortingRequestOrderByWithRelationInput[] {
+  const stable = { id: 'asc' as const }
+
+  const dirOf = (s: string): SortOrder => (s.endsWith('_DESC') ? 'desc' : 'asc')
+
+  switch (sort) {
+    case 'NUMBER_ASC':
+    case 'NUMBER_DESC':
+      return [{ caseNumber: dirOf(sort) }, stable]
+    case 'CLIENT_ASC':
+    case 'CLIENT_DESC': {
+      const dir = dirOf(sort)
+      return [
+        { client: { companyName: dir } },
+        { client: { lastName: dir } },
+        { client: { firstName: dir } },
+        stable,
+      ]
+    }
+    case 'STATUS_ASC':
+    case 'STATUS_DESC':
+      return [{ statusInternal: dirOf(sort) }, stable]
+    case 'CONFIRMED_PORT_DATE_ASC':
+    case 'CONFIRMED_PORT_DATE_DESC':
+      return [
+        { confirmedPortDate: { sort: dirOf(sort), nulls: 'last' } },
+        { createdAt: 'desc' },
+        stable,
+      ]
+    case 'DONOR_OPERATOR_ASC':
+    case 'DONOR_OPERATOR_DESC':
+      return [{ donorOperator: { name: dirOf(sort) } }, stable]
+    case 'PORTING_MODE_ASC':
+    case 'PORTING_MODE_DESC':
+      return [{ portingMode: dirOf(sort) }, stable]
+    case 'ASSIGNED_USER_ASC':
+    case 'ASSIGNED_USER_DESC': {
+      const dir = dirOf(sort)
+      return [
+        { assignedUser: { lastName: dir } },
+        { assignedUser: { firstName: dir } },
+        stable,
+      ]
+    }
+    case 'COMMERCIAL_OWNER_ASC':
+    case 'COMMERCIAL_OWNER_DESC': {
+      const dir = dirOf(sort)
+      return [
+        { commercialOwner: { lastName: dir } },
+        { commercialOwner: { firstName: dir } },
+        stable,
+      ]
+    }
+    default:
+      return { createdAt: 'desc' }
+  }
+}
+
 function buildQuickWorkFilterWhere(
   quickWorkFilter: PortingRequestListQuery['quickWorkFilter'],
 ): Prisma.PortingRequestWhereInput | null {
@@ -943,12 +1030,14 @@ export async function listPortingRequests(
     return listPortingRequestsByWorkPriority(where, page, pageSize)
   }
 
+  const orderBy = buildPortingRequestListOrderBy(sort)
+
   const [total, requests] = await prisma.$transaction([
     prisma.portingRequest.count({ where }),
     prisma.portingRequest.findMany({
       where,
       select: LIST_SELECT,
-      orderBy: { createdAt: 'desc' },
+      orderBy,
       skip: (page - 1) * pageSize,
       take: pageSize,
     }),
@@ -1097,6 +1186,14 @@ function buildPortingRequestListWhere(
     } else if (query.notificationHealthFilter === 'NO_FAILURES') {
       where.events = { none: NOTIFICATION_FAILURE_EVENT_WHERE }
     }
+  }
+
+  const confirmedPortDateFilterWhere = buildConfirmedPortDateFilterWhere(query)
+  if (confirmedPortDateFilterWhere) {
+    where.AND = [
+      ...(Array.isArray(where.AND) ? where.AND : []),
+      confirmedPortDateFilterWhere,
+    ]
   }
 
   if (query.search?.trim()) {

--- a/packages/shared/src/dto/porting-requests.dto.ts
+++ b/packages/shared/src/dto/porting-requests.dto.ts
@@ -27,7 +27,25 @@ export type OwnershipFilter = 'ALL' | 'MINE' | 'UNASSIGNED'
 export type CommercialOwnerFilter = 'ALL' | 'WITH_OWNER' | 'WITHOUT_OWNER' | 'MINE'
 export type NotificationHealthFilter = 'ALL' | 'HAS_FAILURES' | 'NO_FAILURES'
 export type PortingRequestQuickWorkFilter = 'URGENT' | 'NO_DATE' | 'NEEDS_ACTION_TODAY'
-export type PortingRequestListSort = 'CREATED_AT_DESC' | 'WORK_PRIORITY'
+export type PortingRequestListSort =
+  | 'CREATED_AT_DESC'
+  | 'WORK_PRIORITY'
+  | 'NUMBER_ASC'
+  | 'NUMBER_DESC'
+  | 'CLIENT_ASC'
+  | 'CLIENT_DESC'
+  | 'STATUS_ASC'
+  | 'STATUS_DESC'
+  | 'CONFIRMED_PORT_DATE_ASC'
+  | 'CONFIRMED_PORT_DATE_DESC'
+  | 'DONOR_OPERATOR_ASC'
+  | 'DONOR_OPERATOR_DESC'
+  | 'PORTING_MODE_ASC'
+  | 'PORTING_MODE_DESC'
+  | 'ASSIGNED_USER_ASC'
+  | 'ASSIGNED_USER_DESC'
+  | 'COMMERCIAL_OWNER_ASC'
+  | 'COMMERCIAL_OWNER_DESC'
 export type NotificationHealthStatus = 'OK' | 'FAILED' | 'MISCONFIGURED' | 'MIXED'
 
 export interface NotificationHealthDiagnosticsDto {
@@ -93,6 +111,8 @@ export interface PortingRequestListQueryDto {
   quickWorkFilter?: PortingRequestQuickWorkFilter
   commercialOwnerFilter?: CommercialOwnerFilter
   notificationHealthFilter?: NotificationHealthFilter
+  confirmedPortDateFrom?: string
+  confirmedPortDateTo?: string
   sort?: PortingRequestListSort
   page?: number
   pageSize?: number
@@ -106,6 +126,8 @@ export interface PortingRequestSummaryQueryDto {
   ownership?: OwnershipFilter
   commercialOwnerFilter?: CommercialOwnerFilter
   notificationHealthFilter?: NotificationHealthFilter
+  confirmedPortDateFrom?: string
+  confirmedPortDateTo?: string
 }
 
 export interface PortingRequestListItemDto {


### PR DESCRIPTION
## Summary
Etap 5I-A — backend/shared prep for the requests list redesign. Adds backend filtering by `confirmedPortDate` range and backend-side column sorting. No frontend changes.

## Date filter semantics
Two query params, both optional, both date-only (`YYYY-MM-DD`, validated via existing `dateOnlySchema` / `toDateOnlyValue`):

- `confirmedPortDateFrom` — `confirmedPortDate >= toDateOnlyValue(from)`
- `confirmedPortDateTo`   — `confirmedPortDate <= toDateOnlyValue(to)`
- Both — closed range `[from, to]`
- `from === to` — single day (rows with `confirmedPortDate` equal to that midnight UTC)
- `from > to` — schema rejects with custom error
- Filter is appended to `where.AND`, so it composes with `quickWorkFilter` (which sets `where.confirmedPortDate` directly) without overwriting. Combination with `quickWorkFilter=NO_DATE` naturally yields no rows by design (NO_DATE requires null, range requires non-null).
- Null dates are never matched (Prisma `gte`/`lte` exclude null automatically).

## Sort options and Prisma mapping
Existing `PortingRequestListSort` extended; default still `CREATED_AT_DESC`. All non-default mappings append `{ id: 'asc' }` as a stable tiebreaker.

| Sort enum | Prisma `orderBy` |
| --- | --- |
| `CREATED_AT_DESC` (default) | `{ createdAt: 'desc' }` |
| `WORK_PRIORITY` | unchanged in-memory ranking |
| `NUMBER_ASC` / `NUMBER_DESC` | `[{ caseNumber }, id]` |
| `CLIENT_ASC` / `CLIENT_DESC` | `[{ client.companyName }, { client.lastName }, { client.firstName }, id]` |
| `STATUS_ASC` / `STATUS_DESC` | `[{ statusInternal }, id]` |
| `CONFIRMED_PORT_DATE_ASC` / `_DESC` | `[{ confirmedPortDate: { sort, nulls: 'last' } }, { createdAt: 'desc' }, id]` |
| `DONOR_OPERATOR_ASC` / `_DESC` | `[{ donorOperator.name }, id]` |
| `PORTING_MODE_ASC` / `_DESC` | `[{ portingMode }, id]` |
| `ASSIGNED_USER_ASC` / `_DESC` | `[{ assignedUser.lastName }, { assignedUser.firstName }, id]` |
| `COMMERCIAL_OWNER_ASC` / `_DESC` | `[{ commercialOwner.lastName }, { commercialOwner.firstName }, id]` |

## Risks / follow-ups
- **`NOTIFICATION_HEALTH_ASC/DESC` intentionally not added.** Notification health is a derived value (event scan + health helper) not a column; clean Prisma `orderBy` is not trivial. Approximation by raw event `_count` would not respect the failure-vs-misconfigured semantics. Tracked as follow-up — recommended approach is a denormalized counter or a dedicated indexed materialized field, then add the enum entries.
- Frontend consumers using the existing `PortingRequestListSort` union compile cleanly because the union was extended, not changed. Frontend does not yet send any new sort values — that lands in the next slice.
- `confirmedPortDate` sort uses `nulls: 'last'` (Prisma 5 / Postgres). Verified Prisma version >= 5 in repo.

## Test plan
- [x] `npx vitest run src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts` — 48 tests pass (19 new)
- [x] `npx tsc --noEmit` — clean in `apps/backend`, `packages/shared`, `apps/frontend`
- [x] `npm run build --workspace apps/backend` — clean
- [ ] Manual smoke once frontend wires the params (out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)