### PR TITLE
fix(requests): adjust date filter day range and row highlight colors

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
@@ -608,7 +608,7 @@ describe('listPortingRequests - confirmedPortDate filter (Etap 5I-A)', () => {
     const where = (mockPortingRequestCount.mock.calls[0]?.[0] as { where: Record<string, unknown> }).where
     const andClauses = where.AND as Array<Record<string, unknown>>
     expect(andClauses).toContainEqual({
-      confirmedPortDate: { lte: new Date('2026-04-30T00:00:00.000Z') },
+      confirmedPortDate: { lte: new Date('2026-04-30T23:59:59.999Z') },
     })
   })
 
@@ -628,7 +628,7 @@ describe('listPortingRequests - confirmedPortDate filter (Etap 5I-A)', () => {
     expect(andClauses).toContainEqual({
       confirmedPortDate: {
         gte: new Date('2026-04-15T00:00:00.000Z'),
-        lte: new Date('2026-04-30T00:00:00.000Z'),
+        lte: new Date('2026-04-30T23:59:59.999Z'),
       },
     })
   })
@@ -649,7 +649,7 @@ describe('listPortingRequests - confirmedPortDate filter (Etap 5I-A)', () => {
     expect(andClauses).toContainEqual({
       confirmedPortDate: {
         gte: new Date('2026-04-22T00:00:00.000Z'),
-        lte: new Date('2026-04-22T00:00:00.000Z'),
+        lte: new Date('2026-04-22T23:59:59.999Z'),
       },
     })
   })

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -346,6 +346,11 @@ function toDateOnlyValue(value?: string): Date | undefined {
   return new Date(`${value}T00:00:00.000Z`)
 }
 
+function toDateOnlyEndValue(value?: string): Date | undefined {
+  if (!value) return undefined
+  return new Date(`${value}T23:59:59.999Z`)
+}
+
 function buildConfirmedPortDateFilterWhere(
   query: PortingRequestListQuery | PortingRequestSummaryQuery,
 ): Prisma.PortingRequestWhereInput | null {
@@ -360,7 +365,7 @@ function buildConfirmedPortDateFilterWhere(
     if (fromDate) constraint.gte = fromDate
   }
   if (to) {
-    const toDate = toDateOnlyValue(to)
+    const toDate = toDateOnlyEndValue(to)
     if (toDate) constraint.lte = toDate
   }
   if (constraint.gte === undefined && constraint.lte === undefined) {

--- a/apps/frontend/src/lib/requestRowHighlight.test.ts
+++ b/apps/frontend/src/lib/requestRowHighlight.test.ts
@@ -14,81 +14,81 @@ function makeRequest(
 }
 
 describe('getRequestRowHighlight', () => {
-  it('PORTED with past date → ported (blue)', () => {
+  it('PORTED with past date -> ported (calm blue)', () => {
     expect(getRequestRowHighlight(makeRequest('PORTED', '2026-04-01'), NOW)).toBe('ported')
   })
 
-  it('PORTED with no date → ported (blue, overrides no-date)', () => {
+  it('PORTED with no date -> ported (calm blue, overrides no-date)', () => {
     expect(getRequestRowHighlight(makeRequest('PORTED', null), NOW)).toBe('ported')
   })
 
-  it('PORTED with overdue date → ported (blue, overrides overdue)', () => {
+  it('PORTED with overdue date -> ported (calm blue, overrides overdue)', () => {
     expect(getRequestRowHighlight(makeRequest('PORTED', '2026-01-01'), NOW)).toBe('ported')
   })
 
-  it('active case with today date → today (green)', () => {
+  it('active case with today date -> today (blue)', () => {
     expect(getRequestRowHighlight(makeRequest('CONFIRMED', '2026-04-30'), NOW)).toBe('today')
   })
 
-  it('active case with tomorrow date → upcoming (light green)', () => {
-    expect(getRequestRowHighlight(makeRequest('SUBMITTED', '2026-05-01'), NOW)).toBe('upcoming')
+  it('active case with tomorrow date -> tomorrow (yellow)', () => {
+    expect(getRequestRowHighlight(makeRequest('SUBMITTED', '2026-05-01'), NOW)).toBe('tomorrow')
   })
 
-  it('active case with day after tomorrow → upcoming (light green)', () => {
-    expect(getRequestRowHighlight(makeRequest('PENDING_DONOR', '2026-05-02'), NOW)).toBe('upcoming')
+  it('active case with day after tomorrow -> none', () => {
+    expect(getRequestRowHighlight(makeRequest('PENDING_DONOR', '2026-05-02'), NOW)).toBe('none')
   })
 
-  it('active case with overdue date → overdue (alarm red)', () => {
+  it('active case with overdue date -> overdue (alarm red)', () => {
     expect(getRequestRowHighlight(makeRequest('SUBMITTED', '2026-04-01'), NOW)).toBe('overdue')
   })
 
-  it('active case with no date → none', () => {
+  it('active case with no date -> none', () => {
     expect(getRequestRowHighlight(makeRequest('SUBMITTED', null), NOW)).toBe('none')
   })
 
-  it('active case with date far in future → none', () => {
+  it('active case with date far in future -> none', () => {
     expect(getRequestRowHighlight(makeRequest('CONFIRMED', '2026-06-15'), NOW)).toBe('none')
   })
 
-  it('CANCELLED → closed (neutral)', () => {
+  it('CANCELLED -> closed (neutral)', () => {
     expect(getRequestRowHighlight(makeRequest('CANCELLED', '2026-04-01'), NOW)).toBe('closed')
   })
 
-  it('REJECTED → closed (neutral)', () => {
+  it('REJECTED -> closed (neutral)', () => {
     expect(getRequestRowHighlight(makeRequest('REJECTED', null), NOW)).toBe('closed')
   })
 
-  it('CANCELLED with overdue date → closed, not overdue', () => {
+  it('CANCELLED with overdue date -> closed, not overdue', () => {
     expect(getRequestRowHighlight(makeRequest('CANCELLED', '2026-04-01'), NOW)).toBe('closed')
   })
 
-  it('REJECTED with today date → closed, not today', () => {
+  it('REJECTED with today date -> closed, not today', () => {
     expect(getRequestRowHighlight(makeRequest('REJECTED', '2026-04-30'), NOW)).toBe('closed')
   })
 })
 
 describe('rowHighlightClasses', () => {
-  it('ported → bg-sky-50', () => {
+  it('ported -> bg-sky-50', () => {
     expect(rowHighlightClasses('ported')).toBe('bg-sky-50')
   })
 
-  it('overdue → bg-red-50', () => {
+  it('overdue -> bg-red-50', () => {
     expect(rowHighlightClasses('overdue')).toBe('bg-red-50')
   })
 
-  it('today → bg-green-50', () => {
-    expect(rowHighlightClasses('today')).toBe('bg-green-50')
+  it('today -> bg-blue-50', () => {
+    expect(rowHighlightClasses('today')).toBe('bg-blue-50')
   })
 
-  it('upcoming → bg-emerald-50/70', () => {
-    expect(rowHighlightClasses('upcoming')).toBe('bg-emerald-50/70')
+  it('tomorrow -> bg-yellow-50', () => {
+    expect(rowHighlightClasses('tomorrow')).toBe('bg-yellow-50')
   })
 
-  it('closed → bg-gray-50/50', () => {
+  it('closed -> bg-gray-50/50', () => {
     expect(rowHighlightClasses('closed')).toBe('bg-gray-50/50')
   })
 
-  it('none → empty string', () => {
+  it('none -> empty string', () => {
     expect(rowHighlightClasses('none')).toBe('')
   })
 })

--- a/apps/frontend/src/lib/requestRowHighlight.ts
+++ b/apps/frontend/src/lib/requestRowHighlight.ts
@@ -1,12 +1,12 @@
 import type { PortingRequestListItemDto } from '@np-manager/shared'
 import { calculateDaysDiff } from './portingUrgency'
 
-export type RowHighlight = 'ported' | 'overdue' | 'today' | 'upcoming' | 'closed' | 'none'
+export type RowHighlight = 'ported' | 'overdue' | 'today' | 'tomorrow' | 'closed' | 'none'
 
 /**
- * Zwraca token podświetlenia wiersza na podstawie statusu i daty przeniesienia.
+ * Zwraca token podswietlenia wiersza na podstawie statusu i daty przeniesienia.
  *
- * Priorytet: PORTED > CANCELLED/REJECTED > overdue > dziś > jutro/pojutrze > brak stylu
+ * Priorytet: PORTED > CANCELLED/REJECTED > overdue > dzis > jutro > brak stylu.
  */
 export function getRequestRowHighlight(
   request: Pick<PortingRequestListItemDto, 'statusInternal' | 'confirmedPortDate'>,
@@ -21,7 +21,7 @@ export function getRequestRowHighlight(
   if (daysDiff === null) return 'none'
   if (daysDiff < 0) return 'overdue'
   if (daysDiff === 0) return 'today'
-  if (daysDiff <= 2) return 'upcoming'
+  if (daysDiff === 1) return 'tomorrow'
 
   return 'none'
 }
@@ -33,9 +33,9 @@ export function rowHighlightClasses(highlight: RowHighlight): string {
     case 'overdue':
       return 'bg-red-50'
     case 'today':
-      return 'bg-green-50'
-    case 'upcoming':
-      return 'bg-emerald-50/70'
+      return 'bg-blue-50'
+    case 'tomorrow':
+      return 'bg-yellow-50'
     case 'closed':
       return 'bg-gray-50/50'
     case 'none':


### PR DESCRIPTION
﻿## 1. Cel

Closes #107

Naprawa zakresu filtrowania po konkretnej dacie przeniesienia oraz dostosowanie kolorow podswietlenia wierszy spraw na liscie.

## 2. Zakres zmian

### Backend
- `confirmedPortDateTo` obejmuje teraz caly wybrany dzien (`23:59:59.999Z`).
- Filtr jednodniowy `confirmedPortDateFrom=YYYY-MM-DD` + `confirmedPortDateTo=YYYY-MM-DD` obejmuje wszystkie sprawy z tej daty, takze gdy `confirmedPortDate` jest `DateTime` z godzina pozniejsza niz polnoc.
- Testy list service zaktualizowane pod koniec dnia dla `lte`.

### Frontend
- Kolory row highlight zostaly dostosowane:
  - aktywna po terminie -> czerwony,
  - aktywna dzis / dzien przeniesienia -> niebieski,
  - aktywna jutro / dzien przed przeniesieniem -> zolty,
  - `PORTED` -> spokojny `sky` jako stan zakonczenia,
  - `CANCELLED` / `REJECTED` -> neutralny,
  - brak daty -> bez podswietlenia.
- `PORTED` oraz statusy zamkniete nadal maja pierwszenstwo nad data.
- Pojutrze nie jest juz specjalnie podswietlane, zgodnie z priorytetem na dzien przed przeniesieniem.

### Root 404
- Nie zmieniono routingu, bo aktualny router frontendowy juz obsluguje `/` jako chroniona trase aplikacji i ma fallback `*`.
- Wczesniejszy 404 zostal odtworzony na starym/obcym procesie sluchajacym na `5173`, a nie w kodzie routera.
- Runtime QA nalezy wykonac po zabiciu starych procesow i starcie z `D:\Projekt\np-manager`.

## 3. Zmienione pliki / obszary

- `apps/backend/src/modules/porting-requests/porting-requests.service.ts`
- `apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts`
- `apps/frontend/src/lib/requestRowHighlight.ts`
- `apps/frontend/src/lib/requestRowHighlight.test.ts`

## 4. Testy i walidacja

Uruchomione komendy:

- `npm run test --workspace apps/frontend -- requestRowHighlight` - PASS, 19 testow
- `npm run test --workspace apps/frontend -- RequestsPage` - PASS, 37 testow
- `npm run test --workspace apps/backend -- porting-requests.list.service` - PASS, 48 testow
- `npx tsc --noEmit -p apps/frontend/tsconfig.json` - PASS
- `npx tsc --noEmit -p apps/backend/tsconfig.json` - PASS
- `npm run test --workspace apps/frontend` - PASS, 398 testow
- `npm run build --workspace apps/frontend` - PASS, z istniejacymi warningami Vite/chunk size
- `npm run build --workspace apps/backend` - PASS
- `npm run test --workspace apps/backend` - PASS, 567 testow

## 5. Ryzyka / otwarte punkty

- Browser QA w tej sesji Codexa nie zostalo ukonczone, bo lokalne uruchamianie dev serverow bylo blokowane przez Windowsowe `spawn EPERM` dla Vite/tsx/concurrently.
- Proba uruchomienia backendu z `dist` bez env zatrzymala sie na walidacji `DATABASE_URL` / `JWT_SECRET`; nie traktuje tego jako bledu aplikacji.
- Nie dodawano workaroundow runtime ani statycznych fallbackow, zeby nie wprowadzac zmian poza zakresem issue.
- W worktree lokalnie pozostal niecommitowany `temp-vite-preload.cjs`, ktory jest zablokowany przez system i nie nalezy do PR.

Manual QA po merge albo lokalnie w normalnym PowerShellu z `D:\Projekt\np-manager`:

1. Zabic stare procesy `5173` / `3001`.
2. Uruchomic `npm run dev`.
3. `http://localhost:5173/` nie powinien pokazywac stalego 404.
4. `/requests` laduje liste.
5. Wybor `Data przeniesienia = 2026-04-14` ustawia `confirmedPortDateFrom=2026-04-14` i `confirmedPortDateTo=2026-04-14`.
6. Kazdy widoczny wiersz ma date przeniesienia `14.04.2026`.
7. Data bez wynikow pokazuje empty state.
8. Wiersz z data przeniesienia dzis jest niebieski.
9. Wiersz z data przeniesienia jutro jest zolty.
10. Aktywna sprawa po terminie jest czerwona.
11. `PORTED` nie swieci jako overdue.
12. Brak daty pozostaje bez specjalnego podswietlenia.

## 6. Checklist przed merge

- [x] Minimalny diff bez zmian w PLI CBD, notifications, workflow ani admin screens
- [x] Backend single-day date range obejmuje caly dzien
- [x] Frontend row highlight zgodny z decyzja produktowa
- [x] Testy skupione PASS
- [x] Typecheck frontend/backend PASS
- [x] Build frontend/backend PASS
- [x] Pelne testy frontend/backend PASS
- [ ] Manual browser QA z normalnego lokalnego runtime
