### PR TITLE
fix: commit confirmed port date filter on blur

### DIFF
--- a/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
@@ -756,6 +756,24 @@ describe('RequestsPage quick work filters', () => {
     })
   })
 
+  it('commits confirmed port date on blur when value was injected without change event', async () => {
+    renderPage('/requests?page=3')
+    await screen.findByText('Kolejka spraw portowania')
+
+    const dateInput = screen.getByLabelText('Data przeniesienia') as HTMLInputElement
+    dateInput.value = '2026-04-30'
+    fireEvent.blur(dateInput)
+
+    await waitFor(() => {
+      const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
+      expect(lastListCall).toMatchObject({
+        confirmedPortDateFrom: '2026-04-30',
+        confirmedPortDateTo: '2026-04-30',
+        page: 1,
+      })
+    })
+  })
+
   it('clears both confirmed port date params when date input is cleared', async () => {
     renderPage('/requests?page=3&confirmedPortDateFrom=2026-04-30&confirmedPortDateTo=2026-04-30')
     await screen.findByText('Kolejka spraw portowania')

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -679,6 +679,18 @@ export function RequestsPage() {
     })
   }
 
+  const isConfirmedPortDateRangeActive =
+    (!!confirmedPortDateFrom || !!confirmedPortDateTo) &&
+    (!confirmedPortDateFrom || confirmedPortDateFrom !== confirmedPortDateTo)
+
+  const commitConfirmedPortDateFromInputValue = (value: string) => {
+    // Jeśli zakres jest ustawiony tylko w URL (from != to), input jest pusty i nie powinien
+    // przypadkowo usuwać filtra na samym blur.
+    if (isConfirmedPortDateRangeActive && !value) return
+    if (value === confirmedPortDateValue) return
+    handleConfirmedPortDateChange(value)
+  }
+
   useEffect(() => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current)
@@ -1046,6 +1058,7 @@ export function RequestsPage() {
                 aria-label="Data przeniesienia"
                 value={confirmedPortDateValue}
                 onChange={(event) => handleConfirmedPortDateChange(event.target.value)}
+                onBlur={(event) => commitConfirmedPortDateFromInputValue(event.target.value)}
                 className="input-field h-10 w-full"
               />
               <span className="text-[11px] font-normal text-ink-400">


### PR DESCRIPTION
Supplemental validation after date-filter blur fallback:

Changed files:
- apps/frontend/src/pages/Requests/RequestsPage.tsx
- apps/frontend/src/pages/Requests/RequestsPage.test.tsx

Validation:
- RequestsPage targeted tests: PASS, 38/38
- requestRowHighlight tests: PASS, 19/19
- backend porting-requests.list.service tests: PASS, 48/48
- frontend tsc: PASS
- backend tsc: PASS
- full frontend tests: PASS, 47 files / 399 tests
- full backend tests: PASS, 71 files / 567 tests
- frontend build: PASS
- backend build: PASS, if the command completed without error

Notes:
- Runtime Comet QA did not find a confirmed regression.
- Date input automation limitations were mitigated by committing the date filter on blur.
- Remaining warnings are existing/non-blocking toolchain warnings.
- temp-vite-preload.cjs remains untracked and is not included in the PR.