### PR TITLE
fix(frontend): hide port date link and suppress draft warning in Terminy section

### DIFF
--- a/apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestCommandCenter.test.tsx
@@ -145,6 +145,49 @@ describe('RequestCommandCenter', () => {
     expect(onScrollToNotifications).toHaveBeenCalledTimes(1)
   })
 
+  it('DRAFT without confirmedPortDate does not show missing-port-date attention banner', () => {
+    render(
+      <RequestAttentionStrip
+        request={{
+          ...BASE_REQUEST,
+          statusInternal: 'DRAFT' as const,
+          confirmedPortDate: null,
+          assignedUser: null,
+        }}
+        canManageAssignment
+        canManageStatus
+        workflowErrorMessage=""
+        onScrollToAssignment={vi.fn()}
+        onScrollToNotifications={vi.fn()}
+        onScrollToPortingDates={vi.fn()}
+        onScrollToStatusActions={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByText('Brak potwierdzonej daty przeniesienia')).toBeNull()
+  })
+
+  it('SUBMITTED without confirmedPortDate shows missing-port-date attention banner', () => {
+    render(
+      <RequestAttentionStrip
+        request={{
+          ...BASE_REQUEST,
+          statusInternal: 'SUBMITTED' as const,
+          confirmedPortDate: null,
+        }}
+        canManageAssignment={false}
+        canManageStatus
+        workflowErrorMessage=""
+        onScrollToAssignment={vi.fn()}
+        onScrollToNotifications={vi.fn()}
+        onScrollToPortingDates={vi.fn()}
+        onScrollToStatusActions={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Brak potwierdzonej daty przeniesienia')).toBeDefined()
+  })
+
   it('hero-number has large font and mode chip shows "Tryb: DAY"', () => {
     render(
       <MemoryRouter>

--- a/apps/frontend/src/pages/Requests/RequestCommandCenter.tsx
+++ b/apps/frontend/src/pages/Requests/RequestCommandCenter.tsx
@@ -142,7 +142,7 @@ function buildAttentionItems({
     })
   }
 
-  if (!request.confirmedPortDate) {
+  if (!request.confirmedPortDate && request.statusInternal !== 'DRAFT') {
     items.push({
       key: 'missing-port-date',
       tone: 'warning',

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -2087,7 +2087,7 @@ export function RequestDetailPage() {
                 <Field label="Data od dawcy" value={request.donorAssignedPortDate} mono />
                 <Field label="Godzina od dawcy" value={request.donorAssignedPortTime} mono />
 
-                {canUseManualPortDateAction && !request.confirmedPortDate && (
+                {canUseManualPortDateAction && canUseManualPortDateForCurrentStatus && !request.confirmedPortDate && (
                   <div className="sm:col-span-2" data-testid="terminy-process-confirm-hint">
                     <AlertBanner
                       tone="info"


### PR DESCRIPTION
## Summary

- **Fix A** (`RequestDetailPage.tsx`): Info banner + "Przejdź do potwierdzenia daty" button in the Terminy section now requires `canUseManualPortDateForCurrentStatus` to be true. Previously the link appeared for ERROR, DRAFT, PORTED and other statuses where the confirmation form (fixed in #112) was already hidden — the link led nowhere.
- **Fix B** (`RequestCommandCenter.tsx`): Amber attention banner "Brak potwierdzonej daty przeniesienia" is now suppressed for DRAFT status. A draft has no confirmed date by design; the `warning` tone was unnecessarily alarming.
- **Tests** (`RequestCommandCenter.test.tsx`): Added two unit tests — DRAFT without a confirmed date → no amber banner; SUBMITTED without a confirmed date → amber banner visible.

## Context

Follows #111 (workflow section visual separation) and #112 (hide port date confirmation form for unavailable statuses). This PR closes the UX gap where the Terminy section was still advertising an action that was no longer reachable.

## Scope

Frontend-only. No backend, shared, or workflow changes.

## Test plan

- [ ] `npx vitest run src/pages/Requests/RequestCommandCenter.test.tsx` → 6/6 pass
- [ ] `npx tsc --noEmit -p tsconfig.app.json` → no errors
- [ ] Manual QA: ERROR status → Terminy section shows no info banner, no "Przejdź" button
- [ ] Manual QA: DRAFT status → attention strip shows no "Brak potwierdzonej daty przeniesienia"
- [ ] Manual QA: SUBMITTED without confirmed date → both banners visible as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)