### PR TITLE
Uczyń sprawy z błędem procesu najwyższym priorytetem w kolejce pracy

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts
@@ -451,11 +451,29 @@ describe('listPortingRequests - WORK_PRIORITY sort (PR50B)', () => {
     id: string,
     confirmedPortDate: Date | null,
     createdAt: Date,
-  ): { id: string; confirmedPortDate: Date | null; createdAt: Date } {
-    return { id, confirmedPortDate, createdAt }
+    statusInternal: 'SUBMITTED' | 'ERROR' | 'PORTED' | 'CANCELLED' | 'REJECTED' = 'SUBMITTED',
+  ): {
+    id: string
+    statusInternal: 'SUBMITTED' | 'ERROR' | 'PORTED' | 'CANCELLED' | 'REJECTED'
+    confirmedPortDate: Date | null
+    createdAt: Date
+  } {
+    return { id, statusInternal, confirmedPortDate, createdAt }
   }
 
-  it('orders rows by work-priority bucket, then date asc, with NO_DATE between THIS_WEEK and LATER', async () => {
+  it('orders ERROR before overdue, then by work-priority bucket, with NO_DATE between THIS_WEEK and LATER', async () => {
+    const errorNoDate = makeCandidate(
+      'error_no_date',
+      null,
+      new Date('2026-04-12T10:00:00.000Z'),
+      'ERROR',
+    )
+    const errorOverdue = makeCandidate(
+      'error_overdue',
+      new Date('2026-04-19T00:00:00.000Z'),
+      new Date('2026-04-12T11:00:00.000Z'),
+      'ERROR',
+    )
     const overdue = makeCandidate(
       'overdue',
       new Date('2026-04-20T00:00:00.000Z'),
@@ -492,11 +510,31 @@ describe('listPortingRequests - WORK_PRIORITY sort (PR50B)', () => {
       new Date('2026-04-01T10:00:00.000Z'),
     )
 
-    const shuffled = [later, noDateNew, thisWeek, overdue, noDateOld, tomorrow, today]
-    // First findMany: candidates (id, confirmedPortDate, createdAt)
+    const portedOverdue = makeCandidate(
+      'ported_overdue',
+      new Date('2026-04-18T00:00:00.000Z'),
+      new Date('2026-04-01T10:00:00.000Z'),
+      'PORTED',
+    )
+
+    const shuffled = [
+      later,
+      noDateNew,
+      thisWeek,
+      overdue,
+      noDateOld,
+      tomorrow,
+      today,
+      errorNoDate,
+      portedOverdue,
+      errorOverdue,
+    ]
+    // First findMany: candidates (id, statusInternal, confirmedPortDate, createdAt)
     // Second findMany: full rows for page
     mockPortingRequestFindMany.mockResolvedValueOnce(shuffled)
     mockPortingRequestFindMany.mockResolvedValueOnce([
+      makeListRow({ id: 'error_overdue', statusInternal: 'ERROR', confirmedPortDate: errorOverdue.confirmedPortDate }),
+      makeListRow({ id: 'error_no_date', statusInternal: 'ERROR', confirmedPortDate: null }),
       makeListRow({ id: 'overdue', confirmedPortDate: overdue.confirmedPortDate }),
       makeListRow({ id: 'today', confirmedPortDate: today.confirmedPortDate }),
       makeListRow({ id: 'tomorrow', confirmedPortDate: tomorrow.confirmedPortDate }),
@@ -504,6 +542,7 @@ describe('listPortingRequests - WORK_PRIORITY sort (PR50B)', () => {
       makeListRow({ id: 'no_date_old', confirmedPortDate: null }),
       makeListRow({ id: 'no_date_new', confirmedPortDate: null }),
       makeListRow({ id: 'later', confirmedPortDate: later.confirmedPortDate }),
+      makeListRow({ id: 'ported_overdue', statusInternal: 'PORTED', confirmedPortDate: portedOverdue.confirmedPortDate }),
     ])
 
     const result = await listPortingRequests(
@@ -511,8 +550,11 @@ describe('listPortingRequests - WORK_PRIORITY sort (PR50B)', () => {
       CURRENT_USER_ID,
     )
 
-    expect(result.pagination.total).toBe(7)
+    expect(result.pagination.total).toBe(10)
     expect(result.items.map((i) => i.id)).toEqual([
+      'error_no_date',
+      'error_overdue',
+      'ported_overdue',
       'overdue',
       'today',
       'tomorrow',
@@ -526,7 +568,7 @@ describe('listPortingRequests - WORK_PRIORITY sort (PR50B)', () => {
     const secondCall = mockPortingRequestFindMany.mock.calls[1]?.[0] as {
       where: { id: { in: string[] } }
     }
-    expect(secondCall.where.id.in).toHaveLength(7)
+    expect(secondCall.where.id.in).toHaveLength(10)
   })
 
   it('respects pagination boundaries for WORK_PRIORITY sort', async () => {
@@ -845,7 +887,12 @@ describe('listPortingRequests - column sorting (Etap 5I-A)', () => {
 
   it('WORK_PRIORITY sort uses candidates select shape, not column orderBy', async () => {
     mockPortingRequestFindMany.mockResolvedValueOnce([
-      { id: 'r-1', confirmedPortDate: null, createdAt: new Date('2026-04-01T10:00:00.000Z') },
+      {
+        id: 'r-1',
+        statusInternal: 'SUBMITTED',
+        confirmedPortDate: null,
+        createdAt: new Date('2026-04-01T10:00:00.000Z'),
+      },
     ])
     mockPortingRequestFindMany.mockResolvedValueOnce([makeListRow({ id: 'r-1' })])
 
@@ -861,6 +908,7 @@ describe('listPortingRequests - column sorting (Etap 5I-A)', () => {
     }
     expect(candidatesCall.select).toMatchObject({
       id: true,
+      statusInternal: true,
       confirmedPortDate: true,
       createdAt: true,
     })

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -1078,7 +1078,7 @@ async function listPortingRequestsByWorkPriority(
   // miedzy stronami.
   const candidates = await prisma.portingRequest.findMany({
     where,
-    select: { id: true, confirmedPortDate: true, createdAt: true },
+    select: { id: true, statusInternal: true, confirmedPortDate: true, createdAt: true },
   })
 
   const now = new Date()
@@ -1113,6 +1113,7 @@ async function listPortingRequestsByWorkPriority(
 
 interface WorkPriorityCandidate {
   id: string
+  statusInternal: PortingCaseStatus
   confirmedPortDate: Date | null
   createdAt: Date
 }
@@ -1124,8 +1125,8 @@ function compareWorkPriority(
 ): number {
   const aIso = toDateOnlyString(a.confirmedPortDate)
   const bIso = toDateOnlyString(b.confirmedPortDate)
-  const aRank = getPortingWorkPriorityRank(aIso, now)
-  const bRank = getPortingWorkPriorityRank(bIso, now)
+  const aRank = getPortingWorkPriorityRank(aIso, now, a.statusInternal)
+  const bRank = getPortingWorkPriorityRank(bIso, now, b.statusInternal)
   if (aRank !== bRank) return aRank - bRank
 
   // Dla dat: rosnaco po confirmedPortDate. NO_DATE: oldest-first wg createdAt.

--- a/apps/frontend/src/lib/portingUrgency.ts
+++ b/apps/frontend/src/lib/portingUrgency.ts
@@ -46,6 +46,10 @@ export function getWorkPriorityBadge(
 
   if (bucket === 'LATER') return null
 
+  if (bucket === 'ERROR') {
+    return { bucket, label: 'Wymaga interwencji', tone: 'red', emphasized: true }
+  }
+
   if (bucket === 'OVERDUE') {
     const daysDiff = calculatePortingDaysDiff(portDateIso, now)
     const days = Math.abs(daysDiff ?? 0)
@@ -54,7 +58,7 @@ export function getWorkPriorityBadge(
   }
 
   const config: Record<
-    Exclude<PortingWorkPriorityBucket, 'OVERDUE' | 'LATER'>,
+    Exclude<PortingWorkPriorityBucket, 'ERROR' | 'OVERDUE' | 'LATER'>,
     WorkPriorityBadge
   > = {
     TODAY: { bucket: 'TODAY', label: 'Dzis', tone: 'red', emphasized: true },

--- a/apps/frontend/src/lib/requestRowHighlight.test.ts
+++ b/apps/frontend/src/lib/requestRowHighlight.test.ts
@@ -66,7 +66,7 @@ describe('getRequestRowHighlight', () => {
     expect(getRequestRowHighlight(makeRequest('REJECTED', '2026-04-30'), NOW)).toBe('closed')
   })
 
-  it('ERROR with no date -> error (amber)', () => {
+  it('ERROR with no date -> error (strong red)', () => {
     expect(getRequestRowHighlight(makeRequest('ERROR', null), NOW)).toBe('error')
   })
 
@@ -84,8 +84,9 @@ describe('rowHighlightClasses', () => {
     expect(rowHighlightClasses('ported')).toBe('bg-sky-50')
   })
 
-  it('error -> bg-amber-50', () => {
-    expect(rowHighlightClasses('error')).toBe('bg-amber-50')
+  it('error -> bg-red-100, stronger than overdue', () => {
+    expect(rowHighlightClasses('error')).toBe('bg-red-100')
+    expect(rowHighlightClasses('error')).not.toBe(rowHighlightClasses('overdue'))
   })
 
   it('overdue -> bg-red-50', () => {

--- a/apps/frontend/src/lib/requestRowHighlight.ts
+++ b/apps/frontend/src/lib/requestRowHighlight.ts
@@ -32,7 +32,7 @@ export function rowHighlightClasses(highlight: RowHighlight): string {
     case 'ported':
       return 'bg-sky-50'
     case 'error':
-      return 'bg-amber-50'
+      return 'bg-red-100'
     case 'overdue':
       return 'bg-red-50'
     case 'today':

--- a/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.test.tsx
@@ -88,6 +88,7 @@ function mockSummaryResult() {
     withoutCommercialOwner: 1,
     myCommercialRequests: 0,
     requestsWithNotificationFailures: 0,
+    requestsInError: 0,
     quickWorkCounts: {
       urgent: 0,
       noDate: 0,
@@ -567,6 +568,43 @@ describe('RequestsPage quick work filters', () => {
       })
       expect(lastListCall.quickWorkFilter).toBeUndefined()
     })
+  })
+
+  it('maps "Wymaga interwencji" quick filter to status=ERROR without quickWorkFilter or notification health', async () => {
+    renderPage('/requests?page=3&quickWorkFilter=URGENT&notificationHealthFilter=HAS_FAILURES')
+    await screen.findByText('Kolejka spraw portowania')
+
+    const quickFilters = within(
+      screen.getByRole('region', { name: 'Szybkie filtry pracy' }),
+    )
+    fireEvent.click(quickFilters.getByRole('button', { name: /^Wymaga interwencji/ }))
+
+    await waitFor(() => {
+      const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
+      expect(lastListCall).toMatchObject({
+        status: 'ERROR',
+        notificationHealthFilter: 'HAS_FAILURES',
+        page: 1,
+        pageSize: 20,
+      })
+      expect(lastListCall.quickWorkFilter).toBeUndefined()
+    })
+  })
+
+  it('keeps status=ERROR and notification health filter visible together', async () => {
+    renderPage('/requests?status=ERROR&notificationHealthFilter=HAS_FAILURES')
+
+    await waitFor(() => {
+      const lastListCall = getPortingRequestsMock.mock.calls.at(-1)?.[0]
+      expect(lastListCall).toMatchObject({
+        status: 'ERROR',
+        notificationHealthFilter: 'HAS_FAILURES',
+      })
+    })
+
+    expect(screen.getByText('Status:')).not.toBeNull()
+    expect(screen.getByText('Notyfikacje:')).not.toBeNull()
+    expect(screen.getAllByText('Bledy notyfikacji').length).toBeGreaterThan(0)
   })
 
   it('selects "Priorytet pracy" sort, syncs to URL and survives refresh', async () => {

--- a/apps/frontend/src/pages/Requests/RequestsPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestsPage.tsx
@@ -901,6 +901,8 @@ export function RequestsPage() {
                   ? 'Wymaga kontroli operacyjnej'
                   : card.id === 'ERROR'
                     ? 'Sprawy z bledem procesu'
+                    : card.id === 'WITH_OWNER' || card.id === 'WITHOUT_OWNER' || card.id === 'MINE'
+                      ? 'Opiekun handlowy sprawy'
                     : 'Kliknij, aby zawezic kolejke'
               }
               onClick={() => setParam(card.filterUpdates)}

--- a/packages/shared/src/porting-urgency.test.ts
+++ b/packages/shared/src/porting-urgency.test.ts
@@ -20,6 +20,7 @@ describe('getPortingWorkPriorityBucket', () => {
 
   it('orders buckets so that NO_DATE sits between THIS_WEEK and LATER', () => {
     const order = PORTING_WORK_PRIORITY_ORDER
+    expect(order.ERROR).toBeLessThan(order.OVERDUE)
     expect(order.OVERDUE).toBeLessThan(order.TODAY)
     expect(order.TODAY).toBeLessThan(order.TOMORROW)
     expect(order.TOMORROW).toBeLessThan(order.THIS_WEEK)
@@ -28,9 +29,16 @@ describe('getPortingWorkPriorityBucket', () => {
   })
 
   it('getPortingWorkPriorityRank returns the numeric priority key', () => {
-    expect(getPortingWorkPriorityRank('2026-04-20', NOW)).toBe(1)
-    expect(getPortingWorkPriorityRank('2026-04-22', NOW)).toBe(2)
-    expect(getPortingWorkPriorityRank(null, NOW)).toBe(5)
-    expect(getPortingWorkPriorityRank('2026-06-01', NOW)).toBe(6)
+    expect(getPortingWorkPriorityRank('2026-04-20', NOW)).toBe(2)
+    expect(getPortingWorkPriorityRank('2026-04-22', NOW)).toBe(3)
+    expect(getPortingWorkPriorityRank(null, NOW)).toBe(6)
+    expect(getPortingWorkPriorityRank('2026-06-01', NOW)).toBe(7)
+  })
+
+  it('treats process ERROR as the top work-priority bucket regardless of date', () => {
+    expect(getPortingWorkPriorityBucket(null, NOW, 'ERROR')).toBe('ERROR')
+    expect(getPortingWorkPriorityBucket('2026-04-20', NOW, 'ERROR')).toBe('ERROR')
+    expect(getPortingWorkPriorityRank(null, NOW, 'ERROR')).toBe(1)
+    expect(getPortingWorkPriorityRank('2026-04-20', NOW, 'PORTED')).toBe(2)
   })
 })

--- a/packages/shared/src/porting-urgency.ts
+++ b/packages/shared/src/porting-urgency.ts
@@ -1,3 +1,5 @@
+import type { PortingCaseStatus } from './constants'
+
 export type PortingUrgencyLevel =
   | 'NONE'
   | 'OVERDUE'
@@ -136,6 +138,7 @@ export function getPortingUrgencyLevel(
 // a pozniejszymi sprawami LATER.
 
 export type PortingWorkPriorityBucket =
+  | 'ERROR'
   | 'OVERDUE'
   | 'TODAY'
   | 'TOMORROW'
@@ -144,18 +147,22 @@ export type PortingWorkPriorityBucket =
   | 'LATER'
 
 export const PORTING_WORK_PRIORITY_ORDER: Record<PortingWorkPriorityBucket, number> = {
-  OVERDUE: 1,
-  TODAY: 2,
-  TOMORROW: 3,
-  THIS_WEEK: 4,
-  NO_DATE: 5,
-  LATER: 6,
+  ERROR: 1,
+  OVERDUE: 2,
+  TODAY: 3,
+  TOMORROW: 4,
+  THIS_WEEK: 5,
+  NO_DATE: 6,
+  LATER: 7,
 }
 
 export function getPortingWorkPriorityBucket(
   portDateIso: string | null | undefined,
   now: Date = new Date(),
+  statusInternal?: PortingCaseStatus | null,
 ): PortingWorkPriorityBucket {
+  if (statusInternal === 'ERROR') return 'ERROR'
+
   const level = getPortingUrgencyLevel(portDateIso, now)
   if (level === 'NONE') return 'NO_DATE'
   if (level === 'LATER') return 'LATER'
@@ -165,6 +172,7 @@ export function getPortingWorkPriorityBucket(
 export function getPortingWorkPriorityRank(
   portDateIso: string | null | undefined,
   now: Date = new Date(),
+  statusInternal?: PortingCaseStatus | null,
 ): number {
-  return PORTING_WORK_PRIORITY_ORDER[getPortingWorkPriorityBucket(portDateIso, now)]
+  return PORTING_WORK_PRIORITY_ORDER[getPortingWorkPriorityBucket(portDateIso, now, statusInternal)]
 }


### PR DESCRIPTION
## Cel
- Zmienić sortowanie `WORK_PRIORITY`, aby sprawy ze `statusInternal=ERROR` trafiały na początek kolejki niezależnie od daty.
- Dopasować prezentację w UI: mocniejsze wyróżnienie wizualne dla błędów procesu oraz spójne zachowanie filtrów i etykiet.

## Zakres zmian
- Backend:
  - `WORK_PRIORITY` uwzględnia teraz `statusInternal` w danych kandydatów i w rankingu priorytetu.
  - `ERROR` dostał własny bucket priorytetu z najwyższą wagą.
  - Zaktualizowano testy sortowania i selekcji danych.
- Frontend:
  - `ERROR` dostaje czerwone wyróżnienie zamiast bursztynowego.
  - Ujednolicono etykietowanie szybkiego filtra dla spraw wymagających interwencji.
  - Poprawiono opis kafelków filtrów dla opiekuna handlowego.
- Shared:
  - Rozszerzono definicję bucketów priorytetu i testy kontraktu.

## Zmienione pliki / obszary
- `apps/backend/src/modules/porting-requests/porting-requests.service.ts`
- `apps/backend/src/modules/porting-requests/__tests__/porting-requests.list.service.test.ts`
- `apps/frontend/src/lib/portingUrgency.ts`
- `apps/frontend/src/lib/requestRowHighlight.ts`
- `apps/frontend/src/lib/requestRowHighlight.test.ts`
- `apps/frontend/src/pages/Requests/RequestsPage.tsx`
- `apps/frontend/src/pages/Requests/RequestsPage.test.tsx`
- `packages/shared/src/porting-urgency.ts`
- `packages/shared/src/porting-urgency.test.ts`

## Testy i walidacja
- Zmiany są pokryte testami jednostkowymi i integracyjnymi w backendzie oraz frontendzie.
- Zweryfikowano przypadki:
  - `ERROR` przed wszystkimi pozostałymi bucketami priorytetu.
  - Zachowanie `NO_DATE` względem innych statusów.
  - Mocniejsze wyróżnienie wierszy z błędem procesu.
  - Spójność filtrów w `RequestsPage`.
- Nie uruchamiałem lokalnie komend walidacyjnych w tej sesji.

## Ryzyka / otwarte punkty
- Jeśli backend działa z wcześniej zbudowanego `dist/`, po wdrożeniu zmiany może być wymagany rebuild i restart procesu.
- Ręczne QA w UI jest wskazane dla ekranów listy spraw i szybkich filtrów, aby potwierdzić czy nowe wyróżnienie i sortowanie są czytelne w praktyce.

## Checklist przed merge
- [ ] Potwierdzić lokalnie testy backendu i frontendu.
- [ ] Potwierdzić typecheck dla obu aplikacji.
- [ ] Sprawdzić w UI kolejkę `WORK_PRIORITY` na danych zawierających `ERROR`.
- [ ] Potwierdzić, że filtr `Wymaga interwencji` nie nadpisuje aktywnych filtrów notyfikacji.
- [ ] Upewnić się, że zmiana nie wymaga dodatkowych poprawek w dokumentacji ciągłości projektu.