### PR TITLE
fix(frontend): hide port date confirmation form for ineligible statuses

### DIFF
--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.test.tsx
@@ -191,7 +191,7 @@ describe('RequestWorkflowActionsSection', () => {
     expect(screen.getByText(/zapisuje krok procesu/)).toBeDefined()
   })
 
-  it('shows status-restricted hint when manual port date action available but status disallows it', () => {
+  it('hides manual port date form when status disallows it', () => {
     render(
       <RequestWorkflowActionsSection
         {...buildProps({
@@ -201,7 +201,8 @@ describe('RequestWorkflowActionsSection', () => {
       />,
     )
 
-    expect(screen.getByText(/Akcja dostepna tylko dla statusow/)).toBeDefined()
+    expect(screen.queryByText(/Potwierdz date przeniesienia/)).toBeNull()
+    expect(screen.queryByText(/Akcja dostepna tylko dla statusow/)).toBeNull()
   })
 
   it('renders manual port date success and error feedback', () => {

--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
@@ -196,7 +196,7 @@ export function RequestWorkflowActionsSection({
             </div>
           )}
 
-          {canUseManualPortDateAction && (
+          {canUseManualPortDateAction && canUseManualPortDateForCurrentStatus && (
             <div className="space-y-3 rounded-lg border border-sky-200 bg-sky-50/60 p-4">
               <div>
                 <h3 className="text-sm font-semibold text-sky-900">Potwierdz date przeniesienia</h3>
@@ -207,67 +207,59 @@ export function RequestWorkflowActionsSection({
                 </p>
               </div>
 
-              {canUseManualPortDateForCurrentStatus ? (
-                <>
-                  <label className="block">
-                    <span className="mb-1 block text-xs font-medium text-sky-900">
-                      Data przeniesienia
-                    </span>
-                    <input
-                      type="date"
-                      value={manualConfirmedPortDate}
-                      onChange={(event) => onManualConfirmedPortDateChange(event.target.value)}
-                      className="input-field"
-                      disabled={
-                        isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
-                      }
-                    />
-                  </label>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-sky-900">
+                  Data przeniesienia
+                </span>
+                <input
+                  type="date"
+                  value={manualConfirmedPortDate}
+                  onChange={(event) => onManualConfirmedPortDateChange(event.target.value)}
+                  className="input-field"
+                  disabled={
+                    isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
+                  }
+                />
+              </label>
 
-                  <label className="block">
-                    <span className="mb-1 block text-xs font-medium text-sky-900">
-                      Komentarz operacyjny (opcjonalnie)
-                    </span>
-                    <textarea
-                      value={manualPortDateComment}
-                      onChange={(event) => onManualPortDateCommentChange(event.target.value)}
-                      rows={3}
-                      className="input-field"
-                      placeholder="Dodaj komentarz do historii operacyjnej"
-                      disabled={
-                        isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
-                      }
-                    />
-                  </label>
+              <label className="block">
+                <span className="mb-1 block text-xs font-medium text-sky-900">
+                  Komentarz operacyjny (opcjonalnie)
+                </span>
+                <textarea
+                  value={manualPortDateComment}
+                  onChange={(event) => onManualPortDateCommentChange(event.target.value)}
+                  rows={3}
+                  className="input-field"
+                  placeholder="Dodaj komentarz do historii operacyjnej"
+                  disabled={
+                    isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
+                  }
+                />
+              </label>
 
-                  <div className="flex flex-wrap gap-2">
-                    <button
-                      type="button"
-                      onClick={() => onConfirmManualPortDate()}
-                      className="btn-primary"
-                      disabled={
-                        isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
-                      }
-                    >
-                      {isSubmittingManualPortDate
-                        ? 'Zapisywanie potwierdzenia'
-                        : 'Potwierdz date przeniesienia'}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => onManualPortDateCommentChange('')}
-                      className="btn-secondary"
-                      disabled={isSubmittingManualPortDate}
-                    >
-                      Wyczysc komentarz
-                    </button>
-                  </div>
-                </>
-              ) : (
-                <div className="rounded-panel border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
-                  Akcja dostepna tylko dla statusow: Zlozona, Oczekuje na dawce, Potwierdzona.
-                </div>
-              )}
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => onConfirmManualPortDate()}
+                  className="btn-primary"
+                  disabled={
+                    isSubmittingManualPortDate || isUpdatingStatus || isExporting || isSyncing
+                  }
+                >
+                  {isSubmittingManualPortDate
+                    ? 'Zapisywanie potwierdzenia'
+                    : 'Potwierdz date przeniesienia'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onManualPortDateCommentChange('')}
+                  className="btn-secondary"
+                  disabled={isSubmittingManualPortDate}
+                >
+                  Wyczysc komentarz
+                </button>
+              </div>
 
               {manualPortDateSuccess && (
                 <div className="rounded-lg border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">


### PR DESCRIPTION
## Summary

- `RequestWorkflowActionsSection`: outer render guard for the \"Potwierdź datę przeniesienia\" block changed from `canUseManualPortDateAction` to `canUseManualPortDateAction && canUseManualPortDateForCurrentStatus`
- Removed dead inner ternary that rendered an amber warning banner for statuses where the action is unavailable (PORTED, ERROR, DRAFT, REJECTED, CANCELLED)
- Form and all handlers unchanged for eligible statuses (SUBMITTED, PENDING_DONOR, CONFIRMED)
- No changes to backend, shared types, capabilities logic, or `RequestDetailPage`

## Why

Form was always visible for users with the STANDALONE/ADMIN role, regardless of request status. For terminal/error statuses it showed an amber banner instead of the form — confusing UX and flagged as S2b in 6B.2 QA. The `canUseManualPortDateForCurrentStatus` prop was already computed and passed correctly; it just wasn't used in the outer guard.

## Reviewer notes

- Only `RequestWorkflowActionsSection.tsx` and its test file changed
- `canUseManualPortDateForCurrentStatus` prop stays in the interface (still passed from `RequestDetailPage`) — no prop removal, no API change
- 21 unit tests pass, tsc clean

## Test plan

- [ ] PORTED status + STANDALONE mode + ADMIN role → section \"Potwierdź datę przeniesienia\" absent from DOM (no form, no banner)
- [ ] ERROR status → same
- [ ] DRAFT status → same
- [ ] SUBMITTED status + STANDALONE + ADMIN → form visible and functional
- [ ] CONFIRMED status + STANDALONE + ADMIN → form visible and functional