### PR TITLE
chore(etap12): production readiness — AUDITOR seed, deploy checklist, placeholder cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,8 @@ apps/frontend/.vite/
 # Claude Code worktrees (git-managed, must not be tracked as gitlinks)
 .claude/worktrees/
 
+# Claude Code local settings (machine-specific, not for commits)
+.claude/settings.local.json
+
 # Claude Code session scratchpad (local task tracking, not for commits)
 scratchpad/

--- a/README.md
+++ b/README.md
@@ -54,11 +54,17 @@ npm run db:migrate
 npm run db:seed
 ```
 
-Po seedzie dostępne jest konto administratora:
-- **E-mail:** `admin@np-manager.local`
-- **Hasło:** `Admin@NP2026!`
+Po seedzie dostępne są konta QA:
 
-> ⚠️ Zmień hasło administratora po pierwszym zalogowaniu.
+| Rola | E-mail | Hasło |
+|---|---|---|
+| ADMIN | `admin@np-manager.local` | `Admin@NP2026!` |
+| BOK_CONSULTANT | `bok@np-manager.local` | `Bok@NP2026!` |
+| BACK_OFFICE | `back-office@np-manager.local` | `BackOffice@NP2026!` |
+| MANAGER | `manager@np-manager.local` | `Manager@NP2026!` |
+| AUDITOR | `auditor@np-manager.local` | `Auditor@NP2026!` |
+
+> ⚠️ Konta QA są przeznaczone wyłącznie do środowiska dev/demo. Nie używaj tych haseł na produkcji.
 
 ### 5. Uruchom aplikację w trybie deweloperskim
 
@@ -176,6 +182,24 @@ Po uruchomieniu `npm run db:seed` system zawiera:
 - 5 przykładowych operatorów telekomunikacyjnych
 - Ustawienia systemowe (SLA, limity plików)
 - Kalendarz świąt 2026
+
+---
+
+## Deployment checklist
+
+Przed wdrożeniem na środowisko produkcyjne lub staging:
+
+- [ ] Ustaw `NODE_ENV=production` w środowisku backendu
+- [ ] Wygeneruj silny `JWT_SECRET` (min. 32 znaki): `openssl rand -hex 32`
+- [ ] Ustaw `DATABASE_URL` wskazujący na produkcyjną bazę PostgreSQL
+- [ ] Ustaw `FRONTEND_URL` na docelowy adres frontendu (CORS)
+- [ ] Uruchom migracje przed startem: `npm run db:migrate:prod`
+- [ ] Zweryfikuj health check: `GET /health/ready` powinno zwracać `200`
+- [ ] Ustaw `INTERNAL_NOTIFICATION_EMAIL_ADAPTER=STUB|REAL|DISABLED` zgodnie z potrzebą
+- [ ] Nie seeduj kont QA na produkcji (`npm run db:seed` tylko dev/demo)
+- [ ] Zmień hasło pgAdmin (`admin123`) jeśli pgAdmin jest dostępny publicznie
+- [ ] Backend: długo żyjący proces Node.js (Railway, VPS) — nie Vercel serverless
+- [ ] Frontend: statyczny hosting (Vercel, Netlify, nginx) z `VITE_API_URL` wskazującym na backend
 
 ---
 

--- a/apps/backend/prisma/__tests__/seed.qa-users.test.ts
+++ b/apps/backend/prisma/__tests__/seed.qa-users.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { QA_SEED_USERS } from '../seed'
 
 describe('QA seed users', () => {
-  it('contains all four required QA roles', () => {
+  it('contains all required QA roles', () => {
     const roles = QA_SEED_USERS.map((u) => u.role)
     expect(roles).toContain('ADMIN')
     expect(roles).toContain('BOK_CONSULTANT')
     expect(roles).toContain('BACK_OFFICE')
     expect(roles).toContain('MANAGER')
+    expect(roles).toContain('AUDITOR')
   })
 
   it('contains expected email addresses', () => {
@@ -16,6 +17,7 @@ describe('QA seed users', () => {
     expect(emails).toContain('bok@np-manager.local')
     expect(emails).toContain('back-office@np-manager.local')
     expect(emails).toContain('manager@np-manager.local')
+    expect(emails).toContain('auditor@np-manager.local')
   })
 
   it('has unique emails', () => {

--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -879,6 +879,12 @@ export const QA_SEED_USERS = [
     firstName: 'Manager',
     lastName: 'QA',
   },
+  {
+    email: 'auditor@np-manager.local',
+    role: 'AUDITOR' as const,
+    firstName: 'Audytor',
+    lastName: 'QA',
+  },
 ] as const
 
 // ============================================================
@@ -1281,6 +1287,32 @@ export async function seedMain() {
   console.info('   ✓ Konto testowe MANAGER gotowe')
   console.info('   📧  E-mail:  manager@np-manager.local')
   console.info('   🔑  Hasło:   Manager@NP2026!')
+
+  // Konto testowe AUDITOR — dostep do raportow operacyjnych (tylko odczyt)
+  const auditorPassword = 'Auditor@NP2026!'
+  const auditorPasswordHash = await bcrypt.hash(auditorPassword, 12)
+
+  await prisma.user.upsert({
+    where: { email: 'auditor@np-manager.local' },
+    update: {
+      passwordHash: auditorPasswordHash,
+      firstName: 'Audytor',
+      lastName: 'QA',
+      role: 'AUDITOR',
+      isActive: true,
+    },
+    create: {
+      email: 'auditor@np-manager.local',
+      passwordHash: auditorPasswordHash,
+      firstName: 'Audytor',
+      lastName: 'QA',
+      role: 'AUDITOR',
+      isActive: true,
+    },
+  })
+  console.info('   ✓ Konto testowe AUDITOR gotowe')
+  console.info('   📧  E-mail:  auditor@np-manager.local')
+  console.info('   🔑  Hasło:   Auditor@NP2026!')
 
   // ----------------------------------------------------------
   // 6. DANE QA â€” klient i sprawy portowania
@@ -2362,7 +2394,7 @@ export async function seedMain() {
   console.info(`  • ${transitionCount} przejść statusów`)
   console.info(`  • ${documentTypes.length} typów dokumentów`)
   console.info(`  • ${operators.length} operatorów`)
-  console.info('  • 4 konta użytkowników (ADMIN + BOK_CONSULTANT + BACK_OFFICE + MANAGER)')
+  console.info('  • 5 kont użytkowników (ADMIN + BOK_CONSULTANT + BACK_OFFICE + MANAGER + AUDITOR)')
   console.info(`  • ${settings.length} ustawień systemowych`)
   console.info(`  • ${holidays2026.length} dni wolnych 2026`)
   console.info('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━')

--- a/apps/frontend/src/router.tsx
+++ b/apps/frontend/src/router.tsx
@@ -222,7 +222,7 @@ export const router = createBrowserRouter([
       {
         path: ROUTES.TASKS,
         element: (
-          <PlaceholderPage title="Zadania" description="Implementacja w Sprint 2 (Faza 2)" />
+          <PlaceholderPage title="Zadania" description="Moduł zadań nie jest jeszcze dostępny." />
         ),
       },
       {


### PR DESCRIPTION
## Etap 12 — Production Readiness

Audyt + minimalne poprawki przed realnym testowaniem/użyciem przez pracowników.

### Zmiany

**AUDITOR seed account**
- Dodano konto `auditor@np-manager.local` do `QA_SEED_USERS` i `seedMain()`
- Rola AUDITOR istniała w kodzie i backendu i frontendu (raporty operacyjne), ale brakowało konta QA do testowania
- Zaktualizowano `seed.qa-users.test.ts` — test teraz asertuje wszystkie 5 ról

**Placeholder `/tasks`**
- Usunięto stale dev tekst "Sprint 2 (Faza 2)" widoczny dla użytkownika
- Zastąpiono neutralnym komunikatem "Moduł zadań nie jest jeszcze dostępny."

**README**
- Tabela kont QA — wszystkie 5 ról z hasłami
- Nowa sekcja "Deployment checklist" z krokami przed wdrożeniem produkcyjnym
- Wskazanie: backend = długo żyjący proces (Railway/VPS), nie Vercel serverless

**.gitignore**
- Dodano `.claude/settings.local.json` (plik lokalny, nie do commita)

### Testy / walidacja
- `npx tsc --noEmit` — backend ✅, frontend ✅
- `npx vitest run prisma/__tests__/seed.qa-users.test.ts` — 4/4 passed ✅

### Czego świadomie nie zmieniono
- Workflow statusów, PLI CBD, notification ops, raporty, lista spraw
- Brak railway.json/Dockerfile — deployment config do osobnego etapu gdy znana platforma
- Brak nowych migracji DB

### Pozostałe ryzyka przed produkcją
- Brak railway.json / Dockerfile — deployment wymaga ręcznej konfiguracji
- pgAdmin password `admin123` hardcoded w docker-compose (tylko dev, nie produkcja)
- `INTERNAL_NOTIFICATION_EMAIL_ADAPTER=STUB` domyślnie — do zmiany gdy realny SMTP