### PR TITLE
Doprecyzuj operatorowy flow po utworzeniu sprawy FNP

### DIFF
--- a/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.test.tsx
+++ b/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.test.tsx
@@ -79,6 +79,17 @@ const CANCEL_ACTION: PortingRequestStatusActionDto = {
   description: 'Anuluje sprawe.',
 }
 
+const SUBMIT_ACTION: PortingRequestStatusActionDto = {
+  actionId: 'SUBMIT',
+  label: 'Zloz sprawe',
+  targetStatus: 'SUBMITTED',
+  requiresReason: false,
+  requiresComment: false,
+  reasonLabel: null,
+  commentLabel: null,
+  description: 'Przekazuje sprawe do dalszej obslugi.',
+}
+
 const COMM_ACTION: PortingRequestCommunicationActionDto = {
   type: 'CLIENT_CONFIRMATION',
   label: 'Wyślij notyfikację',
@@ -118,6 +129,33 @@ describe('WhatsNextPanel', () => {
     expect(text).toContain('Sprawa: Złożona')
     expect(text).toContain('Najbliższy krok')
     expect(text).toContain('potwierdź')
+  })
+
+  it('DRAFT with submit action clearly points to submitting the prepared case', () => {
+    const tree = WhatsNextPanel(
+      makeProps({
+        status: 'DRAFT' as PortingCaseStatus,
+        availableStatusActions: [SUBMIT_ACTION, CANCEL_ACTION],
+      }),
+    )
+    const text = getTextContent(tree)
+    expect(text).toContain('szkic')
+    expect(text).toContain('Zloz sprawe')
+    expect(text).toContain('przekazac')
+  })
+
+  it('DRAFT without submit action does not suggest unavailable submission', () => {
+    const tree = WhatsNextPanel(
+      makeProps({
+        status: 'DRAFT' as PortingCaseStatus,
+        availableStatusActions: [],
+      }),
+    )
+    const text = getTextContent(tree)
+    expect(text).toContain('szkic')
+    expect(text).not.toContain('Zloz sprawe')
+    expect(text).not.toContain('zloz sprawe')
+    expect(text).not.toContain('przekazac ja do dalszej obslugi')
   })
 
   it('shows prioritized status action as primary button, wires scroll callback', () => {
@@ -180,7 +218,7 @@ describe('WhatsNextPanel', () => {
     expect(getTextContent(blocker)).toContain('nie ma przypisanego operatora BOK')
     const blockerButton = findAllButtons(blocker).find((b) =>
       getTextContent((b.props as { children?: ReactNode }).children).includes(
-        'Przypisz operatora',
+        'Przypisz do siebie',
       ),
     )
     expect(blockerButton).toBeDefined()

--- a/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx
+++ b/apps/frontend/src/components/WhatsNextPanel/WhatsNextPanel.tsx
@@ -73,10 +73,48 @@ const NEXT_STEP_COPY: Partial<Record<PortingCaseStatus, string>> = {
   ERROR: 'Sprawdź przyczynę błędu i wybierz dalsze działanie lub skontaktuj się z przełożonym.',
 }
 
+function hasStatusAction(
+  actions: PortingRequestStatusActionDto[],
+  actionId: PortingRequestStatusActionDto['actionId'],
+): boolean {
+  return actions.some((action) => action.actionId === actionId)
+}
+
 function buildNextStep(
   status: PortingCaseStatus,
   availableStatusActions: PortingRequestStatusActionDto[],
 ): string | null {
+  if (status === 'DRAFT') {
+    if (hasStatusAction(availableStatusActions, 'SUBMIT')) {
+      return 'szkic jest gotowy: uzupelnij brakujace dane, a potem uzyj akcji "Zloz sprawe", zeby przekazac ja dalej.'
+    }
+
+    return 'szkic jest zapisany. Backend nie udostepnia teraz akcji przekazania dalej dla Twojej sesji.'
+  }
+
+  if (status === 'SUBMITTED') {
+    if (
+      hasStatusAction(availableStatusActions, 'MARK_PENDING_DONOR') ||
+      hasStatusAction(availableStatusActions, 'CONFIRM') ||
+      hasStatusAction(availableStatusActions, 'REJECT')
+    ) {
+      return 'Zweryfikuj dane i wybierz jedna z dostepnych akcji statusu: przekazanie do dawcy, potwierdź albo odrzuc.'
+    }
+
+    return 'Sprawa jest zlozona. Jesli nie masz dostepnego kolejnego kroku, wroc do listy spraw i kontynuuj prace na kolejce.'
+  }
+
+  if (status === 'PENDING_DONOR') {
+    if (
+      hasStatusAction(availableStatusActions, 'CONFIRM') ||
+      hasStatusAction(availableStatusActions, 'REJECT')
+    ) {
+      return 'Czekaj na odpowiedz dawcy. Gdy nadejdzie, uzyj dostepnej akcji potwierdzenia albo odrzucenia.'
+    }
+
+    return 'Czekaj na odpowiedz dawcy. Gdy sprawa bedzie wymagala reakcji, dalszy krok pojawi sie w akcjach statusu albo na liscie spraw.'
+  }
+
   if (status === 'CONFIRMED') {
     const hasMarkPorted = availableStatusActions.some((a) => a.actionId === 'MARK_PORTED')
     return hasMarkPorted
@@ -204,8 +242,8 @@ function buildBlocker({
 
   if (!assignedUser) {
     return {
-      text: 'Sprawa nie ma przypisanego operatora BOK.',
-      ctaLabel: canManageAssignment ? 'Przypisz operatora' : 'Zobacz przypisanie',
+      text: 'Sprawa nie ma przypisanego operatora BOK. Jesli zaczynasz obsluge, przypisz ja do siebie.',
+      ctaLabel: canManageAssignment ? 'Przypisz do siebie' : 'Zobacz przypisanie',
       onClick: onScrollToAssignment,
     }
   }
@@ -223,6 +261,26 @@ function buildBlocker({
   }
 
   return null
+}
+
+function buildStatusSummary(status: PortingCaseStatus): string {
+  if (status === 'DRAFT') {
+    return 'To szkic sprawy. Dane sa zapisane, ale sprawa nie zostala jeszcze przekazana dalej.'
+  }
+
+  if (status === 'SUBMITTED') {
+    return 'Sprawa zostala zlozona i czeka na dalsza obsluge operacyjna.'
+  }
+
+  if (status === 'PENDING_DONOR') {
+    return 'Sprawa czeka na odpowiedz operatora oddajacego.'
+  }
+
+  if (status === 'CONFIRMED') {
+    return 'Sprawa jest potwierdzona i czeka na dzien przeniesienia.'
+  }
+
+  return STATUS_SUMMARY[status]
 }
 
 export function WhatsNextPanel({
@@ -270,8 +328,8 @@ export function WhatsNextPanel({
     : `Sprawa: ${statusMeta.label}`
 
   const summary = isTerminal
-    ? terminalCopy?.body ?? STATUS_SUMMARY[status]
-    : STATUS_SUMMARY[status]
+    ? terminalCopy?.body ?? buildStatusSummary(status)
+    : buildStatusSummary(status)
 
   const nextStep = isTerminal ? null : buildNextStep(status, availableStatusActions)
 

--- a/apps/frontend/src/components/layout/AppLayout.test.tsx
+++ b/apps/frontend/src/components/layout/AppLayout.test.tsx
@@ -72,6 +72,10 @@ describe('AppLayout admin navigation', () => {
     expect(html).toContain('Diagnostyka dostarczen')
     expect(html).toContain('Bledy notyfikacji')
     expect(html).toContain('Kolejka diagnostyczna')
+    expect(html).not.toContain('Zadania')
+    expect(html).not.toContain('Praca zespolu')
+    expect(html).not.toContain('Raporty')
+    expect(html).not.toContain('Kontrola i wyniki')
   })
 
   it('hides Users navigation link for non-admin', () => {
@@ -98,5 +102,7 @@ describe('AppLayout admin navigation', () => {
     expect(html).not.toContain('Administracja')
     expect(html).not.toContain('Proby notyfikacji')
     expect(html).not.toContain('Bledy notyfikacji')
+    expect(html).not.toContain('Zadania')
+    expect(html).not.toContain('Raporty')
   })
 })

--- a/apps/frontend/src/components/layout/AppLayout.tsx
+++ b/apps/frontend/src/components/layout/AppLayout.tsx
@@ -18,14 +18,6 @@ const primaryNavItems: NavItem[] = [
   { label: 'Dashboard', description: 'Pulpit operacyjny', path: ROUTES.DASHBOARD, icon: 'dashboard', exact: true },
   { label: 'Sprawy', description: 'Portowanie numerow', path: ROUTES.REQUESTS, icon: 'request-queue' },
   { label: 'Klienci', description: 'Kartoteka klientow', path: ROUTES.CLIENTS, icon: 'clients' },
-  { label: 'Zadania', description: 'Praca zespolu', path: ROUTES.TASKS, icon: 'tasks' },
-  {
-    label: 'Raporty',
-    description: 'Kontrola i wyniki',
-    path: ROUTES.REPORTS,
-    icon: 'reports',
-    roles: ['ADMIN', 'MANAGER', 'AUDITOR'],
-  },
   { label: 'Operatorzy', description: 'Slownik operatorow', path: ROUTES.OPERATORS, icon: 'operators' },
 ]
 

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.test.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+import {
+  RequestCreatedSuccessBanner,
+  clearCreatedRequestNavigationState,
+  isCreatedRequestNavigationState,
+} from './RequestDetailPage'
+
+describe('RequestDetailPage create-flow state', () => {
+  it('shows create success only for explicit createdRequest navigation state', () => {
+    expect(isCreatedRequestNavigationState({ createdRequest: true })).toBe(true)
+    expect(isCreatedRequestNavigationState({ createdRequest: false })).toBe(false)
+    expect(isCreatedRequestNavigationState({})).toBe(false)
+    expect(isCreatedRequestNavigationState(null)).toBe(false)
+  })
+
+  it('clears createdRequest while preserving unrelated navigation state', () => {
+    expect(
+      clearCreatedRequestNavigationState({
+        createdRequest: true,
+        fromList: true,
+        listSearch: '?status=DRAFT',
+      }),
+    ).toEqual({
+      fromList: true,
+      listSearch: '?status=DRAFT',
+    })
+  })
+
+  it('renders a clear operator-facing create success banner', () => {
+    const html = renderToStaticMarkup(<RequestCreatedSuccessBanner />)
+
+    expect(html).toContain('Sprawa zostala utworzona')
+    expect(html).toContain('Co dalej ze sprawa')
+    expect(html).toContain('Akcje statusu')
+  })
+})

--- a/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestDetailPage.tsx
@@ -129,6 +129,39 @@ const TECHNICAL_PAYLOAD_MESSAGE_TYPES = ['E03', 'E12', 'E18', 'E23'] as const
 
 type TechnicalPayloadMessageType = (typeof TECHNICAL_PAYLOAD_MESSAGE_TYPES)[number]
 type ManualExportResultsState = Record<PliCbdManualExportMessageType, PliCbdManualExportResultDto | null>
+type RequestDetailNavigationState = Record<string, unknown> | null
+
+export function isCreatedRequestNavigationState(state: unknown): boolean {
+  return Boolean(
+    state &&
+      typeof state === 'object' &&
+      'createdRequest' in state &&
+      (state as { createdRequest?: unknown }).createdRequest === true,
+  )
+}
+
+export function clearCreatedRequestNavigationState(
+  state: unknown,
+): RequestDetailNavigationState {
+  if (!state || typeof state !== 'object') {
+    return null
+  }
+
+  const rest = { ...(state as Record<string, unknown>) }
+  delete rest.createdRequest
+
+  return Object.keys(rest).length > 0 ? rest : null
+}
+
+export function RequestCreatedSuccessBanner() {
+  return (
+    <AlertBanner
+      tone="success"
+      title="Sprawa zostala utworzona."
+      description="To jest szkic sprawy. Sprawdz panel Co dalej ze sprawa? i wykonaj dostepny nastepny krok w sekcji Akcje statusu."
+    />
+  )
+}
 type ManualExportLoadingState = Record<PliCbdManualExportMessageType, boolean>
 type TechnicalPayloadResultsState = Record<
   TechnicalPayloadMessageType,
@@ -513,6 +546,9 @@ export function RequestDetailPage() {
   const navigate = useNavigate()
   const location = useLocation()
   const { user } = useAuthStore()
+  const [showCreatedRequestSuccess] = useState(() =>
+    isCreatedRequestNavigationState(location.state),
+  )
 
   // UUID of the loaded request — used by all secondary API calls and mutations.
   // Populated by loadRequest after the first successful fetch.
@@ -717,6 +753,17 @@ export function RequestDetailPage() {
     ? canConfirmPortDateForStatus(request.statusInternal)
     : false
   const communicationSummary = request?.communicationSummary ?? EMPTY_COMMUNICATION_SUMMARY
+
+  useEffect(() => {
+    if (!isCreatedRequestNavigationState(location.state)) {
+      return
+    }
+
+    void navigate(location.pathname + location.search, {
+      replace: true,
+      state: clearCreatedRequestNavigationState(location.state),
+    })
+  }, [location.pathname, location.search, location.state, navigate])
 
   const clearCommunicationFeedbackTimer = useCallback(() => {
     if (communicationFeedbackTimeoutRef.current !== null) {
@@ -1954,6 +2001,8 @@ export function RequestDetailPage() {
         onBackToList={backToList}
         onCopyLink={handleCopyLink}
       />
+
+      {showCreatedRequestSuccess && <RequestCreatedSuccessBanner />}
 
       <RequestAttentionStrip
         request={request}

--- a/apps/frontend/src/pages/Requests/RequestNewPage.tsx
+++ b/apps/frontend/src/pages/Requests/RequestNewPage.tsx
@@ -392,7 +392,9 @@ export function RequestNewPage() {
     }
     try {
       const request = await createPortingRequest(payload)
-      void navigate(buildPath(ROUTES.REQUEST_DETAIL, request.id))
+      void navigate(buildPath(ROUTES.REQUEST_DETAIL, request.id), {
+        state: { createdRequest: true },
+      })
     } catch (error) {
       if (axios.isAxiosError(error)) {
         if (error.response?.status === 409) {


### PR DESCRIPTION
## Cel
Doprecyzowanie operatorowego flow po utworzeniu sprawy FNP bez budowania osobnego modułu Zadania.

## Zakres
- WhatsNextPanel opiera sugestie DRAFT/SUBMITTED/PENDING_DONOR na realnych availableStatusActions.
- DRAFT ma jaśniejsze copy jako szkic i sugeruje przypisanie do siebie, jeśli jest to właściwe.
- Success banner po utworzeniu sprawy jest jednorazowy i czyści location.state przez replace.
- Ukryto puste zakładki Zadania i Raporty z głównego menu.
- Routing bezpośredni /tasks i /reports pozostawiono.

## Walidacja
- apps/frontend: npx vitest run — PASS, 48 plików / 425 testów.
- apps/frontend: npx tsc --noEmit — PASS.
- apps/frontend: npm run build — PASS.
- apps/backend: npx vitest run — PASS, 72 pliki / 588 testów.
- apps/backend: npx tsc --noEmit — PASS.

## Poza zakresem
- Brak nowego modułu Tasks.
- Brak raportów.
- Brak nowych statusów.
- Brak zmian w backend workflow, liście, filtrach, sortowaniu, ERROR i notification ops.

## Runtime QA
Zalecany krótki smoke test detaila po create-flow przed merge.