### PR TITLE
feat(frontend): separate status actions from external actions in workflow section

### DIFF
--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.test.tsx
@@ -323,6 +323,52 @@ describe('RequestWorkflowActionsSection', () => {
     expect(screen.queryByRole('button', { name: 'Oznacz jako przeniesiona' })).toBeNull()
   })
 
+  it('renders external slot inside separator wrapper when canUsePliCbdExternalActions is true', () => {
+    const { container } = render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          canUsePliCbdExternalActions: true,
+          pliCbdExternalActionsSlot: <div data-testid="ext-slot">EXT</div>,
+        })}
+      />,
+    )
+
+    const slot = screen.getByTestId('ext-slot')
+    expect(slot).toBeDefined()
+    // separator wrapper must be an ancestor
+    const wrapper = slot.closest('.border-t')
+    expect(wrapper).not.toBeNull()
+  })
+
+  it('shows external slot even when status is terminal and status actions are empty', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          statusInternal: 'PORTED',
+          availableStatusActions: [],
+          canUsePliCbdExternalActions: true,
+          pliCbdExternalActionsSlot: <div data-testid="ext-slot">EXT</div>,
+        })}
+      />,
+    )
+
+    expect(screen.getByText(/Sprawa zako/)).toBeDefined()
+    expect(screen.getByTestId('ext-slot')).toBeDefined()
+  })
+
+  it('does not render external slot wrapper when pliCbdExternalActionsSlot is null', () => {
+    const { container } = render(
+      <RequestWorkflowActionsSection
+        {...buildProps({
+          canUsePliCbdExternalActions: true,
+          pliCbdExternalActionsSlot: null,
+        })}
+      />,
+    )
+
+    expect(container.querySelector('.border-t')).toBeNull()
+  })
+
   it('disables status action buttons when isUpdatingStatus is true', () => {
     render(
       <RequestWorkflowActionsSection

--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
@@ -283,7 +283,15 @@ export function RequestWorkflowActionsSection({
             </div>
           )}
 
-          {canUsePliCbdExternalActions && pliCbdExternalActionsSlot}
+          {canUsePliCbdExternalActions && pliCbdExternalActionsSlot && (
+            <div className="mt-6 border-t border-line pt-4">
+              <p className="mb-3 text-xs text-ink-500">
+                Czynności zewnętrzne dokumentują etap procesu zewnętrznego i są niezależne od akcji
+                statusu sprawy.
+              </p>
+              {pliCbdExternalActionsSlot}
+            </div>
+          )}
         </div>
       ) : (
         <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-4 py-3 text-sm text-gray-600">


### PR DESCRIPTION
## Summary

- Wraps `pliCbdExternalActionsSlot` in a `border-t` separator with a contextual description
- External/operational actions now visually distinct from status workflow actions
- Eliminates UX confusion: terminal-status empty state no longer appears to contradict visible external action buttons

## What changed

**`RequestWorkflowActionsSection.tsx`**
- `pliCbdExternalActionsSlot` rendered inside `div.mt-6.border-t.border-line.pt-4` with description text:
  _"Czynności zewnętrzne dokumentują etap procesu zewnętrznego i są niezależne od akcji statusu sprawy."_
- Separator only renders when both `canUsePliCbdExternalActions` and `pliCbdExternalActionsSlot` are truthy — no empty wrapper when slot is null

**`RequestWorkflowActionsSection.test.tsx`**
- 3 new tests: separator wrapper exists, external slot visible at terminal status, no wrapper when slot is null

## Out of scope

No changes to `RequestDetailPage`, `PortingExternalActionsPanel`, backend, shared, or workflow rules.

## Reviewer notes

- `border-line` is a project Tailwind token — if missing in the design system, fallback to `border-gray-200`
- Manual QA: open a PORTED/REJECTED/CANCELLED case with `canUsePliCbdExternalActions=true` — horizontal rule + description should appear above "Etapy zewnetrzne" block