### PR TITLE
fix: generate Prisma client before backend build

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "tsx watch src/app.ts",
     "clean": "rimraf dist",
-    "prebuild": "npm run clean",
+    "generate": "prisma generate --schema prisma/schema.prisma",
+    "prebuild": "npm run clean && npm run generate",
     "build": "tsc",
     "start": "node dist/apps/backend/src/app.js",
     "start:check": "node -e \"const p=require('path').resolve('dist/app.js');require('fs').existsSync(p)&&(console.error('STALE dist/app.js found — run npm run build to fix'),process.exit(1))\" && node dist/apps/backend/src/app.js",


### PR DESCRIPTION
## Summary - Adds `generate` script (`prisma generate --schema prisma/schema.prisma`) to `apps/backend/package.json` - Updates `prebuild` to run `clean && generate` before `tsc` - Fixes Vercel build failures where Prisma types (`UserRole`, `PortingRequestGetPayload`, etc.) were missing because `prisma generate` was never called before `tsc`  ## Test plan - [ ] Vercel deployment runs `npm run build` → `prebuild` triggers `prisma generate` → Prisma Client generated → `tsc` finds types → build passes  🤖 Generated with [Claude Code](https://claude.com/claude-code) 

 Targeted Vitest from repository root is not reliable in this local setup because it scans .claude/worktrees and fails frontend alias resolution. Frontend tsc passed and manual QA passed. Targeted frontend test should be run from apps/frontend with the frontend Vite config.