### PR TITLE
Doprecyzuj copy niedostępnych akcji komunikacyjnych dla statusów terminalnych

### DIFF
--- a/apps/frontend/src/components/PortingCommunicationPanel/PortingCommunicationPanel.test.tsx
+++ b/apps/frontend/src/components/PortingCommunicationPanel/PortingCommunicationPanel.test.tsx
@@ -127,7 +127,7 @@ describe('PortingCommunicationPanel', () => {
     expect(html).toContain('Brak komunikacji zapisanych dla tej sprawy.')
   })
 
-  it('renders status-blocked draft action as disabled secondary UI with operational reason', () => {
+  it('renders status-blocked draft action for non-terminal status with future availability reason', () => {
     const html = renderToStaticMarkup(
       <PortingCommunicationPanel
         actions={[
@@ -168,6 +168,51 @@ describe('PortingCommunicationPanel', () => {
     expect(html).toContain('Aktualny status:')
     expect(html).toContain('bg-ink-50 text-ink-400')
     expect(html).not.toContain('bg-brand-600')
+  })
+
+  it('renders status-blocked draft action for terminal status without future availability promise', () => {
+    const html = renderToStaticMarkup(
+      <PortingCommunicationPanel
+        actions={[
+          {
+            type: 'MISSING_DOCUMENTS',
+            label: 'Brakujace dokumenty',
+            description: 'Prosba do klienta o doslanie brakujacych dokumentow lub korekte danych.',
+            canPreview: false,
+            canCreateDraft: false,
+            canMarkSent: false,
+            disabled: true,
+            disabledReason:
+              'Akcja jest dostepna dopiero dla spraw w statusie zgodnym z polityka komunikacji.',
+            existingDraftId: null,
+            existingDraftInfo: null,
+            allowsMultipleDrafts: false,
+          },
+        ]}
+        summary={EMPTY_SUMMARY}
+        items={[]}
+        isLoadingHistory={false}
+        preview={null}
+        feedbackError={null}
+        feedbackSuccess={null}
+        previewingActionType={null}
+        creatingDraftActionType={null}
+        markingSentId={null}
+        currentStatus="PORTED"
+        onPreviewDraft={vi.fn()}
+        onCreateDraft={vi.fn()}
+        onMarkAsSent={vi.fn()}
+        {...NEW_DELIVERY_PROPS}
+      />,
+    )
+
+    expect(html).toContain('Niedostepne teraz')
+    expect(html).not.toContain('Akcja bedzie dostepna')
+    expect(html).toContain('Ta akcja nie jest dostepna dla zakonczonej sprawy.')
+    expect(html).toContain('Przewidziana jest dla statusow:')
+    expect(html).toContain('Szkic')
+    expect(html).toContain('Zlozona')
+    expect(html).toContain('Oczekuje na dawce')
   })
 
   it('does not keep a stale success message when the panel is rendered again without feedback', () => {

--- a/apps/frontend/src/components/PortingCommunicationPanel/PortingCommunicationPanel.tsx
+++ b/apps/frontend/src/components/PortingCommunicationPanel/PortingCommunicationPanel.tsx
@@ -70,6 +70,8 @@ const actionAvailabilityByType: Record<PortingRequestCommunicationActionType, Po
   INTERNAL_NOTE_EMAIL: ['DRAFT', 'SUBMITTED', 'PENDING_DONOR', 'CONFIRMED', 'ERROR'],
 }
 
+const TERMINAL_STATUSES: PortingCaseStatus[] = ['REJECTED', 'CANCELLED', 'PORTED']
+
 function formatStatusList(statuses: PortingCaseStatus[]): string {
   return statuses.map((status) => PORTING_CASE_STATUS_LABELS[status]).join(', ')
 }
@@ -89,6 +91,10 @@ function buildBlockedReason(
   const availableStatuses = actionAvailabilityByType[action.type]
 
   if (availableStatuses.length > 0) {
+    if (currentStatus && TERMINAL_STATUSES.includes(currentStatus)) {
+      return `Ta akcja nie jest dostepna dla zakonczonej sprawy. Przewidziana jest dla statusow: ${formatStatusList(availableStatuses)}.`
+    }
+
     const currentStatusLabel = currentStatus ? PORTING_CASE_STATUS_LABELS[currentStatus] : 'nieznany'
     return `Akcja bedzie dostepna dla statusow: ${formatStatusList(availableStatuses)}. Aktualny status: ${currentStatusLabel}.`
   }


### PR DESCRIPTION
## Cel
- Zmienić frontendowy komunikat blokady w sekcji „Komunikacja operacyjna” tak, aby dla spraw terminalnych nie sugerował przyszłej dostępności akcji.

## Zakres zmian
- Dodano rozróżnienie dla statusów terminalnych `PORTED`, `REJECTED`, `CANCELLED` w `PortingCommunicationPanel`.
- Dla statusów nieterminalnych zachowano dotychczasowy komunikat „Akcja bedzie dostepna dla statusow...”.
- Dla statusów terminalnych komunikat został zastąpiony neutralnym copy bez frazy sugerującej przyszłą dostępność.
- Utrzymano badge „Niedostepne teraz” oraz dotychczasowe zachowanie aktywnego draftu i przycisków.

## Zmienione pliki / obszary
- `apps/frontend/src/components/PortingCommunicationPanel/PortingCommunicationPanel.tsx`
- `apps/frontend/src/components/PortingCommunicationPanel/PortingCommunicationPanel.test.tsx`

## Testy i walidacja
- `npx vitest run src/components/PortingCommunicationPanel/PortingCommunicationPanel.test.tsx` - passed
- `npx tsc --noEmit -p tsconfig.app.json` - passed
- Testy pokrywają przypadek statusu nieterminalnego, terminalnego oraz aktywnego draftu.

## Ryzyka / otwarte punkty
- Terminalność jest rozpoznawana lokalną stałą w komponencie, więc wiedza ta jest zdublowana względem polityki domenowej.
- Zmiana dotyczy wyłącznie copy; katalog akcji i reguły dostępności pozostają bez zmian.
- Ręczne QA w UI nadal wskazane, żeby potwierdzić czy neutralny komunikat jest wystarczająco czytelny dla operatorów.

## Checklist przed merge
- [x] Komunikat dla `PORTED` / `REJECTED` / `CANCELLED` nie zawiera frazy sugerującej przyszłą dostępność.
- [x] Komunikat dla statusów nieterminalnych zachowuje dotychczasowy sens.
- [x] Aktywny draft zachowuje osobny komunikat bez zmian.
- [x] Testy komponentu przechodzą.
- [x] Typecheck frontendu przechodzi.