### PR TITLE
feat(frontend): row highlighting by status and port date (5I-C)

### DIFF
--- a/apps/frontend/src/lib/requestRowHighlight.test.ts
+++ b/apps/frontend/src/lib/requestRowHighlight.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest'
+import { getRequestRowHighlight, rowHighlightClasses } from './requestRowHighlight'
+
+const NOW = new Date('2026-04-30T12:00:00.000Z')
+
+function makeRequest(
+  statusInternal: string,
+  confirmedPortDate: string | null = null,
+) {
+  return { statusInternal, confirmedPortDate } as {
+    statusInternal: Parameters<typeof getRequestRowHighlight>[0]['statusInternal']
+    confirmedPortDate: string | null
+  }
+}
+
+describe('getRequestRowHighlight', () => {
+  it('PORTED with past date → ported (blue)', () => {
+    expect(getRequestRowHighlight(makeRequest('PORTED', '2026-04-01'), NOW)).toBe('ported')
+  })
+
+  it('PORTED with no date → ported (blue, overrides no-date)', () => {
+    expect(getRequestRowHighlight(makeRequest('PORTED', null), NOW)).toBe('ported')
+  })
+
+  it('PORTED with overdue date → ported (blue, overrides overdue)', () => {
+    expect(getRequestRowHighlight(makeRequest('PORTED', '2026-01-01'), NOW)).toBe('ported')
+  })
+
+  it('active case with today date → today (green)', () => {
+    expect(getRequestRowHighlight(makeRequest('CONFIRMED', '2026-04-30'), NOW)).toBe('today')
+  })
+
+  it('active case with tomorrow date → upcoming (light green)', () => {
+    expect(getRequestRowHighlight(makeRequest('SUBMITTED', '2026-05-01'), NOW)).toBe('upcoming')
+  })
+
+  it('active case with day after tomorrow → upcoming (light green)', () => {
+    expect(getRequestRowHighlight(makeRequest('PENDING_DONOR', '2026-05-02'), NOW)).toBe('upcoming')
+  })
+
+  it('active case with overdue date → overdue (alarm red)', () => {
+    expect(getRequestRowHighlight(makeRequest('SUBMITTED', '2026-04-01'), NOW)).toBe('overdue')
+  })
+
+  it('active case with no date → none', () => {
+    expect(getRequestRowHighlight(makeRequest('SUBMITTED', null), NOW)).toBe('none')
+  })
+
+  it('active case with date far in future → none', () => {
+    expect(getRequestRowHighlight(makeRequest('CONFIRMED', '2026-06-15'), NOW)).toBe('none')
+  })
+
+  it('CANCELLED → closed (neutral)', () => {
+    expect(getRequestRowHighlight(makeRequest('CANCELLED', '2026-04-01'), NOW)).toBe('closed')
+  })
+
+  it('REJECTED → closed (neutral)', () => {
+    expect(getRequestRowHighlight(makeRequest('REJECTED', null), NOW)).toBe('closed')
+  })
+
+  it('CANCELLED with overdue date → closed, not overdue', () => {
+    expect(getRequestRowHighlight(makeRequest('CANCELLED', '2026-04-01'), NOW)).toBe('closed')
+  })
+
+  it('REJECTED with today date → closed, not today', () => {
+    expect(getRequestRowHighlight(makeRequest('REJECTED', '2026-04-30'), NOW)).toBe('closed')
+  })
+})
+
+describe('rowHighlightClasses', () => {
+  it('ported → bg-sky-50', () => {
+    expect(rowHighlightClasses('ported')).toBe('bg-sky-50')
+  })
+
+  it('overdue → bg-red-50', () => {
+    expect(rowHighlightClasses('overdue')).toBe('bg-red-50')
+  })
+
+  it('today → bg-green-50', () => {
+    expect(rowHighlightClasses('today')).toBe('bg-green-50')
+  })
+
+  it('upcoming → bg-emerald-50/70', () => {
+    expect(rowHighlightClasses('upcoming')).toBe('bg-emerald-50/70')
+  })
+
+  it('closed → bg-gray-50/50', () => {
+    expect(rowHighlightClasses('closed')).toBe('bg-gray-50/50')
+  })
+
+  it('none → empty string', () => {
+    expect(rowHighlightClasses('none')).toBe('')
+  })
+})

--- a/apps/frontend/src/lib/requestRowHighlight.ts
+++ b/apps/frontend/src/lib/requestRowHighlight.ts
@@ -1,0 +1,44 @@
+import type { PortingRequestListItemDto } from '@np-manager/shared'
+import { calculateDaysDiff } from './portingUrgency'
+
+export type RowHighlight = 'ported' | 'overdue' | 'today' | 'upcoming' | 'closed' | 'none'
+
+/**
+ * Zwraca token podświetlenia wiersza na podstawie statusu i daty przeniesienia.
+ *
+ * Priorytet: PORTED > CANCELLED/REJECTED > overdue > dziś > jutro/pojutrze > brak stylu
+ */
+export function getRequestRowHighlight(
+  request: Pick<PortingRequestListItemDto, 'statusInternal' | 'confirmedPortDate'>,
+  now: Date = new Date(),
+): RowHighlight {
+  const { statusInternal, confirmedPortDate } = request
+
+  if (statusInternal === 'PORTED') return 'ported'
+  if (statusInternal === 'CANCELLED' || statusInternal === 'REJECTED') return 'closed'
+
+  const daysDiff = calculateDaysDiff(confirmedPortDate, now)
+  if (daysDiff === null) return 'none'
+  if (daysDiff < 0) return 'overdue'
+  if (daysDiff === 0) return 'today'
+  if (daysDiff <= 2) return 'upcoming'
+
+  return 'none'
+}
+
+export function rowHighlightClasses(highlight: RowHighlight): string {
+  switch (highlight) {
+    case 'ported':
+      return 'bg-sky-50'
+    case 'overdue':
+      return 'bg-red-50'
+    case 'today':
+      return 'bg-green-50'
+    case 'upcoming':
+      return 'bg-emerald-50/70'
+    case 'closed':
+      return 'bg-gray-50/50'
+    case 'none':
+      return ''
+  }
+}

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -29,6 +29,7 @@ import {
 import { getPortingOperationalHint } from '@/lib/portingOperationalHint'
 import { getPortingStatusMeta } from '@/lib/portingStatusMeta'
 import { getStatusAwareWorkPriorityBadge } from '@/lib/portingUrgency'
+import { getRequestRowHighlight, rowHighlightClasses } from '@/lib/requestRowHighlight'
 import {
   assignPortingRequestToMe,
   getPortingRequests,
@@ -346,10 +347,16 @@ export function RequestRow({
     onClick()
   }
 
+  const highlight = getRequestRowHighlight(request)
+  const highlightClass = rowHighlightClasses(highlight)
+
   return (
     <tr
       onClick={onClick}
-      className="group cursor-pointer border-b border-line/70 transition-colors last:border-b-0 hover:bg-brand-50/50"
+      className={cx(
+        'group cursor-pointer border-b border-line/70 transition-colors last:border-b-0 hover:bg-brand-50/50',
+        highlightClass,
+      )}
     >
       <td className="px-4 py-3.5 align-top">
         <div className="max-w-[210px] truncate font-mono text-sm font-bold text-ink-900">


### PR DESCRIPTION
## Summary

- Adds `getRequestRowHighlight(request, now)` helper (`src/lib/requestRowHighlight.ts`) — returns semantic token (`ported | overdue | today | upcoming | closed | none`) based on status and confirmed port date
- Adds `rowHighlightClasses(highlight)` — maps token to Tailwind background class
- Wires both into `RequestRow` via `cx()` on `<tr>`

## Color logic

| Condition | Class | Color |
|-----------|-------|-------|
| PORTED (any date) | `bg-sky-50` | subtle blue |
| CANCELLED / REJECTED | `bg-gray-50/50` | neutral/muted |
| Active + overdue | `bg-red-50` | alarm red |
| Active + today | `bg-green-50` | green |
| Active + tomorrow/pojutrze (daysDiff ≤ 2) | `bg-emerald-50/70` | light green/mint |
| Active + no date or later | — | none |

Priority: PORTED > CANCELLED/REJECTED > overdue > today > upcoming > none

## Tests

- 19 new unit tests in `requestRowHighlight.test.ts` covering all 7 scenarios from spec
- 23 existing `RequestsPage` tests pass without regression

## Blocker note

`/requests` error ("Nie udalo sie zaladowac kolejki") is not a code bug — all tests pass, TypeScript compiles, build succeeds. Most likely cause: stale local backend (pre-PR #103). Fix: restart backend from main/branch containing PR #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)