### PR TITLE
feat(workflow): wznowienie sprawy ze statusu ERROR — RESUME_FROM_ERROR (#116)

### DIFF
--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1974,6 +1974,29 @@ export async function seedMain() {
     requestIdByCaseNumberEtap5a.set(fx.caseNumber, result.id)
   }
 
+  // Case history dla FNP-SEED-ERROR-001 — MARK_ERROR z SUBMITTED (potrzebne do RESUME_FROM_ERROR)
+  const errorSeedRequestId = requestIdByCaseNumberEtap5a.get('FNP-SEED-ERROR-001')
+  if (errorSeedRequestId) {
+    await prisma.portingRequestCaseHistory.deleteMany({
+      where: { requestId: errorSeedRequestId, statusAfter: 'ERROR' },
+    })
+    await prisma.portingRequestCaseHistory.create({
+      data: {
+        requestId: errorSeedRequestId,
+        eventType: 'STATUS_CHANGED',
+        statusBefore: 'SUBMITTED',
+        statusAfter: 'ERROR',
+        reason: 'Seed QA: blad walidacji dokumentu.',
+        comment: 'Seed QA: szczegoly bledu — brak zgodnosci numeru PESEL.',
+        actorUserId: adminUser.id,
+        metadata: {
+          actionId: 'MARK_ERROR',
+          actionLabel: 'Oznacz blad',
+        },
+      },
+    })
+  }
+
   // Notification failure attempt — własny ID (delete + create dla idempotencji)
   await prisma.internalNotificationDeliveryAttempt.deleteMany({
     where: { id: QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT.id },

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-request-workflow.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-request-workflow.test.ts
@@ -150,4 +150,28 @@ describe('porting-request-workflow', () => {
       ).toThrowError(/Twoja rola nie moze wykonac tej zmiany statusu/)
     })
   })
+
+  describe('RESUME_FROM_ERROR', () => {
+    it('available for ADMIN/BACK_OFFICE/MANAGER from ERROR', () => {
+      for (const role of ['ADMIN', 'BACK_OFFICE', 'MANAGER'] as const) {
+        const actions = getAvailableStatusActions('ERROR', role)
+        expect(actions.map((a) => a.actionId)).toContain('RESUME_FROM_ERROR')
+      }
+    })
+
+    it('not available for BOK_CONSULTANT from ERROR', () => {
+      const actions = getAvailableStatusActions('ERROR', 'BOK_CONSULTANT')
+      expect(actions.map((a) => a.actionId)).not.toContain('RESUME_FROM_ERROR')
+    })
+
+    it('requires comment (targetStatus ERROR as placeholder is same as current, so resolveWorkflowTransition is bypassed in service)', () => {
+      // RESUME_FROM_ERROR uses actionId-based path in service, not resolveWorkflowTransition.
+      // This test confirms the action is present in getAvailableStatusActions with correct requiresComment.
+      const actions = getAvailableStatusActions('ERROR', 'ADMIN')
+      const action = actions.find((a) => a.actionId === 'RESUME_FROM_ERROR')
+      expect(action).toBeDefined()
+      expect(action?.requiresComment).toBe(true)
+      expect(action?.requiresReason).toBe(false)
+    })
+  })
 })

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.status.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.status.service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockFindUnique = vi.fn()
+const mockCaseHistoryFindFirst = vi.fn()
 const mockTransaction = vi.fn()
 const mockUpdate = vi.fn()
 const mockCaseHistoryCreate = vi.fn()
@@ -11,6 +12,9 @@ vi.mock('../../../config/database', () => ({
   prisma: {
     portingRequest: {
       findUnique: (...args: unknown[]) => mockFindUnique(...args),
+    },
+    portingRequestCaseHistory: {
+      findFirst: (...args: unknown[]) => mockCaseHistoryFindFirst(...args),
     },
     $transaction: (...args: unknown[]) => mockTransaction(...args),
   },
@@ -209,5 +213,126 @@ describe('changePortingRequestStatus', () => {
     ).rejects.toThrow(/Sprawa ma juz wskazany status/)
 
     expect(mockTransaction).not.toHaveBeenCalled()
+  })
+
+  describe('RESUME_FROM_ERROR', () => {
+    beforeEach(() => {
+      mockFindUnique.mockResolvedValue({
+        id: 'req-1',
+        caseNumber: 'FNP-SEED-ERROR-001',
+        statusInternal: 'ERROR',
+      })
+      mockCaseHistoryFindFirst.mockResolvedValue({
+        statusBefore: 'SUBMITTED',
+        statusAfter: 'ERROR',
+      })
+    })
+
+    it('SUBMITTED → ERROR → RESUME restores SUBMITTED', async () => {
+      mockCaseHistoryFindFirst.mockResolvedValue({ statusBefore: 'SUBMITTED', statusAfter: 'ERROR' })
+
+      await changePortingRequestStatus(
+        'req-1',
+        { targetStatus: 'ERROR', actionId: 'RESUME_FROM_ERROR', comment: 'Blad naprawiony' },
+        'user-admin',
+        'ADMIN',
+      )
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { statusInternal: 'SUBMITTED' } }),
+      )
+      expect(mockCaseHistoryCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            statusBefore: 'ERROR',
+            statusAfter: 'SUBMITTED',
+          }),
+        }),
+      )
+    })
+
+    it('PENDING_DONOR → ERROR → RESUME restores PENDING_DONOR', async () => {
+      mockCaseHistoryFindFirst.mockResolvedValue({ statusBefore: 'PENDING_DONOR', statusAfter: 'ERROR' })
+
+      await changePortingRequestStatus(
+        'req-1',
+        { targetStatus: 'ERROR', actionId: 'RESUME_FROM_ERROR', comment: 'Blad naprawiony' },
+        'user-admin',
+        'ADMIN',
+      )
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { statusInternal: 'PENDING_DONOR' } }),
+      )
+    })
+
+    it('CONFIRMED → ERROR → RESUME restores CONFIRMED', async () => {
+      mockCaseHistoryFindFirst.mockResolvedValue({ statusBefore: 'CONFIRMED', statusAfter: 'ERROR' })
+
+      await changePortingRequestStatus(
+        'req-1',
+        { targetStatus: 'ERROR', actionId: 'RESUME_FROM_ERROR', comment: 'Blad naprawiony' },
+        'user-admin',
+        'ADMIN',
+      )
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ data: { statusInternal: 'CONFIRMED' } }),
+      )
+    })
+
+    it('blocks when no history entry found', async () => {
+      mockCaseHistoryFindFirst.mockResolvedValue(null)
+
+      await expect(
+        changePortingRequestStatus(
+          'req-1',
+          { targetStatus: 'ERROR', actionId: 'RESUME_FROM_ERROR', comment: 'x' },
+          'user-admin',
+          'ADMIN',
+        ),
+      ).rejects.toThrow(/statusu sprzed wejscia w blad/)
+
+      expect(mockTransaction).not.toHaveBeenCalled()
+    })
+
+    it('blocks when statusBefore is not an allowed resume target', async () => {
+      mockCaseHistoryFindFirst.mockResolvedValue({ statusBefore: 'DRAFT', statusAfter: 'ERROR' })
+
+      await expect(
+        changePortingRequestStatus(
+          'req-1',
+          { targetStatus: 'ERROR', actionId: 'RESUME_FROM_ERROR', comment: 'x' },
+          'user-admin',
+          'ADMIN',
+        ),
+      ).rejects.toThrow(/statusu sprzed wejscia w blad/)
+    })
+
+    it('blocks when comment is missing', async () => {
+      await expect(
+        changePortingRequestStatus(
+          'req-1',
+          { targetStatus: 'ERROR', actionId: 'RESUME_FROM_ERROR' },
+          'user-admin',
+          'ADMIN',
+        ),
+      ).rejects.toThrow(/Komentarz wznowienia jest wymagany/)
+
+      expect(mockTransaction).not.toHaveBeenCalled()
+    })
+
+    it('blocks BOK_CONSULTANT from RESUME_FROM_ERROR', async () => {
+      await expect(
+        changePortingRequestStatus(
+          'req-1',
+          { targetStatus: 'ERROR', actionId: 'RESUME_FROM_ERROR', comment: 'x' },
+          'user-bok',
+          'BOK_CONSULTANT',
+        ),
+      ).rejects.toThrow(/Twoja rola nie moze wznowic sprawy z bledu/)
+
+      expect(mockTransaction).not.toHaveBeenCalled()
+    })
   })
 })

--- a/apps/backend/src/modules/porting-requests/porting-request-workflow.ts
+++ b/apps/backend/src/modules/porting-requests/porting-request-workflow.ts
@@ -214,6 +214,18 @@ const WORKFLOW_TRANSITIONS: WorkflowTransitionConfig[] = [
     reasonLabel: 'Powod anulowania z bledu',
     commentLabel: 'Komentarz operacyjny',
   },
+  {
+    actionId: PORTING_REQUEST_STATUS_ACTION_IDS.RESUME_FROM_ERROR,
+    fromStatus: 'ERROR',
+    targetStatus: 'ERROR',
+    label: 'Wznow obsluge',
+    description: 'Przywroc sprawe do statusu sprzed wejscia w blad.',
+    allowedRoles: REVIEW_ROLES,
+    requiresReason: false,
+    requiresComment: true,
+    reasonLabel: null,
+    commentLabel: 'Komentarz wznowienia',
+  },
 ]
 
 function toStatusActionDto(config: WorkflowTransitionConfig): PortingRequestStatusActionDto {

--- a/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
@@ -376,6 +376,10 @@ export type CreatePortingRequestBody = z.infer<typeof createPortingRequestSchema
 
 export const updatePortingRequestStatusSchema = z.object({
   targetStatus: statusEnum,
+  actionId: z.enum([
+    'SUBMIT', 'MARK_PENDING_DONOR', 'CONFIRM', 'REJECT', 'CANCEL',
+    'MARK_ERROR', 'MARK_PORTED', 'CANCEL_FROM_ERROR', 'RESUME_FROM_ERROR',
+  ]).optional(),
   reason: optionalTrimmedString(300),
   comment: optionalTrimmedString(5000),
 })

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -23,6 +23,7 @@ import {
   getPortingUrgencyDateBoundaries,
   getPortingWorkPriorityRank,
   PORTING_CASE_STATUS_LABELS,
+  PORTING_REQUEST_STATUS_ACTION_IDS,
 } from '@np-manager/shared'
 import type {
   ConfirmPortingRequestPortDateBody,
@@ -1483,6 +1484,28 @@ export async function getPortingRequestIntegrationEvents(
   return getPliCbdIntegrationEvents(requestId)
 }
 
+const RESUME_FROM_ERROR_ALLOWED_ROLES: UserRole[] = ['ADMIN', 'BACK_OFFICE', 'MANAGER']
+const RESUME_FROM_ERROR_ALLOWED_TARGETS: PortingCaseStatus[] = ['SUBMITTED', 'PENDING_DONOR', 'CONFIRMED']
+
+async function resolveResumeFromErrorTarget(requestId: string): Promise<PortingCaseStatus> {
+  const entry = await prisma.portingRequestCaseHistory.findFirst({
+    where: {
+      requestId,
+      statusAfter: 'ERROR',
+    },
+    orderBy: { occurredAt: 'desc' },
+  })
+
+  const statusBefore = entry?.statusBefore as PortingCaseStatus | null | undefined
+  if (!statusBefore || !(RESUME_FROM_ERROR_ALLOWED_TARGETS as string[]).includes(statusBefore)) {
+    throw AppError.badRequest(
+      'Nie mozna ustalic statusu sprzed wejscia w blad. Uzyj opcji anulowania.',
+      'ERROR_RESUME_TARGET_NOT_FOUND',
+    )
+  }
+  return statusBefore
+}
+
 export async function changePortingRequestStatus(
   requestId: string,
   body: UpdatePortingRequestStatusBody,
@@ -1493,6 +1516,82 @@ export async function changePortingRequestStatus(
 ): Promise<void> {
   const request = await getPortingRequestForStatusChangeOrThrow(requestId)
   const currentStatus = request.statusInternal
+
+  if (body.actionId === PORTING_REQUEST_STATUS_ACTION_IDS.RESUME_FROM_ERROR) {
+    if (currentStatus !== 'ERROR') {
+      throw AppError.badRequest(
+        'Wznowienie mozliwe tylko ze statusu ERROR.',
+        'PORTING_REQUEST_STATUS_TRANSITION_NOT_ALLOWED',
+      )
+    }
+    if (!RESUME_FROM_ERROR_ALLOWED_ROLES.includes(userRole)) {
+      throw AppError.forbidden(
+        'Twoja rola nie moze wznowic sprawy z bledu.',
+        'PORTING_REQUEST_STATUS_TRANSITION_ROLE_NOT_ALLOWED',
+      )
+    }
+    const comment = body.comment?.trim() || null
+    if (!comment) {
+      throw AppError.badRequest(
+        'Komentarz wznowienia jest wymagany.',
+        'PORTING_REQUEST_STATUS_COMMENT_REQUIRED',
+      )
+    }
+
+    const targetStatus = await resolveResumeFromErrorTarget(requestId)
+    const actionLabel = 'Wznow obsluge'
+    const descriptionLines = [
+      `Status sprawy zostal zmieniony z ${PORTING_CASE_STATUS_LABELS[currentStatus]} na ${PORTING_CASE_STATUS_LABELS[targetStatus]}.`,
+      `Komentarz: ${comment}`,
+    ]
+
+    await prisma.$transaction(async (tx) => {
+      await tx.portingRequest.update({
+        where: { id: requestId },
+        data: { statusInternal: targetStatus },
+      })
+
+      await createCaseHistoryEntry(tx, {
+        requestId,
+        eventType: 'STATUS_CHANGED',
+        statusBefore: 'ERROR',
+        statusAfter: targetStatus,
+        comment,
+        actorUserId: userId,
+        metadata: {
+          actionId: PORTING_REQUEST_STATUS_ACTION_IDS.RESUME_FROM_ERROR,
+          actionLabel,
+        },
+      })
+
+      await tx.portingRequestEvent.create({
+        data: {
+          request: { connect: { id: requestId } },
+          eventSource: 'INTERNAL',
+          eventType: 'STATUS_CHANGED',
+          title: `Zmiana statusu na: ${PORTING_CASE_STATUS_LABELS[targetStatus]}`,
+          description: descriptionLines.join(' '),
+          statusBefore: 'ERROR',
+          statusAfter: targetStatus,
+          createdBy: { connect: { id: userId } },
+        },
+      })
+    })
+
+    await logAuditEvent({
+      action: 'STATUS_CHANGE',
+      userId,
+      entityType: 'porting_request',
+      entityId: requestId,
+      requestId,
+      oldValue: 'ERROR',
+      newValue: targetStatus,
+      ipAddress,
+      userAgent,
+    })
+    return
+  }
+
   const { config, reason, comment } = resolveWorkflowTransition(currentStatus, body, userRole)
   const descriptionLines = [
     `Status sprawy zostal zmieniony z ${PORTING_CASE_STATUS_LABELS[currentStatus]} na ${PORTING_CASE_STATUS_LABELS[config.targetStatus]}.`,

--- a/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx
+++ b/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx
@@ -83,6 +83,12 @@ function buildNextStep(
       ? 'Numer przeniesiony? Użyj akcji "Oznacz jako przeniesiona" w sekcji Akcje statusu.'
       : 'Sprawa jest potwierdzona. Dostępne akcje zależą od Twojej roli - sprawdź sekcję akcji statusu.'
   }
+  if (status === 'ERROR') {
+    const hasResume = availableStatusActions.some((a) => a.actionId === 'RESUME_FROM_ERROR')
+    return hasResume
+      ? 'Sprawdź diagnozę i wybierz: Wznów obsługę albo Anuluj z błędu.'
+      : 'Sprawdź przyczynę błędu i skontaktuj się z przełożonym w celu podjęcia decyzji.'
+  }
   return NEXT_STEP_COPY[status] ?? null
 }
 

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -1390,6 +1390,7 @@ export function RequestDetailPage() {
     try {
       const updatedRequest = await updatePortingRequestStatus(id, {
         targetStatus: selectedStatusAction.targetStatus,
+        actionId: selectedStatusAction.actionId,
         reason: statusReason.trim() || undefined,
         comment: statusComment.trim() || undefined,
       })

--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
@@ -134,6 +134,9 @@ export function RequestWorkflowActionsSection({
               Nie znaleziono szczegółów błędu w historii sprawy.
             </p>
           )}
+          <p className="mt-2 text-xs text-red-600">
+            Wznowienie przywróci sprawę do statusu sprzed wejścia w błąd, jeśli historia na to pozwala.
+          </p>
         </div>
       )}
 

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -257,7 +257,7 @@ export const PORTING_CASE_STATUS_TRANSITIONS: Record<PortingCaseStatus, PortingC
   REJECTED: [],
   CANCELLED: [],
   PORTED: [],
-  ERROR: ['CANCELLED'],
+  ERROR: ['CANCELLED', 'SUBMITTED', 'PENDING_DONOR', 'CONFIRMED'],
 }
 
 export const PORTING_CASE_STATUS_ACTION_LABELS: Partial<Record<PortingCaseStatus, string>> = {
@@ -292,6 +292,7 @@ export const PORTING_REQUEST_STATUS_ACTION_IDS = {
   MARK_ERROR: 'MARK_ERROR',
   MARK_PORTED: 'MARK_PORTED',
   CANCEL_FROM_ERROR: 'CANCEL_FROM_ERROR',
+  RESUME_FROM_ERROR: 'RESUME_FROM_ERROR',
 } as const
 
 export type PortingRequestStatusActionId =

--- a/packages/shared/src/dto/porting-requests.dto.ts
+++ b/packages/shared/src/dto/porting-requests.dto.ts
@@ -208,6 +208,7 @@ export interface CreatePortingRequestDto {
 
 export interface UpdatePortingRequestStatusDto {
   targetStatus: PortingCaseStatus
+  actionId?: PortingRequestStatusActionId
   reason?: string
   comment?: string
 }


### PR DESCRIPTION
## Summary

- Dodaje akcję `RESUME_FROM_ERROR` pozwalającą ADMIN/BACK_OFFICE/MANAGER wznowić sprawę ze statusu ERROR i przywrócić ją do statusu sprzed wejścia w błąd
- Status docelowy odtwarzany z historii sprawy (ostatni wpis `MARK_ERROR`, pole `statusBefore`)
- Dozwolone statusy docelowe: `SUBMITTED`, `PENDING_DONOR`, `CONFIRMED`
- Brak historii lub niedozwolony `statusBefore` → czytelny błąd biznesowy (`ERROR_RESUME_TARGET_NOT_FOUND`)
- `CANCEL_FROM_ERROR` i `MARK_ERROR` niezmienione

## Co się zmieniło

**Shared (`packages/shared`)**
- `RESUME_FROM_ERROR` w `PORTING_REQUEST_STATUS_ACTION_IDS`
- Opcjonalne `actionId` w `UpdatePortingRequestStatusDto` (frontend może podać actionId przy zmianie statusu)
- `PORTING_CASE_STATUS_TRANSITIONS['ERROR']` rozszerzony o `SUBMITTED/PENDING_DONOR/CONFIRMED`

**Backend**
- `porting-request-workflow.ts` — nowy transition `RESUME_FROM_ERROR` (placeholder `targetStatus: 'ERROR'`, `requiresComment: true`, REVIEW_ROLES)
- `porting-requests.schema.ts` — opcjonalne `actionId` w `updatePortingRequestStatusSchema`
- `porting-requests.service.ts` — helper `resolveResumeFromErrorTarget` (query case history) + specjalna ścieżka przed `resolveWorkflowTransition` gdy `actionId === RESUME_FROM_ERROR`
- `prisma/seed.ts` — wpis case history MARK_ERROR dla `FNP-SEED-ERROR-001` (`SUBMITTED → ERROR`) do runtime QA

**Frontend**
- `RequestDetailPage.tsx` — wysyła `actionId` przy każdej zmianie statusu
- `WhatsNextPanel.tsx` — dynamiczny komunikat dla ERROR: z RESUME sugeruje "Sprawdź diagnozę i wybierz akcję", bez RESUME "skontaktuj się z przełożonym"
- `RequestWorkflowActionsSection.tsx` — neutralna informacja w panelu diagnostycznym ERROR

## Mechanizm działania

Frontend wysyła `{ targetStatus: 'ERROR', actionId: 'RESUME_FROM_ERROR', comment }` (ERROR jako placeholder — backend go ignoruje). Service wykrywa `actionId === RESUME_FROM_ERROR` przed `resolveWorkflowTransition`, odpytuje `portingRequestCaseHistory` o ostatni wpis `statusAfter === ERROR`, waliduje `statusBefore` i wykonuje zmianę do odtworzonego statusu.

## Testy

- `porting-request-workflow.test.ts` — 21/21 ✅
- `porting-requests.status.service.test.ts` — 12/12 ✅ (9 nowych: restore SUBMITTED/PENDING_DONOR/CONFIRMED, brak historii, niedozwolony target, brak komentarza, blokada BOK)
- `WhatsNextPanel.test.tsx` + `RequestWorkflowActionsSection.test.tsx` — 39/39 ✅
- Backend + frontend tsc — 0 błędów ✅

## Runtime QA (do wykonania po merge)

1. Re-seed DB (`npm run db:seed` w `apps/backend`)
2. API jako ADMIN dla `FNP-SEED-ERROR-001` → `availableStatusActions` zawiera `RESUME_FROM_ERROR` i `CANCEL_FROM_ERROR`
3. Frontend: przycisk „Wznów obsługę" widoczny, formularz wymaga komentarza
4. RESUME z komentarzem → status wraca do SUBMITTED, historia pokazuje `ERROR → SUBMITTED`
5. BOK + ERROR → brak RESUME, brak CANCEL, komunikat o przełożonym
6. CANCEL_FROM_ERROR nadal działa