### PR TITLE
chore(qa): seed kont QA dla ról BACK_OFFICE i MANAGER + fix copy w sekcji akcji statusu (#120)

### DIFF
--- a/apps/backend/prisma/__tests__/seed.qa-users.test.ts
+++ b/apps/backend/prisma/__tests__/seed.qa-users.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { QA_SEED_USERS } from '../seed'
+
+describe('QA seed users', () => {
+  it('contains all four required QA roles', () => {
+    const roles = QA_SEED_USERS.map((u) => u.role)
+    expect(roles).toContain('ADMIN')
+    expect(roles).toContain('BOK_CONSULTANT')
+    expect(roles).toContain('BACK_OFFICE')
+    expect(roles).toContain('MANAGER')
+  })
+
+  it('contains expected email addresses', () => {
+    const emails = QA_SEED_USERS.map((u) => u.email)
+    expect(emails).toContain('admin@np-manager.local')
+    expect(emails).toContain('bok@np-manager.local')
+    expect(emails).toContain('back-office@np-manager.local')
+    expect(emails).toContain('manager@np-manager.local')
+  })
+
+  it('has unique emails', () => {
+    const emails = QA_SEED_USERS.map((u) => u.email)
+    expect(new Set(emails).size).toBe(emails.length)
+  })
+
+  it('each user has firstName and lastName', () => {
+    for (const user of QA_SEED_USERS) {
+      expect(user.firstName.length).toBeGreaterThan(0)
+      expect(user.lastName.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -851,6 +851,37 @@ const transitionData: TransitionDef[] = [
 ]
 
 // ============================================================
+// QA SEED USERS
+// ============================================================
+
+export const QA_SEED_USERS = [
+  {
+    email: 'admin@np-manager.local',
+    role: 'ADMIN' as const,
+    firstName: 'Admin',
+    lastName: 'NP-Manager',
+  },
+  {
+    email: 'bok@np-manager.local',
+    role: 'BOK_CONSULTANT' as const,
+    firstName: 'Anna',
+    lastName: 'Konsultant',
+  },
+  {
+    email: 'back-office@np-manager.local',
+    role: 'BACK_OFFICE' as const,
+    firstName: 'Back Office',
+    lastName: 'QA',
+  },
+  {
+    email: 'manager@np-manager.local',
+    role: 'MANAGER' as const,
+    firstName: 'Manager',
+    lastName: 'QA',
+  },
+] as const
+
+// ============================================================
 // MAIN SEED
 // ============================================================
 
@@ -1198,6 +1229,58 @@ export async function seedMain() {
   console.info('   ✓ Konto testowe BOK_CONSULTANT gotowe')
   console.info('   📧  E-mail:  bok@np-manager.local')
   console.info('   🔑  Hasło:   Bok@NP2026!')
+
+  // Konto testowe BACK_OFFICE — do weryfikacji RBAC akcji naprawczych ERROR
+  const backOfficePassword = 'BackOffice@NP2026!'
+  const backOfficePasswordHash = await bcrypt.hash(backOfficePassword, 12)
+
+  await prisma.user.upsert({
+    where: { email: 'back-office@np-manager.local' },
+    update: {
+      passwordHash: backOfficePasswordHash,
+      firstName: 'Back Office',
+      lastName: 'QA',
+      role: 'BACK_OFFICE',
+      isActive: true,
+    },
+    create: {
+      email: 'back-office@np-manager.local',
+      passwordHash: backOfficePasswordHash,
+      firstName: 'Back Office',
+      lastName: 'QA',
+      role: 'BACK_OFFICE',
+      isActive: true,
+    },
+  })
+  console.info('   ✓ Konto testowe BACK_OFFICE gotowe')
+  console.info('   📧  E-mail:  back-office@np-manager.local')
+  console.info('   🔑  Hasło:   BackOffice@NP2026!')
+
+  // Konto testowe MANAGER — do weryfikacji RBAC akcji naprawczych ERROR
+  const managerPassword = 'Manager@NP2026!'
+  const managerPasswordHash = await bcrypt.hash(managerPassword, 12)
+
+  await prisma.user.upsert({
+    where: { email: 'manager@np-manager.local' },
+    update: {
+      passwordHash: managerPasswordHash,
+      firstName: 'Manager',
+      lastName: 'QA',
+      role: 'MANAGER',
+      isActive: true,
+    },
+    create: {
+      email: 'manager@np-manager.local',
+      passwordHash: managerPasswordHash,
+      firstName: 'Manager',
+      lastName: 'QA',
+      role: 'MANAGER',
+      isActive: true,
+    },
+  })
+  console.info('   ✓ Konto testowe MANAGER gotowe')
+  console.info('   📧  E-mail:  manager@np-manager.local')
+  console.info('   🔑  Hasło:   Manager@NP2026!')
 
   // ----------------------------------------------------------
   // 6. DANE QA â€” klient i sprawy portowania
@@ -2279,7 +2362,7 @@ export async function seedMain() {
   console.info(`  • ${transitionCount} przejść statusów`)
   console.info(`  • ${documentTypes.length} typów dokumentów`)
   console.info(`  • ${operators.length} operatorów`)
-  console.info('  • 2 konta użytkowników (ADMIN + BOK_CONSULTANT)')
+  console.info('  • 4 konta użytkowników (ADMIN + BOK_CONSULTANT + BACK_OFFICE + MANAGER)')
   console.info(`  • ${settings.length} ustawień systemowych`)
   console.info(`  • ${holidays2026.length} dni wolnych 2026`)
   console.info('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')

--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.test.tsx
@@ -357,6 +357,30 @@ describe('RequestWorkflowActionsSection', () => {
     expect(screen.getByTestId('ext-slot')).toBeDefined()
   })
 
+  it('terminal closed state shows correct Polish copy without encoding artifacts', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({ statusInternal: 'CANCELLED', availableStatusActions: [] })}
+      />,
+    )
+
+    expect(
+      screen.getByText('Sprawa zakończona — brak dostępnych akcji statusowych.'),
+    ).toBeDefined()
+  })
+
+  it('role-gated empty state shows correct Polish copy without encoding artifacts', () => {
+    render(
+      <RequestWorkflowActionsSection
+        {...buildProps({ statusInternal: 'SUBMITTED', availableStatusActions: [] })}
+      />,
+    )
+
+    expect(
+      screen.getByText('Brak akcji dostępnych dla Twojej roli w tym statusie sprawy.'),
+    ).toBeDefined()
+  })
+
   it('does not render external slot wrapper when pliCbdExternalActionsSlot is null', () => {
     const { container } = render(
       <RequestWorkflowActionsSection

--- a/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
+++ b/apps/frontend/src/pages/Requests/RequestWorkflowActionsSection.tsx
@@ -165,7 +165,7 @@ export function RequestWorkflowActionsSection({
             </div>
           ) : TERMINAL_CLOSED_STATUSES.includes(statusInternal) ? (
             <div className="rounded-panel border border-line bg-ink-50 px-4 py-3 text-sm text-ink-500">
-              Sprawa zakoĹ„czona â€” brak dostÄ™pnych akcji statusowych.
+              Sprawa zakończona — brak dostępnych akcji statusowych.
             </div>
           ) : statusInternal === 'ERROR' ? (
             <div className="rounded-panel border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
@@ -173,7 +173,7 @@ export function RequestWorkflowActionsSection({
             </div>
           ) : (
             <div className="rounded-panel border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
-              Brak akcji dostÄ™pnych dla Twojej roli w tym statusie sprawy.
+              Brak akcji dostępnych dla Twojej roli w tym statusie sprawy.
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- Dodano konta QA: `back-office@np-manager.local` (BACK_OFFICE) i `manager@np-manager.local` (MANAGER) — odblokowują runtime QA akcji naprawczych ERROR (RESUME_FROM_ERROR, CANCEL_FROM_ERROR) dla tych ról
- Wyeksportowano `QA_SEED_USERS` jako stałą do weryfikacji w testach seedowych
- Naprawiono mojibake w 2 stringach `RequestWorkflowActionsSection` (terminal state + role-gated empty state)
- Nowe testy: `seed.qa-users.test.ts` (4 asercje) + 2 testy copy w istniejącym pliku

## Kontekst

PR #115–#119 domknęły obsługę ERROR. Audyt 7A wykazał brak kont BACK_OFFICE i MANAGER w seedzie — runtime QA był możliwy tylko dla ADMIN i BOK. Ten PR odblokowuje pełną macierz ról QA.

## Test plan

- [x] `npx vitest run prisma/__tests__/seed.qa-users.test.ts` → 4 passed
- [x] `npx vitest run src/pages/Requests/RequestWorkflowActionsSection.test.tsx` → 23 passed
- [x] `npx tsc --noEmit` (backend) → brak błędów
- [x] `npx tsc --noEmit` (frontend) → brak błędów

## Nie ruszono

- workflow transitions
- RESUME_FROM_ERROR / CANCEL_FROM_ERROR / MARK_ERROR
- lista / summary / requestRowHighlight
- notification health
- CLAUDE.md / AGENTS.md / docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)