### PR TITLE
Ujednolić REVIEW_ROLES dla RESUME_FROM_ERROR

### DIFF
--- a/apps/backend/src/modules/porting-requests/porting-request-workflow.ts
+++ b/apps/backend/src/modules/porting-requests/porting-request-workflow.ts
@@ -31,7 +31,7 @@ export interface ResolvedWorkflowTransition {
 }
 
 const WRITE_ROLES: UserRole[] = ['ADMIN', 'BOK_CONSULTANT', 'BACK_OFFICE', 'MANAGER']
-const REVIEW_ROLES: UserRole[] = ['ADMIN', 'BACK_OFFICE', 'MANAGER']
+export const REVIEW_ROLES: UserRole[] = ['ADMIN', 'BACK_OFFICE', 'MANAGER']
 
 const WORKFLOW_TRANSITIONS: WorkflowTransitionConfig[] = [
   {

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -57,6 +57,7 @@ import {
 } from './porting-request-case-history.service'
 import {
   getAvailableStatusActions,
+  REVIEW_ROLES,
   resolveWorkflowTransition,
 } from './porting-request-workflow'
 import {
@@ -1491,7 +1492,6 @@ export async function getPortingRequestIntegrationEvents(
   return getPliCbdIntegrationEvents(requestId)
 }
 
-const RESUME_FROM_ERROR_ALLOWED_ROLES: UserRole[] = ['ADMIN', 'BACK_OFFICE', 'MANAGER']
 const RESUME_FROM_ERROR_ALLOWED_TARGETS: PortingCaseStatus[] = ['SUBMITTED', 'PENDING_DONOR', 'CONFIRMED']
 
 async function resolveResumeFromErrorTarget(requestId: string): Promise<PortingCaseStatus> {
@@ -1531,7 +1531,7 @@ export async function changePortingRequestStatus(
         'PORTING_REQUEST_STATUS_TRANSITION_NOT_ALLOWED',
       )
     }
-    if (!RESUME_FROM_ERROR_ALLOWED_ROLES.includes(userRole)) {
+    if (!REVIEW_ROLES.includes(userRole)) {
       throw AppError.forbidden(
         'Twoja rola nie moze wznowic sprawy z bledu.',
         'PORTING_REQUEST_STATUS_TRANSITION_ROLE_NOT_ALLOWED',


### PR DESCRIPTION
chore(workflow): use REVIEW_ROLES as single source for RESUME_FROM_ERROR

Summary:
- Exports existing REVIEW_ROLES from porting-request-workflow.ts.
- Removes duplicated RESUME_FROM_ERROR_ALLOWED_ROLES from porting-requests.service.ts.
- RESUME_FROM_ERROR now uses the shared REVIEW_ROLES definition.
- No workflow semantics changed.

Why:
- Audit 7A found a small drift risk: RESUME_FROM_ERROR used a local allowed roles constant that duplicated REVIEW_ROLES.
- This PR keeps the behavior identical while removing the duplicated role source.

Scope:
- apps/backend/src/modules/porting-requests/porting-request-workflow.ts
- apps/backend/src/modules/porting-requests/porting-requests.service.ts

Out of scope:
- frontend
- seed
- summary/list/highlight
- notification health
- workflow behavior changes

Validation:
- npx vitest run src/modules/porting-requests/__tests__/porting-request-workflow.test.ts → PASS, 21 tests
- npx vitest run src/modules/porting-requests/__tests__/porting-requests.status.service.test.ts → PASS, 12 tests
- npx tsc --noEmit → PASS
- git diff --check → PASS, only Windows LF→CRLF warnings

Notes:
- First Vitest run hit transient spawn EPERM, but rerun passed.