### PR TITLE
feat(workflow): obsługa spraw w stanie ERROR — diagnostyka i anulowanie (#115)

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-request-workflow.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-request-workflow.test.ts
@@ -109,4 +109,45 @@ describe('porting-request-workflow', () => {
       resolveWorkflowTransition('PORTED', { targetStatus: 'PORTED' }, 'ADMIN'),
     ).toThrowError(/Sprawa ma juz wskazany status/)
   })
+
+  describe('CANCEL_FROM_ERROR', () => {
+    it('available for ADMIN/BACK_OFFICE/MANAGER from ERROR', () => {
+      for (const role of ['ADMIN', 'BACK_OFFICE', 'MANAGER'] as const) {
+        const actions = getAvailableStatusActions('ERROR', role)
+        expect(actions.map((a) => a.actionId)).toContain('CANCEL_FROM_ERROR')
+      }
+    })
+
+    it('not available for BOK_CONSULTANT from ERROR', () => {
+      const actions = getAvailableStatusActions('ERROR', 'BOK_CONSULTANT')
+      expect(actions.map((a) => a.actionId)).not.toContain('CANCEL_FROM_ERROR')
+    })
+
+    it('ERROR → CANCELLED succeeds with reason', () => {
+      const result = resolveWorkflowTransition(
+        'ERROR',
+        { targetStatus: 'CANCELLED', reason: 'Decyzja operacyjna' },
+        'ADMIN',
+      )
+      expect(result.config.actionId).toBe('CANCEL_FROM_ERROR')
+      expect(result.config.targetStatus).toBe('CANCELLED')
+      expect(result.reason).toBe('Decyzja operacyjna')
+    })
+
+    it('requires reason', () => {
+      expect(() =>
+        resolveWorkflowTransition('ERROR', { targetStatus: 'CANCELLED' }, 'ADMIN'),
+      ).toThrowError(/Powod anulowania z bledu jest wymagany/)
+    })
+
+    it('blocks BOK_CONSULTANT from ERROR → CANCELLED', () => {
+      expect(() =>
+        resolveWorkflowTransition(
+          'ERROR',
+          { targetStatus: 'CANCELLED', reason: 'x' },
+          'BOK_CONSULTANT',
+        ),
+      ).toThrowError(/Twoja rola nie moze wykonac tej zmiany statusu/)
+    })
+  })
 })

--- a/apps/backend/src/modules/porting-requests/porting-request-workflow.ts
+++ b/apps/backend/src/modules/porting-requests/porting-request-workflow.ts
@@ -202,6 +202,18 @@ const WORKFLOW_TRANSITIONS: WorkflowTransitionConfig[] = [
     reasonLabel: 'Powod bledu',
     commentLabel: 'Szczegoly bledu',
   },
+  {
+    actionId: PORTING_REQUEST_STATUS_ACTION_IDS.CANCEL_FROM_ERROR,
+    fromStatus: 'ERROR',
+    targetStatus: 'CANCELLED',
+    label: 'Anuluj z bledu',
+    description: 'Zamknij sprawe w stanie bledu jako anulowana po decyzji operacyjnej.',
+    allowedRoles: REVIEW_ROLES,
+    requiresReason: true,
+    requiresComment: false,
+    reasonLabel: 'Powod anulowania z bledu',
+    commentLabel: 'Komentarz operacyjny',
+  },
 ]
 
 function toStatusActionDto(config: WorkflowTransitionConfig): PortingRequestStatusActionDto {

--- a/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.test.tsx
+++ b/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.test.tsx
@@ -226,9 +226,9 @@ describe('WhatsNextPanel', () => {
     expect(getTextContent(blocker)).toContain('podgląd')
   })
 
-  it('does not attribute missing ERROR actions to user role', () => {
-    // Backend workflow defines no transitions from ERROR for any role, so the
-    // panel must not mislead operators into thinking it is a permissions gap.
+  it('ERROR with no actions: shows role-gap blocker (REVIEW_ROLES have CANCEL_FROM_ERROR)', () => {
+    // CANCEL_FROM_ERROR exists for REVIEW_ROLES — so a user with no actions for ERROR
+    // genuinely lacks the required role. Panel should surface this as a role gap.
     const tree = WhatsNextPanel(
       makeProps({
         status: 'ERROR' as PortingCaseStatus,
@@ -237,10 +237,8 @@ describe('WhatsNextPanel', () => {
       }),
     )
     const blocker = findByTestId(tree, 'whats-next-blocker')
-    expect(blocker).toBeUndefined()
-    const text = getTextContent(tree)
-    expect(text).not.toContain('dla Twojej roli')
-    expect(text).toContain('błędu')
+    expect(blocker).toBeDefined()
+    expect(getTextContent(blocker)).toContain('dla Twojej roli')
   })
 
   it('does not show role-gap blocker while waiting on donor', () => {
@@ -348,5 +346,30 @@ describe('WhatsNextPanel', () => {
     const text = getTextContent(tree)
     expect(text).toContain('błędu')
     expect(text).toContain('interwencji')
+  })
+
+  it('ERROR with CANCEL_FROM_ERROR action: shows action button, no dead-end blocker', () => {
+    const cancelFromErrorAction: PortingRequestStatusActionDto = {
+      actionId: 'CANCEL_FROM_ERROR',
+      label: 'Anuluj z bledu',
+      targetStatus: 'CANCELLED',
+      requiresReason: true,
+      requiresComment: false,
+      reasonLabel: 'Powod anulowania z bledu',
+      commentLabel: 'Komentarz operacyjny',
+      description: 'Zamknij sprawe w stanie bledu jako anulowana.',
+    }
+    const tree = WhatsNextPanel(
+      makeProps({
+        status: 'ERROR' as PortingCaseStatus,
+        availableStatusActions: [cancelFromErrorAction],
+        canManageStatus: true,
+      }),
+    )
+    const actions = findByTestId(tree, 'whats-next-actions')
+    expect(actions).toBeDefined()
+    expect(getTextContent(actions)).toContain('Anuluj z bledu')
+    const blocker = findByTestId(tree, 'whats-next-blocker')
+    expect(blocker).toBeUndefined()
   })
 })

--- a/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx
+++ b/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx
@@ -35,9 +35,9 @@ const TERMINAL_STATUSES: PortingCaseStatus[] = ['REJECTED', 'CANCELLED', 'PORTED
 
 // Statuses where a missing status action can be truthfully attributed to the
 // current user's role — i.e. some role in the workflow has a transition from
-// this status. Excludes PENDING_DONOR (waiting on donor) and ERROR (backend
-// workflow defines no transitions from ERROR for any role).
-const ROLE_GATED_STATUSES: PortingCaseStatus[] = ['DRAFT', 'SUBMITTED', 'CONFIRMED']
+// this status. Excludes PENDING_DONOR (waiting on donor).
+// ERROR is included: REVIEW_ROLES have CANCEL_FROM_ERROR, so BOK missing it is a role gap.
+const ROLE_GATED_STATUSES: PortingCaseStatus[] = ['DRAFT', 'SUBMITTED', 'CONFIRMED', 'ERROR']
 
 const TERMINAL_COPY: Partial<Record<PortingCaseStatus, { headline: string; body: string }>> = {
   PORTED: {

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -115,6 +115,7 @@ import {
 import {
   canConfirmPortDateForStatus,
   canUseManualPortDateConfirmation,
+  getErrorDiagnosticsEntry,
   getWorkflowErrorEmptyStateMessage,
   shouldShowPliCbdOperationalMeta,
 } from './requestDetailCapabilities'
@@ -1888,6 +1889,7 @@ export function RequestDetailPage() {
   const hasQuickActions =
     quickStatusActions.length > 0 || canManageAssignment || availableCommunicationActions.length > 0
   const workflowErrorMessage = getWorkflowErrorEmptyStateMessage(canUsePliCbdExternalActions)
+  const errorDiagnosticsEntry = getErrorDiagnosticsEntry(caseHistoryItems)
   const workflowActionsSection = (
     <RequestWorkflowActionsSection
       canManageStatus={canManageStatus}
@@ -1918,6 +1920,7 @@ export function RequestDetailPage() {
       onManualConfirmedPortDateChange={setManualConfirmedPortDate}
       onManualPortDateCommentChange={setManualPortDateComment}
       onConfirmManualPortDate={() => void handleConfirmManualPortDate()}
+      errorDiagnosticsEntry={errorDiagnosticsEntry}
       pliCbdExternalActionsSlot={
         <PortingExternalActionsPanel
           availableActions={availableExternalActions}

--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
@@ -1,7 +1,9 @@
 import type {
   PortingCaseStatus,
+  PortingRequestCaseHistoryItemDto,
   PortingRequestStatusActionDto,
 } from '@np-manager/shared'
+import { PORTING_CASE_STATUS_LABELS } from '@np-manager/shared'
 
 const TERMINAL_CLOSED_STATUSES: PortingCaseStatus[] = ['REJECTED', 'CANCELLED', 'PORTED']
 
@@ -38,6 +40,7 @@ export interface RequestWorkflowActionsSectionProps {
   onConfirmManualPortDate: () => void
 
   pliCbdExternalActionsSlot?: React.ReactNode
+  errorDiagnosticsEntry?: PortingRequestCaseHistoryItemDto | null
 }
 
 export function RequestWorkflowActionsSection({
@@ -70,6 +73,7 @@ export function RequestWorkflowActionsSection({
   onManualPortDateCommentChange,
   onConfirmManualPortDate,
   pliCbdExternalActionsSlot,
+  errorDiagnosticsEntry,
 }: RequestWorkflowActionsSectionProps) {
   return (
     <section id="workflow-actions" className="panel scroll-mt-6 p-4">
@@ -81,6 +85,57 @@ export function RequestWorkflowActionsSection({
           </p>
         </div>
       </div>
+
+      {statusInternal === 'ERROR' && (
+        <div
+          className="mb-4 rounded-panel border border-red-200 bg-red-50 p-4"
+          data-testid="error-diagnostics-panel"
+        >
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-red-700">
+            Diagnoza błędu
+          </p>
+          {errorDiagnosticsEntry ? (
+            <dl className="space-y-1 text-sm text-red-900">
+              {errorDiagnosticsEntry.reason && (
+                <div>
+                  <dt className="inline font-medium">Powód: </dt>
+                  <dd className="inline">{errorDiagnosticsEntry.reason}</dd>
+                </div>
+              )}
+              {errorDiagnosticsEntry.comment && (
+                <div>
+                  <dt className="inline font-medium">Szczegóły: </dt>
+                  <dd className="inline">{errorDiagnosticsEntry.comment}</dd>
+                </div>
+              )}
+              {errorDiagnosticsEntry.statusBefore && (
+                <div>
+                  <dt className="inline font-medium">Status przed błędem: </dt>
+                  <dd className="inline">
+                    {PORTING_CASE_STATUS_LABELS[errorDiagnosticsEntry.statusBefore]}
+                  </dd>
+                </div>
+              )}
+              {errorDiagnosticsEntry.actorDisplayName && (
+                <div>
+                  <dt className="inline font-medium">Oznaczył(a): </dt>
+                  <dd className="inline">{errorDiagnosticsEntry.actorDisplayName}</dd>
+                </div>
+              )}
+              <div>
+                <dt className="inline font-medium">Data: </dt>
+                <dd className="inline">
+                  {new Date(errorDiagnosticsEntry.timestamp).toLocaleString('pl-PL')}
+                </dd>
+              </div>
+            </dl>
+          ) : (
+            <p className="text-sm text-red-700">
+              Nie znaleziono szczegółów błędu w historii sprawy.
+            </p>
+          )}
+        </div>
+      )}
 
       {canManageStatus ? (
         <div className="space-y-4">

--- a/apps/frontend/src/pages/Requests/requestDetailCapabilities.test.ts
+++ b/apps/frontend/src/pages/Requests/requestDetailCapabilities.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { SystemCapabilitiesDto } from '@np-manager/shared'
+import type { PortingRequestCaseHistoryItemDto } from '@np-manager/shared'
 import {
   canConfirmPortDateForStatus,
   canUseManualPortDateConfirmation,
+  getErrorDiagnosticsEntry,
   getWorkflowErrorEmptyStateMessage,
   shouldShowPliCbdOperationalMeta,
 } from './requestDetailCapabilities'
@@ -97,5 +99,55 @@ describe('requestDetailCapabilities', () => {
     expect(canConfirmPortDateForStatus('CONFIRMED')).toBe(true)
     expect(canConfirmPortDateForStatus('PORTED')).toBe(false)
     expect(canConfirmPortDateForStatus('CANCELLED')).toBe(false)
+  })
+
+  describe('getErrorDiagnosticsEntry', () => {
+    function makeItem(
+      overrides: Partial<PortingRequestCaseHistoryItemDto>,
+    ): PortingRequestCaseHistoryItemDto {
+      return {
+        id: 'id-1',
+        eventType: 'STATUS_CHANGED',
+        timestamp: '2026-05-01T10:00:00.000Z',
+        statusBefore: null,
+        statusAfter: null,
+        actorDisplayName: null,
+        actorRole: null,
+        reason: null,
+        comment: null,
+        metadata: null,
+        ...overrides,
+      }
+    }
+
+    it('returns last MARK_ERROR entry when present', () => {
+      const items = [
+        makeItem({ id: 'a', statusBefore: 'SUBMITTED', statusAfter: 'ERROR', timestamp: '2026-05-01T09:00:00.000Z', reason: 'Powod 1', metadata: { actionId: 'MARK_ERROR' } }),
+        makeItem({ id: 'b', statusBefore: 'CONFIRMED', statusAfter: 'ERROR', timestamp: '2026-05-01T10:00:00.000Z', reason: 'Powod 2', metadata: { actionId: 'MARK_ERROR' } }),
+      ]
+      const result = getErrorDiagnosticsEntry(items)
+      expect(result?.id).toBe('b')
+      expect(result?.reason).toBe('Powod 2')
+      expect(result?.statusBefore).toBe('CONFIRMED')
+    })
+
+    it('returns null when no ERROR entry exists', () => {
+      const items = [
+        makeItem({ statusAfter: 'SUBMITTED' }),
+        makeItem({ statusAfter: 'CANCELLED' }),
+      ]
+      expect(getErrorDiagnosticsEntry(items)).toBeNull()
+    })
+
+    it('returns null for empty history', () => {
+      expect(getErrorDiagnosticsEntry([])).toBeNull()
+    })
+
+    it('falls back to any statusAfter=ERROR entry even without metadata', () => {
+      const items = [
+        makeItem({ id: 'x', statusAfter: 'ERROR', reason: 'bez metadanych', metadata: null }),
+      ]
+      expect(getErrorDiagnosticsEntry(items)?.id).toBe('x')
+    })
   })
 })

--- a/apps/frontend/src/pages/Requests/requestDetailCapabilities.ts
+++ b/apps/frontend/src/pages/Requests/requestDetailCapabilities.ts
@@ -1,4 +1,9 @@
-import type { PortingCaseStatus, SystemCapabilitiesDto, UserRole } from '@np-manager/shared'
+import type {
+  PortingCaseStatus,
+  PortingRequestCaseHistoryItemDto,
+  SystemCapabilitiesDto,
+  UserRole,
+} from '@np-manager/shared'
 
 const MANUAL_PORT_DATE_CONFIRMATION_ROLES: UserRole[] = ['ADMIN', 'BACK_OFFICE', 'MANAGER']
 const MANUAL_PORT_DATE_CONFIRMATION_STATUSES: PortingCaseStatus[] = [
@@ -40,4 +45,11 @@ export function canUseManualPortDateConfirmation(
 
 export function canConfirmPortDateForStatus(status: PortingCaseStatus): boolean {
   return MANUAL_PORT_DATE_CONFIRMATION_STATUSES.includes(status)
+}
+
+export function getErrorDiagnosticsEntry(
+  items: PortingRequestCaseHistoryItemDto[],
+): PortingRequestCaseHistoryItemDto | null {
+  const errorEntries = items.filter((item) => item.statusAfter === 'ERROR')
+  return errorEntries.at(-1) ?? null
 }

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -257,7 +257,7 @@ export const PORTING_CASE_STATUS_TRANSITIONS: Record<PortingCaseStatus, PortingC
   REJECTED: [],
   CANCELLED: [],
   PORTED: [],
-  ERROR: [],
+  ERROR: ['CANCELLED'],
 }
 
 export const PORTING_CASE_STATUS_ACTION_LABELS: Partial<Record<PortingCaseStatus, string>> = {
@@ -291,6 +291,7 @@ export const PORTING_REQUEST_STATUS_ACTION_IDS = {
   CANCEL: 'CANCEL',
   MARK_ERROR: 'MARK_ERROR',
   MARK_PORTED: 'MARK_PORTED',
+  CANCEL_FROM_ERROR: 'CANCEL_FROM_ERROR',
 } as const
 
 export type PortingRequestStatusActionId =


### PR DESCRIPTION
## Summary

Sprawa w statusie `ERROR` była dead-endem: brak akcji, brak widocznej diagnozy, użytkownik widział tylko komunikat „skontaktuj się z przełożonym". Ten PR dodaje minimalną, bezpieczną obsługę:

- **Panel diagnostyczny ERROR** — wyróżniony blok w sekcji Akcje statusu pokazujący powód błędu, szczegóły, aktora, datę wejścia w błąd i status sprzed błędu; widoczny dla wszystkich ról włącznie z BOK; fallback gdy historia jest pusta
- **Akcja `CANCEL_FROM_ERROR`** — nowe przejście `ERROR → CANCELLED` dostępne dla ról `ADMIN`, `BACK_OFFICE`, `MANAGER`; wymaga podania powodu; BOK nie widzi akcji (backend filtruje)
- **WhatsNextPanel** — `ERROR` dodany do `ROLE_GATED_STATUSES`; BOK widzi komunikat o braku uprawnień zamiast pustego stanu bez wyjaśnienia

`RESUME_FROM_ERROR` (powrót do poprzedniego statusu) celowo pominięty — osobny PR.

## Changes

| Warstwa | Zmiana |
|---|---|
| `packages/shared` | `CANCEL_FROM_ERROR` w `PORTING_REQUEST_STATUS_ACTION_IDS`; `ERROR: ['CANCELLED']` w `STATUS_TRANSITIONS` |
| `apps/backend` | Nowa tranzycja w `WORKFLOW_TRANSITIONS`; `allowedRoles: REVIEW_ROLES`; `requiresReason: true` |
| `apps/frontend` | Helper `getErrorDiagnosticsEntry`; panel diagnostyczny w `RequestWorkflowActionsSection`; przekazanie `errorDiagnosticsEntry` z `RequestDetailPage`; aktualizacja `ROLE_GATED_STATUSES` w `WhatsNextPanel` |

## Test plan

- [ ] Backend: `npx vitest run` z `apps/backend` — `porting-request-workflow.test.ts` (18 testów: CANCEL_FROM_ERROR dla ADMIN/BACK_OFFICE/MANAGER, blokada BOK, wymóg reason)
- [ ] Frontend: `npx vitest run` z `apps/frontend` — `requestDetailCapabilities.test.ts`, `WhatsNextPanel.test.tsx`, `RequestWorkflowActionsSection.test.tsx` (55 testów)
- [ ] TypeScript: `tsc --noEmit` backend + frontend — czyste
- [ ] Runtime S1: ADMIN + FNP-SEED-ERROR-001 → panel diagnostyczny widoczny, akcja „Anuluj z bledu" widoczna
- [ ] Runtime S2: ADMIN submit bez powodu → blokada
- [ ] Runtime S3: ADMIN submit z powodem → status CANCELLED, historia zapisana
- [ ] Runtime S4: BOK + ERROR → panel widoczny, akcja niewidoczna, WhatsNextPanel informuje o roli

🤖 Generated with [Claude Code](https://claude.com/claude-code)