### PR TITLE
feat(frontend): confirmedPortDate filter + sortable headers (#104)

### DIFF
--- a/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
@@ -720,55 +720,55 @@ describe('RequestsPage quick work filters', () => {
     expect(quickFilters.getByRole('button', { name: 'Moje' })).not.toBeNull()
     expect(quickFilters.getByRole('button', { name: 'Nieprzypisane' })).not.toBeNull()
   })
-  it('initializes confirmed port date inputs from URL params', async () => {
-    renderPage('/requests?confirmedPortDateFrom=2026-04-14&confirmedPortDateTo=2026-04-20')
+  it('initializes confirmed port date input when URL params point to one day', async () => {
+    renderPage('/requests?confirmedPortDateFrom=2026-04-14&confirmedPortDateTo=2026-04-14')
 
     await waitFor(() => {
       expect(getPortingRequestsMock).toHaveBeenCalledWith(
         expect.objectContaining({
           confirmedPortDateFrom: '2026-04-14',
-          confirmedPortDateTo: '2026-04-20',
+          confirmedPortDateTo: '2026-04-14',
         }),
       )
     })
 
-    const fromInput = screen.getByLabelText('Data przeniesienia od') as HTMLInputElement
-    const toInput = screen.getByLabelText('Data przeniesienia do') as HTMLInputElement
-    expect(fromInput.value).toBe('2026-04-14')
-    expect(toInput.value).toBe('2026-04-20')
+    const dateInput = screen.getByLabelText('Data przeniesienia') as HTMLInputElement
+    expect(dateInput.value).toBe('2026-04-14')
+    expect(screen.queryByLabelText('Data przeniesienia od')).toBeNull()
+    expect(screen.queryByLabelText('Data przeniesienia do')).toBeNull()
   })
 
-  it('updates confirmedPortDateFrom and resets page when "Data od" changes', async () => {
+  it('updates confirmed port date range to one selected day and resets page', async () => {
     renderPage('/requests?page=3')
     await screen.findByText('Kolejka spraw portowania')
 
-    fireEvent.change(screen.getByLabelText('Data przeniesienia od'), {
-      target: { value: '2026-04-14' },
+    fireEvent.change(screen.getByLabelText('Data przeniesienia'), {
+      target: { value: '2026-04-30' },
     })
 
     await waitFor(() => {
       const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
       expect(lastListCall).toMatchObject({
-        confirmedPortDateFrom: '2026-04-14',
+        confirmedPortDateFrom: '2026-04-30',
+        confirmedPortDateTo: '2026-04-30',
         page: 1,
       })
     })
   })
 
-  it('updates confirmedPortDateTo and resets page when "Data do" changes', async () => {
-    renderPage('/requests?page=3')
+  it('clears both confirmed port date params when date input is cleared', async () => {
+    renderPage('/requests?page=3&confirmedPortDateFrom=2026-04-30&confirmedPortDateTo=2026-04-30')
     await screen.findByText('Kolejka spraw portowania')
 
-    fireEvent.change(screen.getByLabelText('Data przeniesienia do'), {
-      target: { value: '2026-04-20' },
+    fireEvent.change(screen.getByLabelText('Data przeniesienia'), {
+      target: { value: '' },
     })
 
     await waitFor(() => {
       const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
-      expect(lastListCall).toMatchObject({
-        confirmedPortDateTo: '2026-04-20',
-        page: 1,
-      })
+      expect(lastListCall.confirmedPortDateFrom).toBeUndefined()
+      expect(lastListCall.confirmedPortDateTo).toBeUndefined()
+      expect(lastListCall.page).toBe(1)
     })
   })
 
@@ -784,6 +784,26 @@ describe('RequestsPage quick work filters', () => {
       expect(lastListCall.confirmedPortDateFrom).toBeUndefined()
       expect(lastListCall.confirmedPortDateTo).toBeUndefined()
     })
+  })
+
+  it('shows one active chip for selected confirmed port date', async () => {
+    renderPage('/requests?confirmedPortDateFrom=2026-04-30&confirmedPortDateTo=2026-04-30')
+    await screen.findByText('Kolejka spraw portowania')
+
+    expect(screen.getByText('Data przeniesienia:')).not.toBeNull()
+    expect(screen.getByText('2026-04-30')).not.toBeNull()
+    expect(screen.queryByText('Data od:')).toBeNull()
+    expect(screen.queryByText('Data do:')).toBeNull()
+  })
+
+  it('shows range chip and leaves date input empty for manual URL date ranges', async () => {
+    renderPage('/requests?confirmedPortDateFrom=2026-04-14&confirmedPortDateTo=2026-04-20')
+    await screen.findByText('Kolejka spraw portowania')
+
+    const dateInput = screen.getByLabelText('Data przeniesienia') as HTMLInputElement
+    expect(dateInput.value).toBe('')
+    expect(screen.getByText('Zakres dat:')).not.toBeNull()
+    expect(screen.getByText('2026-04-14 - 2026-04-20')).not.toBeNull()
   })
 
   it('toggles "Numer i klient" header sort between ASC and DESC', async () => {

--- a/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
@@ -720,6 +720,194 @@ describe('RequestsPage quick work filters', () => {
     expect(quickFilters.getByRole('button', { name: 'Moje' })).not.toBeNull()
     expect(quickFilters.getByRole('button', { name: 'Nieprzypisane' })).not.toBeNull()
   })
+  it('initializes confirmed port date inputs from URL params', async () => {
+    renderPage('/requests?confirmedPortDateFrom=2026-04-14&confirmedPortDateTo=2026-04-20')
+
+    await waitFor(() => {
+      expect(getPortingRequestsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          confirmedPortDateFrom: '2026-04-14',
+          confirmedPortDateTo: '2026-04-20',
+        }),
+      )
+    })
+
+    const fromInput = screen.getByLabelText('Data przeniesienia od') as HTMLInputElement
+    const toInput = screen.getByLabelText('Data przeniesienia do') as HTMLInputElement
+    expect(fromInput.value).toBe('2026-04-14')
+    expect(toInput.value).toBe('2026-04-20')
+  })
+
+  it('updates confirmedPortDateFrom and resets page when "Data od" changes', async () => {
+    renderPage('/requests?page=3')
+    await screen.findByText('Kolejka spraw portowania')
+
+    fireEvent.change(screen.getByLabelText('Data przeniesienia od'), {
+      target: { value: '2026-04-14' },
+    })
+
+    await waitFor(() => {
+      const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
+      expect(lastListCall).toMatchObject({
+        confirmedPortDateFrom: '2026-04-14',
+        page: 1,
+      })
+    })
+  })
+
+  it('updates confirmedPortDateTo and resets page when "Data do" changes', async () => {
+    renderPage('/requests?page=3')
+    await screen.findByText('Kolejka spraw portowania')
+
+    fireEvent.change(screen.getByLabelText('Data przeniesienia do'), {
+      target: { value: '2026-04-20' },
+    })
+
+    await waitFor(() => {
+      const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
+      expect(lastListCall).toMatchObject({
+        confirmedPortDateTo: '2026-04-20',
+        page: 1,
+      })
+    })
+  })
+
+  it('clears confirmed port date filters when filters are reset', async () => {
+    renderPage('/requests?confirmedPortDateFrom=2026-04-14&confirmedPortDateTo=2026-04-20')
+    await screen.findByText('Kolejka spraw portowania')
+
+    const clearButtons = screen.getAllByRole('button', { name: 'Wyczysc filtry' })
+    fireEvent.click(clearButtons[0]!)
+
+    await waitFor(() => {
+      const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
+      expect(lastListCall.confirmedPortDateFrom).toBeUndefined()
+      expect(lastListCall.confirmedPortDateTo).toBeUndefined()
+    })
+  })
+
+  it('toggles "Numer i klient" header sort between ASC and DESC', async () => {
+    renderPage()
+    await screen.findByText('Kolejka spraw portowania')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Numer i klient' }))
+
+    await waitFor(() => {
+      const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
+      expect(lastListCall).toMatchObject({ sort: 'NUMBER_ASC', page: 1 })
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Numer i klient' }))
+
+    await waitFor(() => {
+      const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
+      expect(lastListCall).toMatchObject({ sort: 'NUMBER_DESC', page: 1 })
+    })
+  })
+
+  it('toggles "Status" header sort between ASC and DESC', async () => {
+    renderPage()
+    await screen.findByText('Kolejka spraw portowania')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Status' }))
+    await waitFor(() => {
+      expect(getPortingRequestsMock.mock.calls.at(-1)?.[0]).toMatchObject({ sort: 'STATUS_ASC' })
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Status' }))
+    await waitFor(() => {
+      expect(getPortingRequestsMock.mock.calls.at(-1)?.[0]).toMatchObject({ sort: 'STATUS_DESC' })
+    })
+  })
+
+  it('toggles "Data przeniesienia" header sort between ASC and DESC', async () => {
+    renderPage()
+    await screen.findByText('Kolejka spraw portowania')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Data przeniesienia' }))
+    await waitFor(() => {
+      expect(getPortingRequestsMock.mock.calls.at(-1)?.[0]).toMatchObject({
+        sort: 'CONFIRMED_PORT_DATE_ASC',
+      })
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Data przeniesienia' }))
+    await waitFor(() => {
+      expect(getPortingRequestsMock.mock.calls.at(-1)?.[0]).toMatchObject({
+        sort: 'CONFIRMED_PORT_DATE_DESC',
+      })
+    })
+  })
+
+  it('toggles "Operator / tryb" header sort between ASC and DESC', async () => {
+    renderPage()
+    await screen.findByText('Kolejka spraw portowania')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Operator / tryb' }))
+    await waitFor(() => {
+      expect(getPortingRequestsMock.mock.calls.at(-1)?.[0]).toMatchObject({
+        sort: 'DONOR_OPERATOR_ASC',
+      })
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Operator / tryb' }))
+    await waitFor(() => {
+      expect(getPortingRequestsMock.mock.calls.at(-1)?.[0]).toMatchObject({
+        sort: 'DONOR_OPERATOR_DESC',
+      })
+    })
+  })
+
+  it('toggles "Przypisanie" header sort between ASC and DESC', async () => {
+    renderPage()
+    await screen.findByText('Kolejka spraw portowania')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Przypisanie' }))
+    await waitFor(() => {
+      expect(getPortingRequestsMock.mock.calls.at(-1)?.[0]).toMatchObject({
+        sort: 'ASSIGNED_USER_ASC',
+      })
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Przypisanie' }))
+    await waitFor(() => {
+      expect(getPortingRequestsMock.mock.calls.at(-1)?.[0]).toMatchObject({
+        sort: 'ASSIGNED_USER_DESC',
+      })
+    })
+  })
+
+  it('toggles "Opiekun handlowy" header sort between ASC and DESC', async () => {
+    renderPage()
+    await screen.findByText('Kolejka spraw portowania')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Opiekun handlowy' }))
+    await waitFor(() => {
+      expect(getPortingRequestsMock.mock.calls.at(-1)?.[0]).toMatchObject({
+        sort: 'COMMERCIAL_OWNER_ASC',
+      })
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Sortuj wg Opiekun handlowy' }))
+    await waitFor(() => {
+      expect(getPortingRequestsMock.mock.calls.at(-1)?.[0]).toMatchObject({
+        sort: 'COMMERCIAL_OWNER_DESC',
+      })
+    })
+  })
+
+  it('does not render a sort button for the Notyfikacje column', async () => {
+    renderPage()
+    await screen.findByText('Kolejka spraw portowania')
+
+    expect(screen.queryByRole('button', { name: /Sortuj wg Notyfikacje/ })).toBeNull()
+  })
+
+  it('marks the active sort column header with aria-sort', async () => {
+    renderPage('/requests?sort=NUMBER_ASC')
+    await screen.findByText('Kolejka spraw portowania')
+
+    const button = screen.getByRole('button', { name: 'Sortuj wg Numer i klient' })
+    const sortedHeader = button.closest('th')
+    expect(sortedHeader).not.toBeNull()
+    expect(sortedHeader!.getAttribute('aria-sort')).toBe('ascending')
+  })
+
   it('shows clear feedback when assign-to-me fails', async () => {
     assignPortingRequestToMeMock.mockRejectedValueOnce(new Error('forbidden'))
 

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -572,6 +572,10 @@ export function RequestsPage() {
   const page = parsePage(searchParams.get('page'))
   const confirmedPortDateFrom = searchParams.get('confirmedPortDateFrom') ?? ''
   const confirmedPortDateTo = searchParams.get('confirmedPortDateTo') ?? ''
+  const confirmedPortDateValue =
+    confirmedPortDateFrom && confirmedPortDateFrom === confirmedPortDateTo
+      ? confirmedPortDateFrom
+      : ''
 
   const filters = useMemo(
     () => ({
@@ -658,6 +662,14 @@ export function RequestsPage() {
     debounceRef.current = setTimeout(() => {
       setParam({ search: value || null, page: null })
     }, 400)
+  }
+
+  const handleConfirmedPortDateChange = (value: string) => {
+    setParam({
+      confirmedPortDateFrom: value || null,
+      confirmedPortDateTo: value || null,
+      page: null,
+    })
   }
 
   useEffect(() => {
@@ -795,21 +807,19 @@ export function RequestsPage() {
       })
     }
 
-    if (confirmedPortDateFrom) {
+    if (confirmedPortDateFrom && confirmedPortDateFrom === confirmedPortDateTo) {
       chips.push({
-        id: 'confirmedPortDateFrom',
-        label: 'Data od',
+        id: 'confirmedPortDate',
+        label: 'Data przeniesienia',
         value: confirmedPortDateFrom,
-        updates: { confirmedPortDateFrom: null, page: null },
+        updates: { confirmedPortDateFrom: null, confirmedPortDateTo: null, page: null },
       })
-    }
-
-    if (confirmedPortDateTo) {
+    } else if (confirmedPortDateFrom || confirmedPortDateTo) {
       chips.push({
-        id: 'confirmedPortDateTo',
-        label: 'Data do',
-        value: confirmedPortDateTo,
-        updates: { confirmedPortDateTo: null, page: null },
+        id: 'confirmedPortDateRange',
+        label: 'Zakres dat',
+        value: `${confirmedPortDateFrom || '...'} - ${confirmedPortDateTo || '...'}`,
+        updates: { confirmedPortDateFrom: null, confirmedPortDateTo: null, page: null },
       })
     }
 
@@ -1022,33 +1032,19 @@ export function RequestsPage() {
               ))}
             </select>
 
-            <input
-              type="date"
-              aria-label="Data przeniesienia od"
-              value={confirmedPortDateFrom}
-              onChange={(event) => {
-                setParam({
-                  confirmedPortDateFrom: event.target.value || null,
-                  page: null,
-                })
-              }}
-              className="input-field h-10 w-full"
-              placeholder="Data od"
-            />
-
-            <input
-              type="date"
-              aria-label="Data przeniesienia do"
-              value={confirmedPortDateTo}
-              onChange={(event) => {
-                setParam({
-                  confirmedPortDateTo: event.target.value || null,
-                  page: null,
-                })
-              }}
-              className="input-field h-10 w-full"
-              placeholder="Data do"
-            />
+            <label className="flex flex-col gap-1 text-xs font-semibold text-ink-500">
+              <span>Data przeniesienia</span>
+              <input
+                type="date"
+                aria-label="Data przeniesienia"
+                value={confirmedPortDateValue}
+                onChange={(event) => handleConfirmedPortDateChange(event.target.value)}
+                className="input-field h-10 w-full"
+              />
+              <span className="text-[11px] font-normal text-ink-400">
+                Pokaż sprawy z wybranego dnia
+              </span>
+            </label>
 
             <select
               aria-label="Sortowanie listy"

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -124,6 +124,37 @@ const sortOptions: Array<{ id: PortingRequestListSort; label: string }> = [
   { id: 'WORK_PRIORITY', label: 'Priorytet pracy' },
 ]
 
+interface SortableColumnConfig {
+  label: string
+  asc: PortingRequestListSort
+  desc: PortingRequestListSort
+}
+
+const SORTABLE_COLUMNS = {
+  number: { label: 'Numer i klient', asc: 'NUMBER_ASC', desc: 'NUMBER_DESC' },
+  status: { label: 'Status', asc: 'STATUS_ASC', desc: 'STATUS_DESC' },
+  confirmedPortDate: {
+    label: 'Data przeniesienia',
+    asc: 'CONFIRMED_PORT_DATE_ASC',
+    desc: 'CONFIRMED_PORT_DATE_DESC',
+  },
+  donorOperator: {
+    label: 'Operator / tryb',
+    asc: 'DONOR_OPERATOR_ASC',
+    desc: 'DONOR_OPERATOR_DESC',
+  },
+  assignedUser: {
+    label: 'Przypisanie',
+    asc: 'ASSIGNED_USER_ASC',
+    desc: 'ASSIGNED_USER_DESC',
+  },
+  commercialOwner: {
+    label: 'Opiekun handlowy',
+    asc: 'COMMERCIAL_OWNER_ASC',
+    desc: 'COMMERCIAL_OWNER_DESC',
+  },
+} as const satisfies Record<string, SortableColumnConfig>
+
 interface ActiveFilterChip {
   id: string
   label: string
@@ -472,6 +503,44 @@ export function RequestRow({
   )
 }
 
+function SortableHeader({
+  column,
+  currentSort,
+  onClick,
+}: {
+  column: SortableColumnConfig
+  currentSort: PortingRequestListSort
+  onClick: (column: SortableColumnConfig) => void
+}) {
+  const direction =
+    currentSort === column.asc ? 'asc' : currentSort === column.desc ? 'desc' : null
+  const arrow = direction === 'asc' ? '▲' : direction === 'desc' ? '▼' : ''
+  const ariaSort = direction === 'asc' ? 'ascending' : direction === 'desc' ? 'descending' : 'none'
+
+  return (
+    <th
+      scope="col"
+      aria-sort={ariaSort}
+      className="px-4 py-3 text-left"
+    >
+      <button
+        type="button"
+        onClick={() => onClick(column)}
+        className={cx(
+          'inline-flex items-center gap-1 text-left uppercase tracking-[0.06em]',
+          direction ? 'text-ink-900' : 'text-ink-500 hover:text-ink-700',
+        )}
+        aria-label={`Sortuj wg ${column.label}`}
+      >
+        <span>{column.label}</span>
+        <span aria-hidden className="text-[10px]">
+          {arrow}
+        </span>
+      </button>
+    </th>
+  )
+}
+
 export function RequestsPage() {
   const navigate = useNavigate()
   const location = useLocation()
@@ -501,6 +570,8 @@ export function RequestsPage() {
   )
   const sort = parseListSort(searchParams.get('sort'))
   const page = parsePage(searchParams.get('page'))
+  const confirmedPortDateFrom = searchParams.get('confirmedPortDateFrom') ?? ''
+  const confirmedPortDateTo = searchParams.get('confirmedPortDateTo') ?? ''
 
   const filters = useMemo(
     () => ({
@@ -512,6 +583,8 @@ export function RequestsPage() {
       quickWorkFilter,
       commercialOwnerFilter,
       notificationHealthFilter,
+      confirmedPortDateFrom,
+      confirmedPortDateTo,
       sort,
       page,
       pageSize: PAGE_SIZE,
@@ -527,6 +600,8 @@ export function RequestsPage() {
       portingModeFilter,
       searchInput,
       statusFilter,
+      confirmedPortDateFrom,
+      confirmedPortDateTo,
     ],
   )
 
@@ -549,6 +624,14 @@ export function RequestsPage() {
       setSearchParams((prev) => applyQueryParamUpdates(prev, updates))
     },
     [setSearchParams],
+  )
+
+  const handleSortHeaderClick = useCallback(
+    (column: SortableColumnConfig) => {
+      const next = sort === column.asc ? column.desc : column.asc
+      setParam({ sort: next, page: null })
+    },
+    [setParam, sort],
   )
 
   const setQuickWorkFilter = useCallback(
@@ -712,9 +795,29 @@ export function RequestsPage() {
       })
     }
 
+    if (confirmedPortDateFrom) {
+      chips.push({
+        id: 'confirmedPortDateFrom',
+        label: 'Data od',
+        value: confirmedPortDateFrom,
+        updates: { confirmedPortDateFrom: null, page: null },
+      })
+    }
+
+    if (confirmedPortDateTo) {
+      chips.push({
+        id: 'confirmedPortDateTo',
+        label: 'Data do',
+        value: confirmedPortDateTo,
+        updates: { confirmedPortDateTo: null, page: null },
+      })
+    }
+
     return chips
   }, [
     commercialOwnerFilter,
+    confirmedPortDateFrom,
+    confirmedPortDateTo,
     donorOperatorId,
     notificationHealthFilter,
     operators,
@@ -919,6 +1022,34 @@ export function RequestsPage() {
               ))}
             </select>
 
+            <input
+              type="date"
+              aria-label="Data przeniesienia od"
+              value={confirmedPortDateFrom}
+              onChange={(event) => {
+                setParam({
+                  confirmedPortDateFrom: event.target.value || null,
+                  page: null,
+                })
+              }}
+              className="input-field h-10 w-full"
+              placeholder="Data od"
+            />
+
+            <input
+              type="date"
+              aria-label="Data przeniesienia do"
+              value={confirmedPortDateTo}
+              onChange={(event) => {
+                setParam({
+                  confirmedPortDateTo: event.target.value || null,
+                  page: null,
+                })
+              }}
+              className="input-field h-10 w-full"
+              placeholder="Data do"
+            />
+
             <select
               aria-label="Sortowanie listy"
               value={sort}
@@ -936,6 +1067,9 @@ export function RequestsPage() {
                   Sortuj: {option.label}
                 </option>
               ))}
+              {!sortOptions.some((option) => option.id === sort) && (
+                <option value={sort}>Sortuj: kolumna</option>
+              )}
             </select>
 
           </div>
@@ -1052,12 +1186,28 @@ export function RequestsPage() {
             <table className="w-full min-w-[1120px] text-sm">
               <thead className="bg-ink-50/80 text-[11px] font-semibold uppercase tracking-[0.06em] text-ink-500">
                 <tr>
-                  <th className="px-4 py-3 text-left">Numer i klient</th>
-                  <th className="px-4 py-3 text-left">Status</th>
-                  <th className="px-4 py-3 text-left">Data przeniesienia</th>
-                  <th className="px-4 py-3 text-left">Operator / tryb</th>
-                  <th className="px-4 py-3 text-left">Przypisanie</th>
-                  <th className="px-4 py-3 text-left">Opiekun handlowy</th>
+                  <SortableHeader column={SORTABLE_COLUMNS.number} currentSort={sort} onClick={handleSortHeaderClick} />
+                  <SortableHeader column={SORTABLE_COLUMNS.status} currentSort={sort} onClick={handleSortHeaderClick} />
+                  <SortableHeader
+                    column={SORTABLE_COLUMNS.confirmedPortDate}
+                    currentSort={sort}
+                    onClick={handleSortHeaderClick}
+                  />
+                  <SortableHeader
+                    column={SORTABLE_COLUMNS.donorOperator}
+                    currentSort={sort}
+                    onClick={handleSortHeaderClick}
+                  />
+                  <SortableHeader
+                    column={SORTABLE_COLUMNS.assignedUser}
+                    currentSort={sort}
+                    onClick={handleSortHeaderClick}
+                  />
+                  <SortableHeader
+                    column={SORTABLE_COLUMNS.commercialOwner}
+                    currentSort={sort}
+                    onClick={handleSortHeaderClick}
+                  />
                   <th className="min-w-[130px] whitespace-nowrap px-4 py-3 text-left">Notyfikacje</th>
                   <th className="min-w-[64px] whitespace-nowrap px-3 py-3 text-left">Akcje</th>
                 </tr>

--- a/apps/frontend/src/pages/Requests/requestsOperational.test.ts
+++ b/apps/frontend/src/pages/Requests/requestsOperational.test.ts
@@ -25,6 +25,8 @@ function makeFilters(
     quickWorkFilter: 'ALL',
     commercialOwnerFilter: 'ALL',
     notificationHealthFilter: 'ALL',
+    confirmedPortDateFrom: '',
+    confirmedPortDateTo: '',
     sort: 'CREATED_AT_DESC',
     page: 1,
     pageSize: 20,

--- a/apps/frontend/src/pages/Requests/requestsOperational.ts
+++ b/apps/frontend/src/pages/Requests/requestsOperational.ts
@@ -39,7 +39,26 @@ const QUICK_WORK_FILTERS: RequestsQuickWorkFilter[] = [
   'NEEDS_ACTION_TODAY',
 ]
 
-const LIST_SORTS: PortingRequestListSort[] = ['CREATED_AT_DESC', 'WORK_PRIORITY']
+const LIST_SORTS: PortingRequestListSort[] = [
+  'CREATED_AT_DESC',
+  'WORK_PRIORITY',
+  'NUMBER_ASC',
+  'NUMBER_DESC',
+  'CLIENT_ASC',
+  'CLIENT_DESC',
+  'STATUS_ASC',
+  'STATUS_DESC',
+  'CONFIRMED_PORT_DATE_ASC',
+  'CONFIRMED_PORT_DATE_DESC',
+  'DONOR_OPERATOR_ASC',
+  'DONOR_OPERATOR_DESC',
+  'PORTING_MODE_ASC',
+  'PORTING_MODE_DESC',
+  'ASSIGNED_USER_ASC',
+  'ASSIGNED_USER_DESC',
+  'COMMERCIAL_OWNER_ASC',
+  'COMMERCIAL_OWNER_DESC',
+]
 export const DEFAULT_REQUESTS_SORT: PortingRequestListSort = 'CREATED_AT_DESC'
 
 export interface RequestsOperationalFilterState {
@@ -51,6 +70,8 @@ export interface RequestsOperationalFilterState {
   quickWorkFilter: RequestsQuickWorkFilter
   commercialOwnerFilter: CommercialOwnerFilter
   notificationHealthFilter: NotificationHealthFilter
+  confirmedPortDateFrom: string
+  confirmedPortDateTo: string
   sort: PortingRequestListSort
   page: number
   pageSize: number
@@ -133,6 +154,8 @@ export function buildListQueryFromFilters(
       filters.notificationHealthFilter !== 'ALL'
         ? filters.notificationHealthFilter
         : undefined,
+    confirmedPortDateFrom: filters.confirmedPortDateFrom || undefined,
+    confirmedPortDateTo: filters.confirmedPortDateTo || undefined,
     sort: filters.sort !== DEFAULT_REQUESTS_SORT ? filters.sort : undefined,
     page: filters.page,
     pageSize: filters.pageSize,
@@ -148,6 +171,8 @@ export function buildSummaryQueryFromFilters(
     portingMode: filters.portingModeFilter ?? undefined,
     donorOperatorId: filters.donorOperatorId || undefined,
     ownership: filters.ownershipFilter !== 'ALL' ? filters.ownershipFilter : undefined,
+    confirmedPortDateFrom: filters.confirmedPortDateFrom || undefined,
+    confirmedPortDateTo: filters.confirmedPortDateTo || undefined,
   }
 }
 
@@ -159,7 +184,9 @@ export function hasActiveRequestsFilters(filters: RequestsOperationalFilterState
     !!filters.donorOperatorId ||
     filters.quickWorkFilter !== 'ALL' ||
     filters.commercialOwnerFilter !== 'ALL' ||
-    filters.notificationHealthFilter !== 'ALL'
+    filters.notificationHealthFilter !== 'ALL' ||
+    !!filters.confirmedPortDateFrom ||
+    !!filters.confirmedPortDateTo
   )
 }
 

--- a/apps/frontend/src/services/portingRequests.api.ts
+++ b/apps/frontend/src/services/portingRequests.api.ts
@@ -68,6 +68,8 @@ function appendListFiltersToQuery(
     quickWorkFilter?: string
     commercialOwnerFilter?: string
     notificationHealthFilter?: string
+    confirmedPortDateFrom?: string
+    confirmedPortDateTo?: string
   },
   options: {
     includeQuickWorkFilter?: boolean
@@ -86,6 +88,12 @@ function appendListFiltersToQuery(
   }
   if (params.notificationHealthFilter && params.notificationHealthFilter !== 'ALL') {
     query.set('notificationHealthFilter', params.notificationHealthFilter)
+  }
+  if (params.confirmedPortDateFrom) {
+    query.set('confirmedPortDateFrom', params.confirmedPortDateFrom)
+  }
+  if (params.confirmedPortDateTo) {
+    query.set('confirmedPortDateTo', params.confirmedPortDateTo)
   }
 }
 


### PR DESCRIPTION
## Summary
- Wires the porting request list UI to the 5I-A backend additions (PR #103).
- Adds `Data przeniesienia od/do` date inputs in the operational filter panel; values sync to `confirmedPortDateFrom` / `confirmedPortDateTo` query params and reset `page` to 1.
- Makes table headers clickable for `Numer i klient`, `Status`, `Data przeniesienia`, `Operator / tryb`, `Przypisanie`, `Opiekun handlowy`. Click toggles ASC <-> DESC; aria-sort reflects active direction. `Notyfikacje` and `Akcje` stay non-sortable.
- Header sort writes `sort` to URL and resets `page` to 1; `CREATED_AT_DESC` stays default; existing `WORK_PRIORITY` select option preserved. Sort dropdown gains a fallback `Sortuj: kolumna` option when a column sort is active.
- Reset filters clears the new date params via existing `clearFilters`.

Closes #104.

## Test plan
- [x] `npx tsc --noEmit` (apps/frontend)
- [x] `npm run test --workspace apps/frontend -- RequestsPage` — 35 pass
- [x] `npm run test --workspace apps/frontend` — 377 pass
- [x] `npm run build --workspace apps/frontend`
- [ ] Manual: `/requests?confirmedPortDateFrom=2026-04-14&confirmedPortDateTo=2026-04-14` shows both inputs filled
- [ ] Manual: changing dates updates URL and list, refresh preserves them
- [ ] Manual: clicking headers toggles ASC/DESC, refresh preserves sort
- [ ] Manual: pagination + quick filters still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)