### PR TITLE
Utwórz sprawę FNP z kanoniczną walidacją i nawigacją po utworzeniu

### DIFF
--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.create.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.create.service.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+const mockClientFindUnique = vi.fn()
+const mockOperatorFindUnique = vi.fn()
+const mockOperatorFindFirst = vi.fn()
+const mockPortingRequestFindFirst = vi.fn()
+const mockPortingRequestFindUnique = vi.fn()
+
+vi.mock('../../../config/database', () => ({
+  prisma: {
+    client: {
+      findUnique: (...args: unknown[]) => mockClientFindUnique(...args),
+    },
+    operator: {
+      findUnique: (...args: unknown[]) => mockOperatorFindUnique(...args),
+      findFirst: (...args: unknown[]) => mockOperatorFindFirst(...args),
+    },
+    portingRequest: {
+      findFirst: (...args: unknown[]) => mockPortingRequestFindFirst(...args),
+      findUnique: (...args: unknown[]) => mockPortingRequestFindUnique(...args),
+    },
+  },
+}))
+
+vi.mock('../../../shared/audit/audit.service', () => ({
+  logAuditEvent: vi.fn(),
+}))
+
+vi.mock('../../pli-cbd/pli-cbd.adapter', () => ({
+  PLI_CBD_TRIGGER_SELECT: {},
+  portingRequestPliCbdAdapter: {},
+}))
+
+vi.mock('../../pli-cbd/pli-cbd.integration-tracker', () => ({
+  createFailedIntegrationAttempt: vi.fn(),
+  getPliCbdIntegrationEvents: vi.fn(),
+  withPliCbdIntegrationTracking: vi.fn(),
+}))
+
+vi.mock('../porting-events.service', () => ({
+  PortingEvents: {
+    requestCreated: vi.fn(),
+  },
+}))
+
+vi.mock('../porting-request-case-history.service', () => ({
+  createCaseHistoryEntry: vi.fn(),
+}))
+
+import { createPortingRequest } from '../porting-requests.service'
+import type { CreatePortingRequestBody } from '../porting-requests.schema'
+
+const ACTIVE_OPERATOR = {
+  id: 'op-1',
+  name: 'Dawca',
+  shortName: 'DAWCA',
+  routingNumber: 'OP1',
+  isActive: true,
+}
+
+const DEFAULT_RECIPIENT = {
+  id: 'op-2',
+  name: 'Biorca',
+  shortName: 'BIORCA',
+  routingNumber: 'OP2',
+  isActive: true,
+}
+
+const CLIENT = {
+  id: 'client-1',
+  clientType: 'INDIVIDUAL',
+  firstName: 'Jan',
+  lastName: 'Kowalski',
+  companyName: null,
+  email: 'jan@example.com',
+  addressStreet: 'Testowa 1',
+  addressCity: 'Warszawa',
+  addressZip: '00-001',
+}
+
+function makeBody(overrides: Partial<CreatePortingRequestBody> = {}): CreatePortingRequestBody {
+  return {
+    clientId: 'client-1',
+    donorOperatorId: 'op-1',
+    numberType: 'FIXED_LINE',
+    numberRangeKind: 'SINGLE',
+    primaryNumber: '+48 22 123 45 67',
+    portingMode: 'DAY',
+    requestedPortDate: '2026-05-06',
+    subscriberKind: 'INDIVIDUAL',
+    subscriberFirstName: 'Jan',
+    subscriberLastName: 'Kowalski',
+    identityType: 'PESEL',
+    identityValue: '90010112345',
+    correspondenceAddress: 'Testowa 1, 00-001 Warszawa',
+    hasPowerOfAttorney: true,
+    linkedWholesaleServiceOnRecipientSide: false,
+    contactChannel: 'EMAIL',
+    ...overrides,
+  }
+}
+
+describe('createPortingRequest - numbering safeguards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockClientFindUnique.mockResolvedValue(CLIENT)
+    mockOperatorFindUnique.mockResolvedValue(ACTIVE_OPERATOR)
+    mockOperatorFindFirst.mockResolvedValue(DEFAULT_RECIPIENT)
+  })
+
+  it('rejects active duplicate request for the same canonical single number with 409', async () => {
+    mockPortingRequestFindFirst.mockResolvedValue({
+      id: 'existing-request',
+      caseNumber: 'FNP-20260501-ABC123',
+    })
+
+    await expect(
+      createPortingRequest(makeBody(), 'user-1', 'BOK_CONSULTANT'),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'ACTIVE_REQUEST_ALREADY_EXISTS_FOR_NUMBER',
+    })
+
+    expect(mockPortingRequestFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            { primaryNumber: '+48221234567' },
+            expect.objectContaining({
+              AND: expect.arrayContaining([
+                { rangeStart: { lte: '+48221234567' } },
+                { rangeEnd: { gte: '+48221234567' } },
+              ]),
+            }),
+          ]),
+        }),
+      }),
+    )
+  })
+})

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.create.service.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.create.service.test.ts
@@ -5,6 +5,8 @@ const mockOperatorFindUnique = vi.fn()
 const mockOperatorFindFirst = vi.fn()
 const mockPortingRequestFindFirst = vi.fn()
 const mockPortingRequestFindUnique = vi.fn()
+const mockPortingRequestCreate = vi.fn()
+const mockTransaction = vi.fn()
 
 vi.mock('../../../config/database', () => ({
   prisma: {
@@ -19,6 +21,7 @@ vi.mock('../../../config/database', () => ({
       findFirst: (...args: unknown[]) => mockPortingRequestFindFirst(...args),
       findUnique: (...args: unknown[]) => mockPortingRequestFindUnique(...args),
     },
+    $transaction: (...args: unknown[]) => mockTransaction(...args),
   },
 }))
 
@@ -78,6 +81,76 @@ const CLIENT = {
   addressZip: '00-001',
 }
 
+const tx = {
+  portingRequest: {
+    create: (...args: unknown[]) => mockPortingRequestCreate(...args),
+  },
+}
+
+function makeCreatedRequest(overrides: Record<string, unknown> = {}) {
+  const now = new Date('2026-05-05T10:00:00.000Z')
+
+  return {
+    id: 'created-request',
+    caseNumber: 'FNP-20260505-ABC123',
+    client: CLIENT,
+    numberType: 'FIXED_LINE',
+    numberRangeKind: 'SINGLE',
+    primaryNumber: '+48221234567',
+    rangeStart: null,
+    rangeEnd: null,
+    requestDocumentNumber: null,
+    donorOperator: ACTIVE_OPERATOR,
+    recipientOperator: DEFAULT_RECIPIENT,
+    infrastructureOperator: null,
+    donorOperatorId: ACTIVE_OPERATOR.id,
+    recipientOperatorId: DEFAULT_RECIPIENT.id,
+    infrastructureOperatorId: null,
+    donorRoutingNumber: ACTIVE_OPERATOR.routingNumber,
+    recipientRoutingNumber: DEFAULT_RECIPIENT.routingNumber,
+    sentToExternalSystemAt: null,
+    portingMode: 'DAY',
+    requestedPortDate: new Date('2026-05-06T00:00:00.000Z'),
+    requestedPortTime: '00:00',
+    earliestAcceptablePortDate: null,
+    confirmedPortDate: null,
+    donorAssignedPortDate: null,
+    donorAssignedPortTime: null,
+    statusInternal: 'DRAFT',
+    statusPliCbd: null,
+    pliCbdCaseId: null,
+    pliCbdCaseNumber: null,
+    pliCbdPackageId: null,
+    pliCbdExportStatus: 'NOT_EXPORTED',
+    pliCbdLastSyncAt: null,
+    lastExxReceived: null,
+    lastPliCbdStatusCode: null,
+    lastPliCbdStatusDescription: null,
+    rejectionCode: null,
+    rejectionReason: null,
+    subscriberKind: 'INDIVIDUAL',
+    subscriberFirstName: 'Jan',
+    subscriberLastName: 'Kowalski',
+    subscriberCompanyName: null,
+    identityType: 'PESEL',
+    identityValue: '90010112345',
+    correspondenceAddress: 'Testowa 1, 00-001 Warszawa',
+    hasPowerOfAttorney: true,
+    linkedWholesaleServiceOnRecipientSide: false,
+    contactChannel: 'EMAIL',
+    internalNotes: null,
+    createdByUserId: 'user-1',
+    assignedUser: null,
+    assignedAt: null,
+    assignedByUserId: null,
+    commercialOwner: null,
+    events: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
+}
+
 function makeBody(overrides: Partial<CreatePortingRequestBody> = {}): CreatePortingRequestBody {
   return {
     clientId: 'client-1',
@@ -106,6 +179,14 @@ describe('createPortingRequest - numbering safeguards', () => {
     mockClientFindUnique.mockResolvedValue(CLIENT)
     mockOperatorFindUnique.mockResolvedValue(ACTIVE_OPERATOR)
     mockOperatorFindFirst.mockResolvedValue(DEFAULT_RECIPIENT)
+    mockPortingRequestFindFirst.mockResolvedValue(null)
+    mockPortingRequestFindUnique.mockResolvedValue(null)
+    mockPortingRequestCreate.mockResolvedValue(makeCreatedRequest())
+    mockTransaction.mockImplementation(async (arg: unknown) => {
+      if (Array.isArray(arg)) return Promise.all(arg)
+      if (typeof arg === 'function') return arg(tx)
+      return arg
+    })
   })
 
   it('rejects active duplicate request for the same canonical single number with 409', async () => {
@@ -133,6 +214,58 @@ describe('createPortingRequest - numbering safeguards', () => {
               ]),
             }),
           ]),
+        }),
+      }),
+    )
+  })
+
+  it('stores canonical single number when no duplicate exists', async () => {
+    await createPortingRequest(makeBody(), 'user-1', 'BOK_CONSULTANT')
+
+    expect(mockPortingRequestCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          primaryNumber: '+48221234567',
+          rangeStart: null,
+          rangeEnd: null,
+        }),
+      }),
+    )
+  })
+
+  it('stores canonical DDI range when no duplicate exists', async () => {
+    mockPortingRequestCreate.mockResolvedValue(
+      makeCreatedRequest({
+        numberRangeKind: 'DDI_RANGE',
+        primaryNumber: '+48225551000',
+        rangeStart: '+48225551000',
+        rangeEnd: '+48225551099',
+        requestedPortDate: null,
+        requestedPortTime: null,
+        earliestAcceptablePortDate: new Date('2026-05-08T00:00:00.000Z'),
+      }),
+    )
+
+    await createPortingRequest(
+      makeBody({
+        numberRangeKind: 'DDI_RANGE',
+        primaryNumber: undefined,
+        rangeStart: '+48 22 555 10 00',
+        rangeEnd: '22 555 10 99',
+        portingMode: 'END',
+        requestedPortDate: undefined,
+        earliestAcceptablePortDate: '2026-05-08',
+      }),
+      'user-1',
+      'BOK_CONSULTANT',
+    )
+
+    expect(mockPortingRequestCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          primaryNumber: '+48225551000',
+          rangeStart: '+48225551000',
+          rangeEnd: '+48225551099',
         }),
       }),
     )

--- a/apps/backend/src/modules/porting-requests/__tests__/porting-requests.schema.test.ts
+++ b/apps/backend/src/modules/porting-requests/__tests__/porting-requests.schema.test.ts
@@ -1,8 +1,121 @@
 import { describe, expect, it } from 'vitest'
 import {
+  createPortingRequestSchema,
   portingRequestListQuerySchema,
   portingRequestSummaryQuerySchema,
 } from '../porting-requests.schema'
+
+const VALID_UUID = '11111111-1111-4111-8111-111111111111'
+const DONOR_UUID = '22222222-2222-4222-8222-222222222222'
+
+function nextWeekday(offsetDays = 1): string {
+  const date = new Date()
+  date.setDate(date.getDate() + offsetDays)
+  while ([0, 6].includes(date.getDay())) {
+    date.setDate(date.getDate() + 1)
+  }
+  return date.toISOString().slice(0, 10)
+}
+
+function baseCreateBody(overrides: Record<string, unknown> = {}) {
+  return {
+    clientId: VALID_UUID,
+    donorOperatorId: DONOR_UUID,
+    numberType: 'FIXED_LINE',
+    numberRangeKind: 'SINGLE',
+    primaryNumber: '+48 22 123 45 67',
+    portingMode: 'DAY',
+    requestedPortDate: nextWeekday(),
+    subscriberKind: 'INDIVIDUAL',
+    subscriberFirstName: 'Jan',
+    subscriberLastName: 'Kowalski',
+    identityType: 'PESEL',
+    identityValue: '90010112345',
+    correspondenceAddress: 'Testowa 1, 00-001 Warszawa',
+    hasPowerOfAttorney: true,
+    linkedWholesaleServiceOnRecipientSide: false,
+    contactChannel: 'EMAIL',
+    ...overrides,
+  }
+}
+
+describe('createPortingRequestSchema', () => {
+  it.each(['END', 'EOP'])(
+    'rejects %s mode without earliestAcceptablePortDate',
+    (portingMode) => {
+      const result = createPortingRequestSchema.safeParse(
+        baseCreateBody({
+          portingMode,
+          requestedPortDate: undefined,
+          earliestAcceptablePortDate: undefined,
+        }),
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error?.issues).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            path: ['earliestAcceptablePortDate'],
+            message: 'Dla trybu END/EOP wskaz najwczesniejsza akceptowalna date przeniesienia.',
+          }),
+        ]),
+      )
+    },
+  )
+
+  it('rejects DAY mode without requestedPortDate', () => {
+    const result = createPortingRequestSchema.safeParse(
+      baseCreateBody({ requestedPortDate: undefined }),
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ['requestedPortDate'],
+          message: 'Dla trybu DAY wskaz wnioskowany dzien przeniesienia.',
+        }),
+      ]),
+    )
+  })
+
+  it('rejects DAY mode without power of attorney', () => {
+    const result = createPortingRequestSchema.safeParse(
+      baseCreateBody({ hasPowerOfAttorney: false }),
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ['hasPowerOfAttorney'],
+          message: 'Tryb DAY wymaga pelnomocnictwa.',
+        }),
+      ]),
+    )
+  })
+
+  it('rejects DDI range when canonical end number is lower than canonical start number', () => {
+    const result = createPortingRequestSchema.safeParse(
+      baseCreateBody({
+        numberRangeKind: 'DDI_RANGE',
+        primaryNumber: undefined,
+        rangeStart: '+48 22 555 10 10',
+        rangeEnd: '22 555 10 09',
+      }),
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.error?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: ['rangeEnd'],
+          message: 'Numer koncowy zakresu nie moze byc mniejszy niz numer poczatkowy.',
+        }),
+      ]),
+    )
+  })
+})
 
 describe('portingRequestListQuerySchema - confirmedPortDate range validation', () => {
   it('accepts valid range (from < to)', () => {

--- a/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.schema.ts
@@ -282,6 +282,14 @@ export const createPortingRequestSchema = z
         })
       }
 
+      if (!data.earliestAcceptablePortDate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['earliestAcceptablePortDate'],
+          message: 'Dla trybu END/EOP wskaz najwczesniejsza akceptowalna date przeniesienia.',
+        })
+      }
+
       validateDeferredEarliestDate(data.earliestAcceptablePortDate, ctx)
     }
 

--- a/apps/backend/src/modules/porting-requests/porting-requests.service.ts
+++ b/apps/backend/src/modules/porting-requests/porting-requests.service.ts
@@ -22,6 +22,7 @@ import type {
 import {
   getPortingUrgencyDateBoundaries,
   getPortingWorkPriorityRank,
+  normalizePhoneNumber,
   PORTING_CASE_STATUS_LABELS,
   PORTING_REQUEST_STATUS_ACTION_IDS,
 } from '@np-manager/shared'
@@ -498,6 +499,11 @@ function normalizeIdentityValue(
   return trimmed
 }
 
+function normalizePortingNumber(value: string | null | undefined): string | null {
+  if (!value) return null
+  return normalizePhoneNumber(value)
+}
+
 async function generateCaseNumber(): Promise<string> {
   const datePart = new Date().toISOString().slice(0, 10).replace(/-/g, '')
 
@@ -950,11 +956,16 @@ export async function createPortingRequest(
     ? await getActiveOperatorOrThrow(body.infrastructureOperatorId, 'Operator infrastrukturalny')
     : null
 
+  const numberType = body.numberType ?? 'FIXED_LINE'
   const primaryNumber = body.numberRangeKind === 'SINGLE'
-    ? body.primaryNumber ?? null
-    : body.rangeStart ?? null
-  const rangeStart = body.numberRangeKind === 'DDI_RANGE' ? body.rangeStart ?? null : null
-  const rangeEnd = body.numberRangeKind === 'DDI_RANGE' ? body.rangeEnd ?? null : null
+    ? normalizePortingNumber(body.primaryNumber)
+    : normalizePortingNumber(body.rangeStart)
+  const rangeStart = body.numberRangeKind === 'DDI_RANGE'
+    ? normalizePortingNumber(body.rangeStart)
+    : null
+  const rangeEnd = body.numberRangeKind === 'DDI_RANGE'
+    ? normalizePortingNumber(body.rangeEnd)
+    : null
 
   await assertNoDuplicateOpenRequest(primaryNumber, body.numberRangeKind, rangeStart, rangeEnd)
 
@@ -965,7 +976,7 @@ export async function createPortingRequest(
       data: {
         caseNumber,
         clientId: client.id,
-        numberType: body.numberType,
+        numberType,
         numberRangeKind: body.numberRangeKind,
         primaryNumber,
         rangeStart,

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -1891,6 +1891,11 @@ export function RequestDetailPage() {
     quickStatusActions.length > 0 || canManageAssignment || availableCommunicationActions.length > 0
   const workflowErrorMessage = getWorkflowErrorEmptyStateMessage(canUsePliCbdExternalActions)
   const errorDiagnosticsEntry = getErrorDiagnosticsEntry(caseHistoryItems)
+  const wasCreatedFromFlow =
+    typeof location.state === 'object' &&
+    location.state !== null &&
+    'createdRequest' in location.state &&
+    Boolean((location.state as { createdRequest?: unknown }).createdRequest)
   const workflowActionsSection = (
     <RequestWorkflowActionsSection
       canManageStatus={canManageStatus}
@@ -1954,6 +1959,14 @@ export function RequestDetailPage() {
         onBackToList={backToList}
         onCopyLink={handleCopyLink}
       />
+
+      {wasCreatedFromFlow && (
+        <AlertBanner
+          tone="success"
+          title="Sprawa została utworzona"
+          description={`Numer sprawy: ${request.caseNumber}. Aktualny status: ${PORTING_CASE_STATUS_LABELS[request.statusInternal]}. Najbliższy krok znajdziesz w panelu "Co dalej ze sprawą?" poniżej.`}
+        />
+      )}
 
       <RequestAttentionStrip
         request={request}

--- a/apps/frontend/src/pages/Requests/RequestNewPage.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestNewPage.test.tsx
@@ -82,6 +82,7 @@ describe('RequestNewPage form logic', () => {
   it('clears inactive number fields when switching between SINGLE and DDI_RANGE', () => {
     expect(
       getRequestNumberKindPatch('DDI_RANGE', {
+        numberRangeKind: 'SINGLE',
         primaryNumber: '+48 22 123 45 67',
         rangeStart: '',
         rangeEnd: '',
@@ -95,6 +96,7 @@ describe('RequestNewPage form logic', () => {
 
     expect(
       getRequestNumberKindPatch('SINGLE', {
+        numberRangeKind: 'DDI_RANGE',
         primaryNumber: '',
         rangeStart: '+48 22 555 10 00',
         rangeEnd: '+48 22 555 10 99',
@@ -104,6 +106,38 @@ describe('RequestNewPage form logic', () => {
       primaryNumber: '',
       rangeStart: '',
       rangeEnd: '',
+    })
+  })
+
+  it('keeps entered SINGLE number when clicking active SINGLE again', () => {
+    expect(
+      getRequestNumberKindPatch('SINGLE', {
+        numberRangeKind: 'SINGLE',
+        primaryNumber: '+48 22 123 45 67',
+        rangeStart: '',
+        rangeEnd: '',
+      }),
+    ).toEqual({
+      numberRangeKind: 'SINGLE',
+      primaryNumber: '+48 22 123 45 67',
+      rangeStart: '',
+      rangeEnd: '',
+    })
+  })
+
+  it('keeps entered DDI_RANGE numbers when clicking active DDI_RANGE again', () => {
+    expect(
+      getRequestNumberKindPatch('DDI_RANGE', {
+        numberRangeKind: 'DDI_RANGE',
+        primaryNumber: '',
+        rangeStart: '+48 22 555 10 00',
+        rangeEnd: '+48 22 555 10 99',
+      }),
+    ).toEqual({
+      numberRangeKind: 'DDI_RANGE',
+      primaryNumber: '',
+      rangeStart: '+48 22 555 10 00',
+      rangeEnd: '+48 22 555 10 99',
     })
   })
 

--- a/apps/frontend/src/pages/Requests/RequestNewPage.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestNewPage.test.tsx
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildRequestNewPayload,
+  getCreatedRequestDetailPath,
+  getRequestNewValidationErrors,
+  getRequestNumberKindPatch,
+  normalizeRequestNewPhone,
+} from './RequestNewPage'
+import type { ClientDetailDto } from '@np-manager/shared'
+
+const CLIENT: ClientDetailDto = {
+  id: 'client-1',
+  clientType: 'INDIVIDUAL',
+  displayName: 'Jan Kowalski',
+  firstName: 'Jan',
+  lastName: 'Kowalski',
+  pesel: '90010112345',
+  companyName: null,
+  nip: null,
+  krs: null,
+  proxyName: null,
+  proxyPesel: null,
+  email: 'jan@example.com',
+  phoneContact: '+48221234567',
+  addressStreet: 'Testowa 1',
+  addressCity: 'Warszawa',
+  addressZip: '00-001',
+  requestsCount: 0,
+  createdAt: '2026-05-01T10:00:00.000Z',
+  updatedAt: '2026-05-01T10:00:00.000Z',
+}
+
+const BASE_FIELDS = {
+  donorOperatorId: 'op-1',
+  numberRangeKind: 'SINGLE' as const,
+  primaryNumber: '+48 22 123 45 67',
+  rangeStart: '',
+  rangeEnd: '',
+  requestDocumentNumber: '',
+  portingMode: 'DAY' as const,
+  requestedPortDate: '2026-05-06',
+  earliestAcceptablePortDate: '',
+  subscriberFirstName: 'Jan',
+  subscriberLastName: 'Kowalski',
+  subscriberCompanyName: '',
+  identityType: 'PESEL' as const,
+  identityValue: '90010112345',
+  correspondenceAddress: 'Testowa 1, 00-001 Warszawa',
+  hasPowerOfAttorney: true,
+  linkedWholesaleServiceOnRecipientSide: false,
+  infrastructureOperatorId: '',
+  contactChannel: 'EMAIL' as const,
+  internalNotes: '',
+}
+
+describe('RequestNewPage form logic', () => {
+  it('validates required fields for BOK operator form', () => {
+    const errors = getRequestNewValidationErrors(
+      {
+        ...BASE_FIELDS,
+        donorOperatorId: '',
+        primaryNumber: '',
+        requestedPortDate: '',
+        hasPowerOfAttorney: false,
+        identityValue: '',
+        correspondenceAddress: '',
+      },
+      CLIENT,
+      '2026-05-05',
+    )
+
+    expect(errors).toMatchObject({
+      donorOperatorId: 'Operator oddajacy jest wymagany.',
+      primaryNumber: 'Podaj numer glowny.',
+      requestedPortDate: 'Dla trybu DAY wskaz wnioskowany dzien przeniesienia.',
+      hasPowerOfAttorney: 'Tryb DAY wymaga pelnomocnictwa.',
+      identityValue: 'Wartosc identyfikatora jest wymagana.',
+      correspondenceAddress: 'Adres korespondencyjny jest wymagany.',
+    })
+  })
+
+  it('clears inactive number fields when switching between SINGLE and DDI_RANGE', () => {
+    expect(
+      getRequestNumberKindPatch('DDI_RANGE', {
+        primaryNumber: '+48 22 123 45 67',
+        rangeStart: '',
+        rangeEnd: '',
+      }),
+    ).toEqual({
+      numberRangeKind: 'DDI_RANGE',
+      primaryNumber: '',
+      rangeStart: '',
+      rangeEnd: '',
+    })
+
+    expect(
+      getRequestNumberKindPatch('SINGLE', {
+        primaryNumber: '',
+        rangeStart: '+48 22 555 10 00',
+        rangeEnd: '+48 22 555 10 99',
+      }),
+    ).toEqual({
+      numberRangeKind: 'SINGLE',
+      primaryNumber: '',
+      rangeStart: '',
+      rangeEnd: '',
+    })
+  })
+
+  it('builds canonical SINGLE create payload', () => {
+    const payload = buildRequestNewPayload(BASE_FIELDS, CLIENT)
+
+    expect(payload).toMatchObject({
+      clientId: 'client-1',
+      donorOperatorId: 'op-1',
+      numberType: 'FIXED_LINE',
+      numberRangeKind: 'SINGLE',
+      primaryNumber: '+48221234567',
+      rangeStart: undefined,
+      rangeEnd: undefined,
+      requestedPortDate: '2026-05-06',
+      earliestAcceptablePortDate: undefined,
+    })
+  })
+
+  it('builds canonical DDI_RANGE create payload', () => {
+    const payload = buildRequestNewPayload(
+      {
+        ...BASE_FIELDS,
+        numberRangeKind: 'DDI_RANGE',
+        primaryNumber: '',
+        rangeStart: '+48 22 555 10 00',
+        rangeEnd: '22 555 10 99',
+        portingMode: 'END',
+        requestedPortDate: '',
+        earliestAcceptablePortDate: '2026-05-08',
+      },
+      CLIENT,
+    )
+
+    expect(payload).toMatchObject({
+      numberType: 'FIXED_LINE',
+      numberRangeKind: 'DDI_RANGE',
+      primaryNumber: undefined,
+      rangeStart: '+48225551000',
+      rangeEnd: '+48225551099',
+      requestedPortDate: undefined,
+      earliestAcceptablePortDate: '2026-05-08',
+    })
+  })
+
+  it('uses the canonical detail route after create flow receives caseNumber', () => {
+    expect(getCreatedRequestDetailPath('FNP-20260505-ABC123')).toBe('/requests/FNP-20260505-ABC123')
+    expect(normalizeRequestNewPhone('0048 22 123 45 67')).toBe('+48221234567')
+  })
+})

--- a/apps/frontend/src/pages/Requests/RequestNewPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestNewPage.tsx
@@ -90,13 +90,22 @@ export function normalizeRequestNewPhone(value: string): string {
 
 export function getRequestNumberKindPatch(
   numberRangeKind: PortedNumberKind,
-  _current: Pick<RequestNewFormFields, 'primaryNumber' | 'rangeStart' | 'rangeEnd'>,
+  current: Pick<RequestNewFormFields, 'numberRangeKind' | 'primaryNumber' | 'rangeStart' | 'rangeEnd'>,
 ): Pick<RequestNewFormFields, 'numberRangeKind' | 'primaryNumber' | 'rangeStart' | 'rangeEnd'> {
+  if (numberRangeKind === current.numberRangeKind) {
+    return {
+      numberRangeKind,
+      primaryNumber: current.primaryNumber,
+      rangeStart: current.rangeStart,
+      rangeEnd: current.rangeEnd,
+    }
+  }
+
   return {
     numberRangeKind,
-    primaryNumber: '',
-    rangeStart: '',
-    rangeEnd: '',
+    primaryNumber: numberRangeKind === 'SINGLE' ? current.primaryNumber : '',
+    rangeStart: numberRangeKind === 'DDI_RANGE' ? current.rangeStart : '',
+    rangeEnd: numberRangeKind === 'DDI_RANGE' ? current.rangeEnd : '',
   }
 }
 

--- a/apps/frontend/src/pages/Requests/RequestNewPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestNewPage.tsx
@@ -11,6 +11,7 @@ import {
   PORTING_MODE_DESCRIPTIONS,
   PORTING_MODE_LABELS,
   SUBSCRIBER_IDENTITY_TYPE_LABELS,
+  normalizePhoneNumber,
 } from '@np-manager/shared'
 import type {
   ClientDetailDto,
@@ -22,7 +23,7 @@ import type {
   SubscriberIdentityType,
 } from '@np-manager/shared'
 
-interface FormFields {
+export interface RequestNewFormFields {
   donorOperatorId: string
   numberRangeKind: PortedNumberKind
   primaryNumber: string
@@ -45,9 +46,9 @@ interface FormFields {
   internalNotes: string
 }
 
-type FormErrors = Partial<Record<keyof FormFields | 'clientId' | '_root', string>>
+export type RequestNewFormErrors = Partial<Record<keyof RequestNewFormFields | 'clientId' | '_root', string>>
 
-const EMPTY_FORM: FormFields = {
+const EMPTY_FORM: RequestNewFormFields = {
   donorOperatorId: '',
   numberRangeKind: 'SINGLE',
   primaryNumber: '',
@@ -83,8 +84,24 @@ function isWeekend(value: string): boolean {
   return day === 0 || day === 6
 }
 
-function normalizeComparablePhone(value: string): string {
-  return value.replace(/[\s\-().]/g, '').replace(/^0048/, '+48')
+export function normalizeRequestNewPhone(value: string): string {
+  return normalizePhoneNumber(value.trim())
+}
+
+export function getRequestNumberKindPatch(
+  numberRangeKind: PortedNumberKind,
+  _current: Pick<RequestNewFormFields, 'primaryNumber' | 'rangeStart' | 'rangeEnd'>,
+): Pick<RequestNewFormFields, 'numberRangeKind' | 'primaryNumber' | 'rangeStart' | 'rangeEnd'> {
+  return {
+    numberRangeKind,
+    primaryNumber: '',
+    rangeStart: '',
+    rangeEnd: '',
+  }
+}
+
+export function getCreatedRequestDetailPath(caseNumber: string): string {
+  return buildPath(ROUTES.REQUEST_DETAIL, caseNumber)
 }
 
 function buildCorrespondenceAddress(client: ClientDetailDto): string {
@@ -109,6 +126,94 @@ function getDeferredModeHelperText(mode: PortingMode): string {
   return mode === 'EOP'
     ? 'Finalna date przeniesienia wyznaczy Dawca zgodnie z koncem okresu promocyjnego. To pole okresla najwczesniejszy termin akceptowalny po stronie Biorcy i nie moze wskazywac daty z przeszlosci.'
     : 'Finalna date przeniesienia wyznaczy Dawca zgodnie z okresem wypowiedzenia. To pole okresla najwczesniejszy termin akceptowalny po stronie Biorcy i nie moze wskazywac daty z przeszlosci.'
+}
+
+export function getRequestNewValidationErrors(
+  fields: RequestNewFormFields,
+  selectedClient: ClientDetailDto | null,
+  today = todayString(),
+): RequestNewFormErrors {
+  const nextErrors: RequestNewFormErrors = {}
+  if (!selectedClient) nextErrors.clientId = 'Wybierz klienta z kartoteki.'
+  if (!fields.donorOperatorId) nextErrors.donorOperatorId = 'Operator oddajacy jest wymagany.'
+  if (fields.numberRangeKind === 'SINGLE') {
+    if (!fields.primaryNumber.trim()) nextErrors.primaryNumber = 'Podaj numer glowny.'
+  } else {
+    if (!fields.rangeStart.trim()) nextErrors.rangeStart = 'Podaj numer poczatkowy zakresu.'
+    if (!fields.rangeEnd.trim()) nextErrors.rangeEnd = 'Podaj numer koncowy zakresu.'
+    if (fields.rangeStart.trim() && fields.rangeEnd.trim()) {
+      const start = normalizeRequestNewPhone(fields.rangeStart)
+      const end = normalizeRequestNewPhone(fields.rangeEnd)
+      if (start.length !== end.length) nextErrors.rangeEnd = 'Numery zakresu musza miec zgodny format.'
+      else if (start > end) nextErrors.rangeEnd = 'Numer koncowy zakresu nie moze byc mniejszy niz poczatkowy.'
+    }
+  }
+  if (fields.portingMode === 'DAY') {
+    if (!fields.requestedPortDate) nextErrors.requestedPortDate = 'Dla trybu DAY wskaz wnioskowany dzien przeniesienia.'
+    else if (fields.requestedPortDate < today) nextErrors.requestedPortDate = 'Wnioskowany dzien przeniesienia nie moze byc z przeszlosci.'
+    else if (isWeekend(fields.requestedPortDate)) nextErrors.requestedPortDate = 'Wnioskowany dzien przeniesienia nie moze przypasc w weekend.'
+    if (!fields.hasPowerOfAttorney) nextErrors.hasPowerOfAttorney = 'Tryb DAY wymaga pelnomocnictwa.'
+  } else if (!fields.earliestAcceptablePortDate) {
+    nextErrors.earliestAcceptablePortDate = 'Wskaz najwczesniejsza akceptowalna date po stronie Biorcy.'
+  } else if (fields.earliestAcceptablePortDate < today) {
+    nextErrors.earliestAcceptablePortDate = 'Najwczesniejsza akceptowalna data nie moze byc z przeszlosci.'
+  }
+  if (fields.linkedWholesaleServiceOnRecipientSide) {
+    if (!fields.hasPowerOfAttorney) nextErrors.hasPowerOfAttorney = WHOLESALE_HELPER
+    if (!fields.infrastructureOperatorId) nextErrors.infrastructureOperatorId = 'Wskaz operatora infrastrukturalnego.'
+  }
+  if (selectedClient?.clientType === 'INDIVIDUAL') {
+    if (!fields.subscriberFirstName.trim()) nextErrors.subscriberFirstName = 'Imie abonenta jest wymagane.'
+    if (!fields.subscriberLastName.trim()) nextErrors.subscriberLastName = 'Nazwisko abonenta jest wymagane.'
+  }
+  if (selectedClient?.clientType === 'BUSINESS' && !fields.subscriberCompanyName.trim()) {
+    nextErrors.subscriberCompanyName = 'Nazwa firmy abonenta jest wymagana.'
+  }
+  if (!fields.identityValue.trim()) nextErrors.identityValue = 'Wartosc identyfikatora jest wymagana.'
+  else if (fields.identityType === 'PESEL' && !/^\d{11}$/.test(fields.identityValue.trim())) nextErrors.identityValue = 'PESEL musi zawierac dokladnie 11 cyfr.'
+  else if (fields.identityType === 'NIP' && !/^\d{10}$/.test(fields.identityValue.replace(/[-\s]/g, ''))) nextErrors.identityValue = 'NIP musi zawierac 10 cyfr.'
+  else if (fields.identityType === 'REGON' && !/^(\d{9}|\d{14})$/.test(fields.identityValue.trim())) nextErrors.identityValue = 'REGON musi zawierac 9 albo 14 cyfr.'
+  if (!fields.correspondenceAddress.trim()) nextErrors.correspondenceAddress = 'Adres korespondencyjny jest wymagany.'
+  return nextErrors
+}
+
+export function buildRequestNewPayload(
+  fields: RequestNewFormFields,
+  selectedClient: ClientDetailDto,
+): CreatePortingRequestDto {
+  return {
+    clientId: selectedClient.id,
+    donorOperatorId: fields.donorOperatorId,
+    numberType: 'FIXED_LINE',
+    numberRangeKind: fields.numberRangeKind,
+    primaryNumber: fields.numberRangeKind === 'SINGLE'
+      ? normalizeRequestNewPhone(fields.primaryNumber)
+      : undefined,
+    rangeStart: fields.numberRangeKind === 'DDI_RANGE'
+      ? normalizeRequestNewPhone(fields.rangeStart)
+      : undefined,
+    rangeEnd: fields.numberRangeKind === 'DDI_RANGE'
+      ? normalizeRequestNewPhone(fields.rangeEnd)
+      : undefined,
+    requestDocumentNumber: fields.requestDocumentNumber.trim() || undefined,
+    portingMode: fields.portingMode,
+    requestedPortDate: fields.portingMode === 'DAY' ? fields.requestedPortDate || undefined : undefined,
+    earliestAcceptablePortDate: fields.portingMode !== 'DAY' ? fields.earliestAcceptablePortDate || undefined : undefined,
+    subscriberKind: selectedClient.clientType,
+    subscriberFirstName: selectedClient.clientType === 'INDIVIDUAL' ? fields.subscriberFirstName.trim() : undefined,
+    subscriberLastName: selectedClient.clientType === 'INDIVIDUAL' ? fields.subscriberLastName.trim() : undefined,
+    subscriberCompanyName: selectedClient.clientType === 'BUSINESS' ? fields.subscriberCompanyName.trim() : undefined,
+    identityType: fields.identityType,
+    identityValue: fields.identityValue.trim(),
+    correspondenceAddress: fields.correspondenceAddress.trim(),
+    hasPowerOfAttorney: fields.hasPowerOfAttorney,
+    linkedWholesaleServiceOnRecipientSide: fields.linkedWholesaleServiceOnRecipientSide,
+    infrastructureOperatorId: fields.linkedWholesaleServiceOnRecipientSide && fields.infrastructureOperatorId
+      ? fields.infrastructureOperatorId
+      : undefined,
+    contactChannel: fields.contactChannel,
+    internalNotes: fields.internalNotes.trim() || undefined,
+  }
 }
 
 function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
@@ -149,8 +254,8 @@ export function RequestNewPage() {
   const [selectedClient, setSelectedClient] = useState<ClientDetailDto | null>(null)
   const [isLoadingClient, setIsLoadingClient] = useState(false)
   const [initializedClientId, setInitializedClientId] = useState<string | null>(null)
-  const [fields, setFields] = useState<FormFields>(EMPTY_FORM)
-  const [errors, setErrors] = useState<FormErrors>({})
+  const [fields, setFields] = useState<RequestNewFormFields>(EMPTY_FORM)
+  const [errors, setErrors] = useState<RequestNewFormErrors>({})
   const [isSaving, setIsSaving] = useState(false)
   const isBusiness = selectedClient?.clientType === 'BUSINESS'
   const selectedClientIdFromQuery = searchParams.get('clientId')
@@ -202,14 +307,14 @@ export function RequestNewPage() {
   }, [clientQuery, selectedClient])
 
   const setTextField =
-    (key: keyof FormFields) =>
+    (key: keyof RequestNewFormFields) =>
     (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
       setFields((previous) => ({ ...previous, [key]: event.target.value }))
       setErrors((previous) => ({ ...previous, [key]: undefined, _root: undefined }))
     }
 
   const setCheckboxField =
-    (key: keyof FormFields) =>
+    (key: keyof RequestNewFormFields) =>
     (event: ChangeEvent<HTMLInputElement>) => {
       setFields((previous) => ({ ...previous, [key]: event.target.checked }))
       setErrors((previous) => ({ ...previous, [key]: undefined, _root: undefined }))
@@ -310,89 +415,36 @@ export function RequestNewPage() {
     }))
   }
 
-  function validate(): FormErrors {
-    const nextErrors: FormErrors = {}
-    const today = todayString()
-    if (!selectedClient) nextErrors.clientId = 'Wybierz klienta z kartoteki.'
-    if (!fields.donorOperatorId) nextErrors.donorOperatorId = 'Operator oddajacy jest wymagany.'
-    if (fields.numberRangeKind === 'SINGLE') {
-      if (!fields.primaryNumber.trim()) nextErrors.primaryNumber = 'Podaj numer glowny.'
-    } else {
-      if (!fields.rangeStart.trim()) nextErrors.rangeStart = 'Podaj numer poczatkowy zakresu.'
-      if (!fields.rangeEnd.trim()) nextErrors.rangeEnd = 'Podaj numer koncowy zakresu.'
-      if (fields.rangeStart.trim() && fields.rangeEnd.trim()) {
-        const start = normalizeComparablePhone(fields.rangeStart.trim())
-        const end = normalizeComparablePhone(fields.rangeEnd.trim())
-        if (start.length !== end.length) nextErrors.rangeEnd = 'Numery zakresu musza miec zgodny format.'
-        else if (start > end) nextErrors.rangeEnd = 'Numer koncowy zakresu nie moze byc mniejszy niz poczatkowy.'
-      }
-    }
-    if (fields.portingMode === 'DAY') {
-      if (!fields.requestedPortDate) nextErrors.requestedPortDate = 'Dla trybu DAY wskaz wnioskowany dzien przeniesienia.'
-      else if (fields.requestedPortDate < today) nextErrors.requestedPortDate = 'Wnioskowany dzien przeniesienia nie moze byc z przeszlosci.'
-      else if (isWeekend(fields.requestedPortDate)) nextErrors.requestedPortDate = 'Wnioskowany dzien przeniesienia nie moze przypasc w weekend.'
-      if (!fields.hasPowerOfAttorney) nextErrors.hasPowerOfAttorney = 'Tryb DAY wymaga pelnomocnictwa.'
-    } else if (!fields.earliestAcceptablePortDate) {
-      nextErrors.earliestAcceptablePortDate = 'Wskaz najwczesniejsza akceptowalna date po stronie Biorcy.'
-    } else if (fields.earliestAcceptablePortDate < today) {
-      nextErrors.earliestAcceptablePortDate = 'Najwczesniejsza akceptowalna data nie moze byc z przeszlosci.'
-    }
-    if (fields.linkedWholesaleServiceOnRecipientSide) {
-      if (!fields.hasPowerOfAttorney) nextErrors.hasPowerOfAttorney = WHOLESALE_HELPER
-      if (!fields.infrastructureOperatorId) nextErrors.infrastructureOperatorId = 'Wskaz operatora infrastrukturalnego.'
-    }
-    if (selectedClient?.clientType === 'INDIVIDUAL') {
-      if (!fields.subscriberFirstName.trim()) nextErrors.subscriberFirstName = 'Imie abonenta jest wymagane.'
-      if (!fields.subscriberLastName.trim()) nextErrors.subscriberLastName = 'Nazwisko abonenta jest wymagane.'
-    }
-    if (selectedClient?.clientType === 'BUSINESS' && !fields.subscriberCompanyName.trim()) {
-      nextErrors.subscriberCompanyName = 'Nazwa firmy abonenta jest wymagana.'
-    }
-    if (!fields.identityValue.trim()) nextErrors.identityValue = 'Wartosc identyfikatora jest wymagana.'
-    else if (fields.identityType === 'PESEL' && !/^\d{11}$/.test(fields.identityValue.trim())) nextErrors.identityValue = 'PESEL musi zawierac dokladnie 11 cyfr.'
-    else if (fields.identityType === 'NIP' && !/^\d{10}$/.test(fields.identityValue.replace(/[-\s]/g, ''))) nextErrors.identityValue = 'NIP musi zawierac 10 cyfr.'
-    else if (fields.identityType === 'REGON' && !/^(\d{9}|\d{14})$/.test(fields.identityValue.trim())) nextErrors.identityValue = 'REGON musi zawierac 9 albo 14 cyfr.'
-    if (!fields.correspondenceAddress.trim()) nextErrors.correspondenceAddress = 'Adres korespondencyjny jest wymagany.'
-    return nextErrors
+  const handleNumberKindChange = (numberRangeKind: PortedNumberKind) => {
+    setFields((previous) => ({
+      ...previous,
+      ...getRequestNumberKindPatch(numberRangeKind, previous),
+    }))
+    setErrors((previous) => ({
+      ...previous,
+      primaryNumber: undefined,
+      rangeStart: undefined,
+      rangeEnd: undefined,
+      _root: undefined,
+    }))
   }
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault()
     if (isSaving || !selectedClient) return
-    const validationErrors = validate()
+    const validationErrors = getRequestNewValidationErrors(fields, selectedClient)
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors)
       return
     }
     setIsSaving(true)
     setErrors({})
-    const payload: CreatePortingRequestDto = {
-      clientId: selectedClient.id,
-      donorOperatorId: fields.donorOperatorId,
-      numberRangeKind: fields.numberRangeKind,
-      primaryNumber: fields.numberRangeKind === 'SINGLE' ? fields.primaryNumber.trim() : undefined,
-      rangeStart: fields.numberRangeKind === 'DDI_RANGE' ? fields.rangeStart.trim() : undefined,
-      rangeEnd: fields.numberRangeKind === 'DDI_RANGE' ? fields.rangeEnd.trim() : undefined,
-      requestDocumentNumber: fields.requestDocumentNumber.trim() || undefined,
-      portingMode: fields.portingMode,
-      requestedPortDate: fields.portingMode === 'DAY' ? fields.requestedPortDate || undefined : undefined,
-      earliestAcceptablePortDate: fields.portingMode !== 'DAY' ? fields.earliestAcceptablePortDate || undefined : undefined,
-      subscriberKind: selectedClient.clientType,
-      subscriberFirstName: selectedClient.clientType === 'INDIVIDUAL' ? fields.subscriberFirstName.trim() : undefined,
-      subscriberLastName: selectedClient.clientType === 'INDIVIDUAL' ? fields.subscriberLastName.trim() : undefined,
-      subscriberCompanyName: selectedClient.clientType === 'BUSINESS' ? fields.subscriberCompanyName.trim() : undefined,
-      identityType: fields.identityType,
-      identityValue: fields.identityValue.trim(),
-      correspondenceAddress: fields.correspondenceAddress.trim(),
-      hasPowerOfAttorney: fields.hasPowerOfAttorney,
-      linkedWholesaleServiceOnRecipientSide: fields.linkedWholesaleServiceOnRecipientSide,
-      infrastructureOperatorId: fields.linkedWholesaleServiceOnRecipientSide && fields.infrastructureOperatorId ? fields.infrastructureOperatorId : undefined,
-      contactChannel: fields.contactChannel,
-      internalNotes: fields.internalNotes.trim() || undefined,
-    }
+    const payload = buildRequestNewPayload(fields, selectedClient)
     try {
       const request = await createPortingRequest(payload)
-      void navigate(buildPath(ROUTES.REQUEST_DETAIL, request.id))
+      void navigate(getCreatedRequestDetailPath(request.caseNumber), {
+        state: { createdRequest: true },
+      })
     } catch (error) {
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 409) {
@@ -400,9 +452,9 @@ export function RequestNewPage() {
         } else if (error.response?.status === 400) {
           const details = (error.response.data as { error?: { details?: Record<string, string[]> } } )?.error?.details
           if (details) {
-            const fieldErrors: FormErrors = {}
+            const fieldErrors: RequestNewFormErrors = {}
             for (const [field, messages] of Object.entries(details)) {
-              if (messages?.[0]) fieldErrors[field as keyof FormErrors] = messages[0]
+              if (messages?.[0]) fieldErrors[field as keyof RequestNewFormErrors] = messages[0]
             }
             setErrors(fieldErrors)
           } else {
@@ -423,6 +475,16 @@ export function RequestNewPage() {
 
   const identityTypeOptions: SubscriberIdentityType[] = isBusiness ? ['NIP', 'REGON', 'OTHER'] : ['PESEL', 'ID_CARD', 'PASSPORT', 'OTHER']
   const modeDescription = PORTING_MODE_DESCRIPTIONS[fields.portingMode]
+  const selectedDonorOperator = donorOptions.find((operator) => operator.id === fields.donorOperatorId)
+  const selectedInfrastructureOperator = infrastructureOptions.find(
+    (operator) => operator.id === fields.infrastructureOperatorId,
+  )
+  const numberingSummary = fields.numberRangeKind === 'SINGLE'
+    ? fields.primaryNumber.trim() || 'Nie podano'
+    : `${fields.rangeStart.trim() || 'Nie podano'} - ${fields.rangeEnd.trim() || 'Nie podano'}`
+  const dateSummary = fields.portingMode === 'DAY'
+    ? fields.requestedPortDate || 'Nie podano'
+    : fields.earliestAcceptablePortDate || 'Nie podano'
 
   return (
     <div className="p-6 max-w-4xl">
@@ -475,10 +537,12 @@ export function RequestNewPage() {
           )}
         </SectionCard>
         <SectionCard title="2. Zakres numeracji">
-          <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">Typ uslugi dla B3: numer stacjonarny / FNP.</div>
+          <div className="rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+            Ten formularz dotyczy numerów stacjonarnych FNP.
+          </div>
           <div className="flex rounded-lg border border-gray-300 overflow-hidden w-fit">
             {(['SINGLE', 'DDI_RANGE'] as PortedNumberKind[]).map((kind) => (
-              <button key={kind} type="button" onClick={() => setFields((previous) => ({ ...previous, numberRangeKind: kind }))} className={`px-6 py-2 text-sm font-medium transition-colors ${fields.numberRangeKind === kind ? 'bg-blue-600 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}>
+              <button key={kind} type="button" onClick={() => handleNumberKindChange(kind)} className={`px-6 py-2 text-sm font-medium transition-colors ${fields.numberRangeKind === kind ? 'bg-blue-600 text-white' : 'bg-white text-gray-700 hover:bg-gray-50'}`}>
                 {PORTED_NUMBER_KIND_LABELS[kind]}
               </button>
             ))}
@@ -585,6 +649,9 @@ export function RequestNewPage() {
             <input type="checkbox" checked={fields.hasPowerOfAttorney} onChange={setCheckboxField('hasPowerOfAttorney')} className="w-4 h-4 rounded border-gray-300 text-blue-600" />
             <span className="text-sm text-gray-700">Klient udzielil pelnomocnictwa</span>
           </label>
+          <p className="text-xs text-gray-500">
+            System rejestruje informację operacyjną o pełnomocnictwie. Skan dokumentu nie jest przechowywany w tym formularzu.
+          </p>
           {errors.hasPowerOfAttorney && <p className="error-message">{errors.hasPowerOfAttorney}</p>}
 
           <label className="flex items-center gap-3 cursor-pointer">
@@ -623,6 +690,41 @@ export function RequestNewPage() {
           <FormField label="Notatki wewnetrzne (opcjonalnie)" error={errors.internalNotes}>
             <textarea value={fields.internalNotes} onChange={setTextField('internalNotes')} className={`input-field min-h-28 ${errors.internalNotes ? 'input-error' : ''}`} placeholder="Dodatkowe informacje operacyjne, ustalenia z klientem, kontekst sprawy..." />
           </FormField>
+        </SectionCard>
+
+        <SectionCard title="Sprawdź przed utworzeniem">
+          <dl className="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2">
+            <div>
+              <dt className="text-gray-500">Klient</dt>
+              <dd className="font-medium text-gray-900">{selectedClient?.displayName ?? 'Nie wybrano'}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Numeracja</dt>
+              <dd className="font-mono text-gray-900">{numberingSummary}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Operator oddający</dt>
+              <dd className="font-medium text-gray-900">{selectedDonorOperator?.name ?? 'Nie wybrano'}</dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Tryb i data</dt>
+              <dd className="font-medium text-gray-900">
+                {PORTING_MODE_LABELS[fields.portingMode]} · {dateSummary}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-gray-500">Pełnomocnictwo</dt>
+              <dd className="font-medium text-gray-900">{fields.hasPowerOfAttorney ? 'Zarejestrowane' : 'Brak informacji'}</dd>
+            </div>
+            {fields.linkedWholesaleServiceOnRecipientSide && (
+              <div>
+                <dt className="text-gray-500">Usługa hurtowa</dt>
+                <dd className="font-medium text-gray-900">
+                  {selectedInfrastructureOperator?.name ?? 'Wymaga wskazania operatora infrastrukturalnego'}
+                </dd>
+              </div>
+            )}
+          </dl>
         </SectionCard>
 
         {errors._root && (


### PR DESCRIPTION
**Cel**
- Domknąć MVP operatorowego tworzenia sprawy FNP: spójna walidacja backend/frontend, kanoniczna normalizacja numeracji i czytelny flow po utworzeniu.

**Zakres zmian**
- Backend:
  - `END/EOP` wymagają `earliestAcceptablePortDate`.
  - `DAY` nadal wymaga `requestedPortDate` i pełnomocnictwa.
  - numeracja jest normalizowana do formatu kanonicznego przed zapisem i przed sprawdzeniem duplikatu.
  - duplikat aktywnej sprawy dla tej samej numeracji zwraca `409`.
- Frontend:
  - formularz `RequestNewPage` ma jaśniejsze copy po polsku, opis FNP i blok „Sprawdź przed utworzeniem”.
  - zmiana `SINGLE/DDI_RANGE` czyści pola, które przestają być aktywne.
  - payload tworzenia jest budowany w sposób zgodny z backendem.
  - po utworzeniu sprawa otwiera się na kanonicznym route po `caseNumber`.
  - detail pokazuje jasny komunikat, że sprawa została utworzona, oraz odsyła do panelu „Co dalej ze sprawą?”.
- Testy:
  - dodane testy schematu backendu dla `DAY`, `END/EOP` i DDI range.
  - dodany test serwisu dla duplikatu aktywnej numeracji.
  - dodane testy logiki formularza i payloadu na froncie.

**Zmienione pliki / obszary**
- [apps/backend/src/modules/porting-requests/porting-requests.schema.ts](D:/Projekt/np-manager/apps/backend/src/modules/porting-requests/porting-requests.schema.ts)
- [apps/backend/src/modules/porting-requests/porting-requests.service.ts](D:/Projekt/np-manager/apps/backend/src/modules/porting-requests/porting-requests.service.ts)
- [apps/backend/src/modules/porting-requests/__tests__/porting-requests.schema.test.ts](D:/Projekt/np-manager/apps/backend/src/modules/porting-requests/__tests__/porting-requests.schema.test.ts)
- [apps/backend/src/modules/porting-requests/__tests__/porting-requests.create.service.test.ts](D:/Projekt/np-manager/apps/backend/src/modules/porting-requests/__tests__/porting-requests.create.service.test.ts)
- [apps/frontend/src/pages/Requests/RequestNewPage.tsx](D:/Projekt/np-manager/apps/frontend/src/pages/Requests/RequestNewPage.tsx)
- [apps/frontend/src/pages/Requests/RequestNewPage.test.tsx](D:/Projekt/np-manager/apps/frontend/src/pages/Requests/RequestNewPage.test.tsx)
- [apps/frontend/src/pages/Requests/RequestDetailPage.tsx](D:/Projekt/np-manager/apps/frontend/src/pages/Requests/RequestDetailPage.tsx)

**Testy i walidacja**
- `npx vitest run` w `apps/backend` - PASS, 73 pliki / 594 testy.
- `npx vitest run` w `apps/frontend` - PASS, 48 plików / 425 testów.
- `npx tsc --noEmit` w `apps/backend` - PASS.
- `npx tsc --noEmit` w `apps/frontend` - PASS.
- `npm run build -w packages/shared` - PASS.
- `npm run build -w apps/frontend` - PASS.
- `npx prisma generate --schema prisma/schema.prisma --no-engine` - PASS.
- `npm run build --ignore-scripts -w apps/backend` - PASS.
- `npm run build -w apps/backend` - niepowodzenie środowiskowe: `prisma generate` blokuje rename DLL na Windows (`EPERM`).

**Ryzyka / otwarte punkty**
- Pełny backend build nadal zależy od `prisma generate` bez blokady na Windows; w tym środowisku trzeba używać wariantu `--no-engine` albo odblokować plik DLL.
- Frontend build pokazuje ostrzeżenia Vite o dużym bundlu, ale nie blokuje wydania.
- Ręczne QA formularza i przejścia po utworzeniu nadal warto zrobić w przeglądarce, bo to zmiana UX na ścieżce operatora.

**Checklist przed merge**
- [x] Walidacja backendowa dla `DAY` / `END` / `EOP` jest spójna.
- [x] Numeracja jest normalizowana po stronie backendu i frontendowego payloadu.
- [x] Duplikat aktywnej numeracji zwraca `409`.
- [x] Formularz czyści nieaktywne pola po zmianie typu numeracji.
- [x] Po utworzeniu sprawa otwiera się na kanonicznym route po `caseNumber`.
- [x] Testy backendu, frontendów i typecheck przeszły.
- [ ] Ręczne QA w UI po stronie operatora BOK.