### PR TITLE
feat(frontend): widocznosc spraw ERROR — karta, quick filter i podswietlenie wiersza (#117)

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
@@ -885,6 +885,7 @@ describe('getPortingRequestsOperationalSummary', () => {
       .mockResolvedValueOnce(12) // withoutCommercialOwner
       .mockResolvedValueOnce(9)  // myCommercialRequests
       .mockResolvedValueOnce(4)  // requestsWithNotificationFailures
+      .mockResolvedValueOnce(2)  // requestsInError
       .mockResolvedValueOnce(7)  // urgent
       .mockResolvedValueOnce(3)  // noDate
       .mockResolvedValueOnce(5)  // needsActionToday
@@ -904,13 +905,14 @@ describe('getPortingRequestsOperationalSummary', () => {
       withoutCommercialOwner: 12,
       myCommercialRequests: 9,
       requestsWithNotificationFailures: 4,
+      requestsInError: 2,
       quickWorkCounts: {
         urgent: 7,
         noDate: 3,
         needsActionToday: 5,
       },
     })
-    expect(mockPortingRequestCount).toHaveBeenCalledTimes(8)
+    expect(mockPortingRequestCount).toHaveBeenCalledTimes(9)
   })
 
   it('summary base counters ignore commercialOwnerFilter and notificationHealthFilter', async () => {
@@ -920,6 +922,7 @@ describe('getPortingRequestsOperationalSummary', () => {
       .mockResolvedValueOnce(3)
       .mockResolvedValueOnce(2)
       .mockResolvedValueOnce(1)
+      .mockResolvedValueOnce(0)
       .mockResolvedValueOnce(0)
       .mockResolvedValueOnce(0)
       .mockResolvedValueOnce(0)
@@ -937,13 +940,23 @@ describe('getPortingRequestsOperationalSummary', () => {
     expect(firstCountWhere).not.toHaveProperty('events')
   })
 
+  it('requestsInError uses statusInternal: ERROR where', async () => {
+    mockPortingRequestCount.mockResolvedValue(0)
+
+    await getPortingRequestsOperationalSummary({}, CURRENT_USER_ID)
+
+    // requestsInError is the 6th call (index 5)
+    const errorCall = mockPortingRequestCount.mock.calls[5]?.[0] as { where: Record<string, unknown> }
+    expect(errorCall.where).toMatchObject({ statusInternal: 'ERROR' })
+  })
+
   it('quickWorkCounts noDate uses confirmedPortDate: null where', async () => {
     mockPortingRequestCount.mockResolvedValue(0)
 
     await getPortingRequestsOperationalSummary({}, CURRENT_USER_ID)
 
-    // noDate count is the 7th call (index 6)
-    const noDateCall = mockPortingRequestCount.mock.calls[6]?.[0] as { where: Record<string, unknown> }
+    // noDate count is the 8th call (index 7)
+    const noDateCall = mockPortingRequestCount.mock.calls[7]?.[0] as { where: Record<string, unknown> }
     expect(noDateCall.where).toMatchObject({ confirmedPortDate: null })
   })
 
@@ -952,8 +965,8 @@ describe('getPortingRequestsOperationalSummary', () => {
 
     await getPortingRequestsOperationalSummary({}, CURRENT_USER_ID)
 
-    // urgent count is the 6th call (index 5)
-    const urgentCall = mockPortingRequestCount.mock.calls[5]?.[0] as { where: Record<string, unknown> }
+    // urgent count is the 7th call (index 6)
+    const urgentCall = mockPortingRequestCount.mock.calls[6]?.[0] as { where: Record<string, unknown> }
     expect(urgentCall.where).toMatchObject({
       statusInternal: { notIn: ['REJECTED', 'CANCELLED', 'PORTED'] },
     })
@@ -964,8 +977,8 @@ describe('getPortingRequestsOperationalSummary', () => {
 
     await getPortingRequestsOperationalSummary({}, CURRENT_USER_ID)
 
-    // needsActionToday count is the 8th call (index 7)
-    const needsActionCall = mockPortingRequestCount.mock.calls[7]?.[0] as { where: Record<string, unknown> }
+    // needsActionToday count is the 9th call (index 8)
+    const needsActionCall = mockPortingRequestCount.mock.calls[8]?.[0] as { where: Record<string, unknown> }
     expect(needsActionCall.where).toMatchObject({
       statusInternal: { notIn: ['REJECTED', 'CANCELLED', 'PORTED'] },
     })

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -1269,6 +1269,7 @@ export async function getPortingRequestsOperationalSummary(
     withoutCommercialOwner,
     myCommercialRequests,
     requestsWithNotificationFailures,
+    requestsInError,
     urgentCount,
     noDateCount,
     needsActionTodayCount,
@@ -1295,6 +1296,11 @@ export async function getPortingRequestsOperationalSummary(
       }),
     }),
     prisma.portingRequest.count({
+      where: withAdditionalWhere(baseWhere, {
+        statusInternal: 'ERROR',
+      }),
+    }),
+    prisma.portingRequest.count({
       where: urgentWhere ? withAdditionalWhere(baseWhere, urgentWhere) : baseWhere,
     }),
     prisma.portingRequest.count({
@@ -1311,6 +1317,7 @@ export async function getPortingRequestsOperationalSummary(
     withoutCommercialOwner,
     myCommercialRequests,
     requestsWithNotificationFailures,
+    requestsInError,
     quickWorkCounts: {
       urgent: urgentCount,
       noDate: noDateCount,

--- a/apps/frontend/src/lib/requestRowHighlight.test.ts
+++ b/apps/frontend/src/lib/requestRowHighlight.test.ts
@@ -65,11 +65,27 @@ describe('getRequestRowHighlight', () => {
   it('REJECTED with today date -> closed, not today', () => {
     expect(getRequestRowHighlight(makeRequest('REJECTED', '2026-04-30'), NOW)).toBe('closed')
   })
+
+  it('ERROR with no date -> error (amber)', () => {
+    expect(getRequestRowHighlight(makeRequest('ERROR', null), NOW)).toBe('error')
+  })
+
+  it('ERROR with overdue date -> error, not overdue', () => {
+    expect(getRequestRowHighlight(makeRequest('ERROR', '2026-01-01'), NOW)).toBe('error')
+  })
+
+  it('ERROR with today date -> error, not today', () => {
+    expect(getRequestRowHighlight(makeRequest('ERROR', '2026-04-30'), NOW)).toBe('error')
+  })
 })
 
 describe('rowHighlightClasses', () => {
   it('ported -> bg-sky-50', () => {
     expect(rowHighlightClasses('ported')).toBe('bg-sky-50')
+  })
+
+  it('error -> bg-amber-50', () => {
+    expect(rowHighlightClasses('error')).toBe('bg-amber-50')
   })
 
   it('overdue -> bg-red-50', () => {

--- a/apps/frontend/src/lib/requestRowHighlight.ts
+++ b/apps/frontend/src/lib/requestRowHighlight.ts
@@ -1,12 +1,12 @@
 import type { PortingRequestListItemDto } from '@np-manager/shared'
 import { calculateDaysDiff } from './portingUrgency'
 
-export type RowHighlight = 'ported' | 'overdue' | 'today' | 'tomorrow' | 'closed' | 'none'
+export type RowHighlight = 'ported' | 'error' | 'overdue' | 'today' | 'tomorrow' | 'closed' | 'none'
 
 /**
  * Zwraca token podswietlenia wiersza na podstawie statusu i daty przeniesienia.
  *
- * Priorytet: PORTED > CANCELLED/REJECTED > overdue > dzis > jutro > brak stylu.
+ * Priorytet: PORTED > CANCELLED/REJECTED > ERROR > overdue > dzis > jutro > brak stylu.
  */
 export function getRequestRowHighlight(
   request: Pick<PortingRequestListItemDto, 'statusInternal' | 'confirmedPortDate'>,
@@ -16,6 +16,7 @@ export function getRequestRowHighlight(
 
   if (statusInternal === 'PORTED') return 'ported'
   if (statusInternal === 'CANCELLED' || statusInternal === 'REJECTED') return 'closed'
+  if (statusInternal === 'ERROR') return 'error'
 
   const daysDiff = calculateDaysDiff(confirmedPortDate, now)
   if (daysDiff === null) return 'none'
@@ -30,6 +31,8 @@ export function rowHighlightClasses(highlight: RowHighlight): string {
   switch (highlight) {
     case 'ported':
       return 'bg-sky-50'
+    case 'error':
+      return 'bg-amber-50'
     case 'overdue':
       return 'bg-red-50'
     case 'today':

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -96,6 +96,7 @@ const quickWorkFilterOptions: Array<{ id: RequestsQuickWorkFilter; label: string
   { id: 'URGENT', label: 'Pilne', icon: 'urgent' },
   { id: 'NO_DATE', label: 'Bez daty', icon: 'no-date' },
   { id: 'NEEDS_ACTION_TODAY', label: 'Wymaga reakcji dzis', icon: 'needs-action-today' },
+  { id: 'STATUS_ERROR', label: 'Wymaga interwencji', icon: 'warning' },
 ]
 
 const commercialOwnerFilterLabels: Record<CommercialOwnerFilter, string> = {
@@ -112,6 +113,7 @@ const quickWorkFilterLabels: Record<RequestsQuickWorkFilter, string> = {
   URGENT: 'Pilne',
   NO_DATE: 'Bez daty',
   NEEDS_ACTION_TODAY: 'Wymaga reakcji dzis',
+  STATUS_ERROR: 'Wymaga interwencji',
 }
 
 const notificationHealthFilterLabels: Record<NotificationHealthFilter, string> = {
@@ -193,7 +195,8 @@ function formatDate(iso: string): string {
   })
 }
 
-function getSummaryCardTone(cardId: 'ALL' | 'WITH_OWNER' | 'WITHOUT_OWNER' | 'MINE' | 'HAS_FAILURES') {
+function getSummaryCardTone(cardId: 'ALL' | 'WITH_OWNER' | 'WITHOUT_OWNER' | 'MINE' | 'HAS_FAILURES' | 'ERROR') {
+  if (cardId === 'ERROR') return 'danger'
   if (cardId === 'HAS_FAILURES') return 'danger'
   if (cardId === 'WITHOUT_OWNER') return 'warning'
   if (cardId === 'WITH_OWNER') return 'success'
@@ -647,11 +650,15 @@ export function RequestsPage() {
 
   const setQuickWorkFilter = useCallback(
     (next: RequestsQuickWorkFilter) => {
-      setParam({
-        quickWorkFilter: next === 'ALL' ? null : next,
-        ownership: null,
-        page: null,
-      })
+      if (next === 'STATUS_ERROR') {
+        setParam({ status: 'ERROR', quickWorkFilter: null, ownership: null, page: null })
+      } else {
+        setParam({
+          quickWorkFilter: next === 'ALL' ? null : next,
+          ownership: null,
+          page: null,
+        })
+      }
     },
     [setParam],
   )
@@ -880,7 +887,7 @@ export function RequestsPage() {
       />
 
       {summary && (
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-5">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-6">
           {summaryCards.map((card) => (
             <MetricCard
               key={card.id}
@@ -888,7 +895,13 @@ export function RequestsPage() {
               value={card.value}
               active={card.isActive}
               tone={getSummaryCardTone(card.id)}
-              detail={card.id === 'HAS_FAILURES' ? 'Wymaga kontroli operacyjnej' : 'Kliknij, aby zawezic kolejke'}
+              detail={
+                card.id === 'HAS_FAILURES'
+                  ? 'Wymaga kontroli operacyjnej'
+                  : card.id === 'ERROR'
+                    ? 'Sprawy z bledem procesu'
+                    : 'Kliknij, aby zawezic kolejke'
+              }
               onClick={() => setParam(card.filterUpdates)}
             />
           ))}
@@ -907,15 +920,18 @@ export function RequestsPage() {
             Widok
           </span>
           {quickWorkFilterOptions.map((filter) => {
-            const active = quickWorkFilter === filter.id
+            const active =
+              filter.id === 'STATUS_ERROR' ? statusFilter === 'ERROR' : quickWorkFilter === filter.id
             const count =
-              summary && filter.id === 'URGENT'
-                ? summary.quickWorkCounts.urgent
-                : summary && filter.id === 'NO_DATE'
-                  ? summary.quickWorkCounts.noDate
-                  : summary && filter.id === 'NEEDS_ACTION_TODAY'
-                    ? summary.quickWorkCounts.needsActionToday
-                    : null
+              summary && filter.id === 'STATUS_ERROR'
+                ? summary.requestsInError
+                : summary && filter.id === 'URGENT'
+                  ? summary.quickWorkCounts.urgent
+                  : summary && filter.id === 'NO_DATE'
+                    ? summary.quickWorkCounts.noDate
+                    : summary && filter.id === 'NEEDS_ACTION_TODAY'
+                      ? summary.quickWorkCounts.needsActionToday
+                      : null
             return (
               <FilterChip
                 key={filter.id}

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -657,10 +657,11 @@ export function RequestsPage() {
           quickWorkFilter: next === 'ALL' ? null : next,
           ownership: null,
           page: null,
+          ...(statusFilter === 'ERROR' ? { status: null } : {}),
         })
       }
     },
-    [setParam],
+    [setParam, statusFilter],
   )
 
   const hasActiveFilters = hasActiveRequestsFilters(filters)

--- a/apps/frontend/src/pages/Requests/requestsOperational.test.ts
+++ b/apps/frontend/src/pages/Requests/requestsOperational.test.ts
@@ -147,6 +147,7 @@ describe('requestsOperational helpers', () => {
         withoutCommercialOwner: 30,
         myCommercialRequests: 8,
         requestsWithNotificationFailures: 5,
+        requestsInError: 3,
         quickWorkCounts: { urgent: 0, noDate: 0, needsActionToday: 0 },
       },
       makeFilters({ commercialOwnerFilter: 'MINE' }),
@@ -159,6 +160,29 @@ describe('requestsOperational helpers', () => {
     const failuresCard = cards.find((card) => card.id === 'HAS_FAILURES')
     expect(failuresCard?.value).toBe(5)
     expect(failuresCard?.isActive).toBe(false)
+
+    const errorCard = cards.find((card) => card.id === 'ERROR')
+    expect(errorCard?.value).toBe(3)
+    expect(errorCard?.isActive).toBe(false)
+  })
+
+  it('ERROR card isActive when statusFilter is ERROR', () => {
+    const cards = buildRequestsSummaryCards(
+      {
+        totalRequests: 10,
+        withCommercialOwner: 5,
+        withoutCommercialOwner: 5,
+        myCommercialRequests: 2,
+        requestsWithNotificationFailures: 1,
+        requestsInError: 2,
+        quickWorkCounts: { urgent: 0, noDate: 0, needsActionToday: 0 },
+      },
+      makeFilters({ statusFilter: 'ERROR' }),
+    )
+
+    const errorCard = cards.find((card) => card.id === 'ERROR')
+    expect(errorCard?.isActive).toBe(true)
+    expect(errorCard?.filterUpdates).toMatchObject({ status: 'ERROR', page: null })
   })
 
   it('applies filter updates to URL params and resets pagination for card clicks', () => {

--- a/apps/frontend/src/pages/Requests/requestsOperational.ts
+++ b/apps/frontend/src/pages/Requests/requestsOperational.ts
@@ -29,6 +29,7 @@ export type RequestsQuickWorkFilter =
   | 'MINE'
   | 'UNASSIGNED'
   | PortingRequestQuickWorkFilter
+  | 'STATUS_ERROR'
 
 const QUICK_WORK_FILTERS: RequestsQuickWorkFilter[] = [
   'ALL',
@@ -37,6 +38,7 @@ const QUICK_WORK_FILTERS: RequestsQuickWorkFilter[] = [
   'URGENT',
   'NO_DATE',
   'NEEDS_ACTION_TODAY',
+  'STATUS_ERROR',
 ]
 
 const LIST_SORTS: PortingRequestListSort[] = [
@@ -78,7 +80,7 @@ export interface RequestsOperationalFilterState {
 }
 
 export interface RequestsSummaryCard {
-  id: 'ALL' | 'WITH_OWNER' | 'WITHOUT_OWNER' | 'MINE' | 'HAS_FAILURES'
+  id: 'ALL' | 'WITH_OWNER' | 'WITHOUT_OWNER' | 'MINE' | 'HAS_FAILURES' | 'ERROR'
   title: string
   value: number
   isActive: boolean
@@ -267,6 +269,16 @@ export function buildRequestsSummaryCards(
       filterUpdates: {
         commercialOwnerFilter: null,
         notificationHealthFilter: 'HAS_FAILURES',
+        page: null,
+      },
+    },
+    {
+      id: 'ERROR',
+      title: 'Wymaga interwencji',
+      value: summary.requestsInError,
+      isActive: filters.statusFilter === 'ERROR',
+      filterUpdates: {
+        status: 'ERROR',
         page: null,
       },
     },

--- a/packages/shared/src/dto/porting-requests.dto.ts
+++ b/packages/shared/src/dto/porting-requests.dto.ts
@@ -173,6 +173,7 @@ export interface PortingRequestOperationalSummaryDto {
   withoutCommercialOwner: number
   myCommercialRequests: number
   requestsWithNotificationFailures: number
+  requestsInError: number
   quickWorkCounts: PortingRequestQuickWorkCountsDto
 }
 


### PR DESCRIPTION
## Summary

- Dodaje `requestsInError` do `PortingRequestOperationalSummaryDto` (shared DTO + backend)
- Karta **Wymaga interwencji** w summary grid ustawia `status=ERROR` przez `filterUpdates`
- Quick filter **STATUS_ERROR** w sekcji „Szybka kolejka pracy" ustawia `status=ERROR` przez `setParam` (nie przez `quickWorkFilter` URL param)
- Row highlight `'error'` (`bg-amber-50`) z priorytetem: PORTED > CANCELLED/REJECTED > **ERROR** > overdue > today > tomorrow
- Grid kart rozszerzony z `2xl:grid-cols-5` na `2xl:grid-cols-6`

## Zmienione pliki

| Plik | Co |
|---|---|
| `packages/shared/src/dto/porting-requests.dto.ts` | `requestsInError: number` w DTO |
| `apps/backend/.../porting-requests.service.ts` | COUNT `statusInternal='ERROR'` w transakcji (pozycja 6/9) |
| `apps/frontend/.../requestsOperational.ts` | Typ `STATUS_ERROR`, interfejs `RequestsSummaryCard` z `'ERROR'`, karta ERROR |
| `apps/frontend/.../RequestsPage.tsx` | Chip STATUS_ERROR, tone danger, `setQuickWorkFilter` override, active state, grid cols |
| `apps/frontend/src/lib/requestRowHighlight.ts` | Typ `'error'`, klasa `bg-amber-50` |
| `*.test.ts` (3 pliki) | Testy dla ERROR highlight, ERROR card, requestsInError w summary |

## Decyzje projektowe

- `STATUS_ERROR` w quick filterze ustawia `status=ERROR` bezpośrednio przez `setParam`, nie przez mechanizm `quickWorkFilter` — unika zmiany backendu/shared dla nowego `PortingRequestQuickWorkFilter`
- Karta ERROR zawsze renderuje się (nawet gdy count=0) — spójnie z HAS_FAILURES
- Chip STATUS_ERROR jest aktywny gdy `statusFilter === 'ERROR'` — niezależnie od źródła filtra (karta lub chip)

## Testy

```
vitest run requestRowHighlight.test.ts requestsOperational.test.ts → 33/33 PASS
vitest run porting-requests.list.service.test.ts → 49/49 PASS
frontend full suite → 416/416 PASS
tsc --noEmit (frontend + backend) → czyste
```

## Dane testowe

Seed zawiera `FNP-SEED-ERROR-001` ze `statusInternal='ERROR'`. Po `npm run db:seed -w apps/backend` sprawa powinna być widoczna w row highlight i karcie.

## Ryzyka

- QA może zmienić FNP-SEED-ERROR-001 przez RESUME/CANCEL — wtedy count=0, row highlight nie jest testowalny bez nowej sprawy ERROR
- Grid 6 kolumn może wyglądać ciasno na ekranach 1440px — do weryfikacji UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)