### PR TITLE
Dopisz historię diagnostyczną dla listowego fixture ERROR i popraw copy w seedzie

### DIFF
--- a/apps/backend/prisma/__tests__/seed.qa-porting-fixtures.test.ts
+++ b/apps/backend/prisma/__tests__/seed.qa-porting-fixtures.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   COMMUNICATION_TEMPLATE_SEED_DATA,
+  QA_ETAP5A_ERROR_HISTORY_FIXTURES,
   QA_ETAP5A_DRAFT_SMS_TEMPLATE_FIXTURE,
   QA_ETAP5A_LONG_DATA_CLIENT,
   QA_ETAP5A_NOTIFICATION_FAILED_ATTEMPT,
@@ -42,9 +43,16 @@ describe('Etap 5A QA porting seed fixtures', () => {
     const fx = QA_ETAP5A_PORTING_FIXTURES.find(
       (f) => f.caseNumber === 'FNP-SEED-ERROR-001',
     )
+    const historyFx = QA_ETAP5A_ERROR_HISTORY_FIXTURES.find(
+      (f) => f.caseNumber === 'FNP-SEED-ERROR-001',
+    )
+
     expect(fx?.statusInternal).toBe('ERROR')
     expect(fx?.rejectionCode).toBe('E06_REJECTED')
     expect(fx?.rejectionReason).toContain('PLI CBD')
+    expect(historyFx?.actionId).toBe('MARK_ERROR')
+    expect(historyFx?.statusBefore).toBe('SUBMITTED')
+    expect(historyFx?.statusAfter).toBe('ERROR')
   })
 
   it('exposes stable LIST-ERROR fixture counted by requestsInError', () => {
@@ -54,11 +62,20 @@ describe('Etap 5A QA porting seed fixtures', () => {
     const requestsInError = QA_ETAP5A_PORTING_FIXTURES.filter(
       (f) => f.statusInternal === 'ERROR',
     ).length
+    const historyFx = QA_ETAP5A_ERROR_HISTORY_FIXTURES.find(
+      (f) => f.caseNumber === 'FNP-SEED-LIST-ERROR-001',
+    )
 
     expect(fx).toBeDefined()
     expect(fx?.caseNumber).toBe('FNP-SEED-LIST-ERROR-001')
     expect(fx?.statusInternal).toBe('ERROR')
     expect(fx?.confirmedPortDate).toBe('2026-04-14T00:00:00.000Z')
+    expect(historyFx).toMatchObject({
+      statusBefore: 'SUBMITTED',
+      statusAfter: 'ERROR',
+      actionId: 'MARK_ERROR',
+    })
+    expect(historyFx?.comment).toContain('sprawa listowa w błędzie')
     expect(requestsInError).toBeGreaterThanOrEqual(1)
   })
 

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -195,6 +195,16 @@ export type Etap5aPortingFixture = {
   internalNotes: string
 }
 
+export type Etap5aErrorHistoryFixture = {
+  caseNumber: string
+  statusBefore: 'SUBMITTED'
+  statusAfter: 'ERROR'
+  reason: string
+  comment: string
+  actionId: 'MARK_ERROR'
+  actionLabel: string
+}
+
 export const QA_ETAP5A_LONG_DATA_CLIENT = {
   pesel: '85060512345',
   firstName: 'Bartłomiej-Konstanty',
@@ -319,6 +329,27 @@ export const QA_ETAP5A_PORTING_FIXTURES: readonly Etap5aPortingFixture[] = [
     rejectionReason: null,
     internalNotes:
       'Seed QA: aktywna sprawa CONFIRMED po terminie do testu czerwonego badge Po terminie i filtra Pilne.',
+  },
+]
+
+export const QA_ETAP5A_ERROR_HISTORY_FIXTURES: readonly Etap5aErrorHistoryFixture[] = [
+  {
+    caseNumber: 'FNP-SEED-ERROR-001',
+    statusBefore: 'SUBMITTED',
+    statusAfter: 'ERROR',
+    reason: 'Seed QA: błąd walidacji dokumentu.',
+    comment: 'Seed QA: szczegóły błędu - brak zgodności numeru PESEL.',
+    actionId: 'MARK_ERROR',
+    actionLabel: 'Oznacz błąd',
+  },
+  {
+    caseNumber: 'FNP-SEED-LIST-ERROR-001',
+    statusBefore: 'SUBMITTED',
+    statusAfter: 'ERROR',
+    reason: 'Seed QA: błąd testowy fixture listowego.',
+    comment: 'Seed QA: sprawa listowa w błędzie do testu kolejki Wymaga interwencji.',
+    actionId: 'MARK_ERROR',
+    actionLabel: 'Oznacz błąd',
   },
 ]
 
@@ -1990,24 +2021,31 @@ export async function seedMain() {
     requestIdByCaseNumberEtap5a.set(fx.caseNumber, result.id)
   }
 
-  // Case history dla FNP-SEED-ERROR-001 — MARK_ERROR z SUBMITTED (potrzebne do RESUME_FROM_ERROR)
-  const errorSeedRequestId = requestIdByCaseNumberEtap5a.get('FNP-SEED-ERROR-001')
-  if (errorSeedRequestId) {
+  // Case history dla fixture'ow ERROR - MARK_ERROR z SUBMITTED (diagnostyka detaila i RESUME_FROM_ERROR)
+  for (const errorHistoryFixture of QA_ETAP5A_ERROR_HISTORY_FIXTURES) {
+    const errorSeedRequestId = requestIdByCaseNumberEtap5a.get(errorHistoryFixture.caseNumber)
+    if (!errorSeedRequestId) {
+      continue
+    }
+
     await prisma.portingRequestCaseHistory.deleteMany({
-      where: { requestId: errorSeedRequestId, statusAfter: 'ERROR' },
+      where: {
+        requestId: errorSeedRequestId,
+        statusAfter: errorHistoryFixture.statusAfter,
+      },
     })
     await prisma.portingRequestCaseHistory.create({
       data: {
         requestId: errorSeedRequestId,
         eventType: 'STATUS_CHANGED',
-        statusBefore: 'SUBMITTED',
-        statusAfter: 'ERROR',
-        reason: 'Seed QA: blad walidacji dokumentu.',
-        comment: 'Seed QA: szczegoly bledu — brak zgodnosci numeru PESEL.',
+        statusBefore: errorHistoryFixture.statusBefore,
+        statusAfter: errorHistoryFixture.statusAfter,
+        reason: errorHistoryFixture.reason,
+        comment: errorHistoryFixture.comment,
         actorUserId: adminUser.id,
         metadata: {
-          actionId: 'MARK_ERROR',
-          actionLabel: 'Oznacz blad',
+          actionId: errorHistoryFixture.actionId,
+          actionLabel: errorHistoryFixture.actionLabel,
         },
       },
     })


### PR DESCRIPTION
## Cel
- Ustabilizować detail dla `FNP-SEED-LIST-ERROR-001` przez dosianie historii `MARK_ERROR`.
- Dodać testowy kontrakt dla obu fixture ERROR.
- Skorygować lokalne, dotknięte obszary copy w seedzie dla diagnostyki błędu.

## Zakres zmian
- Wyodrębniono zestaw historii ERROR w `apps/backend/prisma/seed.ts` i użyto go dla:
  - `FNP-SEED-ERROR-001`
  - `FNP-SEED-LIST-ERROR-001`
- Dodano drugi wpis historii z opisem wskazującym na fixture listowy.
- Rozszerzono test seeda o weryfikację historii `MARK_ERROR` dla obu case numberów.
- Naprawiono zepsute znaki w komunikatach diagnostycznych ERROR w seedzie.

## Zmienione pliki / obszary
- `apps/backend/prisma/seed.ts`
- `apps/backend/prisma/__tests__/seed.qa-porting-fixtures.test.ts`

## Testy i walidacja
- `cd apps/backend && npx vitest run prisma/__tests__/seed.qa-porting-fixtures.test.ts` — passed.
- `cd apps/backend && npx tsc --noEmit` — passed.
- `cd apps/backend && npx vitest run` — passed.
- `cd apps/frontend && npx tsc --noEmit` — passed.
- `cd apps/frontend && npx vitest run` — passed.
- `cd apps/frontend && npx vitest run src/pages/Requests/RequestWorkflowActionsSection.test.tsx src/components/WhatsNextPanel/WhatsNextPanel.test.tsx` — początkowo `spawn EPERM` w środowisku, potem pełny frontend Vitest przeszedł.

## Ryzyka / otwarte punkty
- Brak runtime QA po realnym re-seedzie, więc nie potwierdziłem wizualnie detaila `FNP-SEED-LIST-ERROR-001` po odświeżeniu danych.
- Odczyt mojibake w terminalu PowerShell był mylący, ale bajtowo frontendowe stringi ERROR są poprawne i nie wymagały edycji.

## Checklist przed merge
- [x] `MARK_ERROR` dla listowego fixture ERROR jest dosiany idempotentnie.
- [x] `FNP-SEED-ERROR-001` zachowuje dotychczasową historię workflow.
- [x] Test seeda obejmuje oba przypadki ERROR.
- [x] Nie zmieniano workflow, listy, summary ani highlightu.
- [x] Testy i typecheck przeszły.