### PR TITLE
chore(etap13): staging deployment readiness — railway.json, vercel.json, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Etap 13 — pierwsze wdrożenie staging/demo. Realne SMTP, realne PLI CBD oraz d
 |---|---|---|
 | Backend (Fastify, long-running Node) | Railway (lub VPS / Fly.io / Render) | `railway.json` w root — build + healthcheck `/health`. **Nie** Vercel serverless. |
 | PostgreSQL 16 | Railway Postgres / Neon / Supabase / RDS | `DATABASE_URL` przekazany do backendu |
-| Frontend (Vite SPA static) | Vercel / Netlify / Railway static / GH Pages | `apps/frontend/vercel.json` ma SPA fallback (`/(.*) → /index.html`) |
+| Frontend (Vite SPA static) | Vercel / Netlify / Railway static / GH Pages | `vercel.json` (root) ma SPA fallback (`/(.*) → /index.html`), outputDirectory `apps/frontend/dist` |
 
 ### Wymagane zmienne środowiskowe — backend (staging)
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,86 @@ Po uruchomieniu `npm run db:seed` system zawiera:
 
 ---
 
+## Staging deployment (demo/QA)
+
+Etap 13 — pierwsze wdrożenie staging/demo. Realne SMTP, realne PLI CBD oraz dane produkcyjne **nie są** w zakresie tego środowiska.
+
+### Rekomendowana architektura
+
+| Warstwa | Platforma | Uwagi |
+|---|---|---|
+| Backend (Fastify, long-running Node) | Railway (lub VPS / Fly.io / Render) | `railway.json` w root — build + healthcheck `/health`. **Nie** Vercel serverless. |
+| PostgreSQL 16 | Railway Postgres / Neon / Supabase / RDS | `DATABASE_URL` przekazany do backendu |
+| Frontend (Vite SPA static) | Vercel / Netlify / Railway static / GH Pages | `apps/frontend/vercel.json` ma SPA fallback (`/(.*) → /index.html`) |
+
+### Wymagane zmienne środowiskowe — backend (staging)
+
+| Klucz | Wartość staging |
+|---|---|
+| `NODE_ENV` | `staging` |
+| `PORT` | ustawiane przez platformę (Railway injectuje); backend nasłuchuje `0.0.0.0:$PORT` |
+| `DATABASE_URL` | `postgresql://USER:PASS@HOST:PORT/DB` (managed Postgres) |
+| `JWT_SECRET` | min. 32 znaki, unikalny — `openssl rand -hex 32` |
+| `JWT_EXPIRES_IN` | `8h` (lub krócej dla demo) |
+| `FRONTEND_URL` | publiczny URL frontendu staging (CORS allow-origin) |
+| `LOG_LEVEL` | `info` |
+| `UPLOAD_DIR` | `./uploads` (uwaga: ephemeral FS na Railway — pliki znikają po redeploy) |
+| `MAX_FILE_SIZE_MB` | `10` |
+| `INTERNAL_NOTIFICATION_EMAIL_ADAPTER` | `STUB` (brak realnego SMTP na stagingu) |
+| `SMTP_*` | puste |
+| `PLI_CBD_TRANSPORT_MODE` | `STUB` |
+| `PLI_CBD_REAL_SOAP_*` | puste / domyślne placeholdery |
+
+### Wymagane zmienne — frontend (staging)
+
+| Klucz | Wartość staging |
+|---|---|
+| `VITE_API_URL` | publiczny URL backendu staging, np. `https://np-manager-api.up.railway.app` |
+| `VITE_APP_NAME` | `NP-Manager (staging)` (opcjonalne) |
+
+### Kroki wdrożenia
+
+1. **Postgres** — utwórz bazę staging i pobierz `DATABASE_URL`.
+2. **Backend (Railway)**:
+   - Połącz repo, root `/`, plik `railway.json` zostanie wykryty automatycznie.
+   - Build: `npm ci && npm run build -w packages/shared && npm run build -w apps/backend` (wykonywany przez Railway).
+   - Start: `npm run db:migrate:prod -w apps/backend && npm run start -w apps/backend` — migracje uruchamiają się przed startem.
+   - Healthcheck: `/health`.
+   - Ustaw zmienne środowiskowe z tabeli powyżej.
+3. **Seed QA (jednorazowo, ręcznie)**:
+   ```bash
+   railway run --service backend npm run db:seed -w apps/backend
+   ```
+   Seed jest idempotentny i tworzy konta: `admin`, `bok`, `back-office`, `manager`, `auditor`. **Nie uruchamiaj seeda na produkcji z realnymi danymi.**
+4. **Frontend (Vercel)**:
+   - Project root: `apps/frontend` (lub root z `vercel.json` — patrz plik).
+   - Ustaw `VITE_API_URL` na URL backendu staging.
+   - Build/output zdefiniowane w `apps/frontend/vercel.json`.
+5. **CORS** — upewnij się, że `FRONTEND_URL` na backendzie = dokładny URL deployu frontendu (bez trailing slash).
+
+### Smoke checklist (po każdym deployu staging)
+
+- [ ] `GET /health` → `200`
+- [ ] `GET /health/ready` → `200` (DB osiągalna, schema OK)
+- [ ] Login: ADMIN, BOK, BACK_OFFICE, MANAGER, AUDITOR
+- [ ] Utworzenie sprawy FNP (BOK)
+- [ ] Przejście DRAFT → SUBMITTED
+- [ ] Anulowanie błędnej sprawy (Etap 10 flow)
+- [ ] `/reports` dostępne dla ADMIN i MANAGER i AUDITOR
+- [ ] `/reports` zablokowane dla BOK (403/redirect)
+- [ ] Brak błędów CORS w konsoli przeglądarki
+
+### Znane ograniczenia staging
+
+- PLI CBD: tryb STUB, brak realnej integracji SOAP.
+- Notyfikacje email: STUB, brak realnej wysyłki.
+- Dane: tylko demo/QA z seeda — **nie używać realnych danych klientów**.
+- Uploads na Railway: ephemeral FS — załączniki giną po redeploy (akceptowalne dla demo, do zmiany przy produkcji: S3/object storage).
+- Brak skonfigurowanego CI/CD (deploy ręczny / przez integrację Railway+GitHub).
+- Brak realnych sekretów w repo — wszystkie wartości są przykładowe.
+
+---
+
 ## Deployment checklist
 
 Przed wdrożeniem na środowisko produkcyjne lub staging:

--- a/apps/frontend/vercel.json
+++ b/apps/frontend/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd ../.. && npm ci && npm run build -w packages/shared && npm run build -w apps/frontend",
+  "outputDirectory": "dist",
+  "framework": null,
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "NIXPACKS",
+    "buildCommand": "npm ci && npm run build -w packages/shared && npm run build -w apps/backend"
+  },
+  "deploy": {
+    "startCommand": "npm run db:migrate:prod -w apps/backend && npm run start -w apps/backend",
+    "healthcheckPath": "/health",
+    "healthcheckTimeout": 30,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 5
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "cd ../.. && npm ci && npm run build -w packages/shared && npm run build -w apps/frontend",
-  "outputDirectory": "dist",
+  "buildCommand": "npm ci && npm run build -w packages/shared && npm run build -w apps/frontend",
+  "outputDirectory": "apps/frontend/dist",
   "framework": null,
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }


### PR DESCRIPTION
## Summary

Etap 13 — przygotowanie repo pod pierwszy deploy staging/demo. Bez zmian runtime, bez nowych funkcji biznesowych, bez realnej integracji SMTP/PLI CBD.

## What changed

- **`railway.json`** (root) — minimalny config dla backendu na Railway:
  - build: `npm ci && npm run build -w packages/shared && npm run build -w apps/backend`
  - start: `npm run db:migrate:prod -w apps/backend && npm run start -w apps/backend` (migracje przed startem)
  - healthcheck: `/health`, restart ON_FAILURE (max 5)
- **`apps/frontend/vercel.json`** — SPA fallback (`/(.*) → /index.html`) + build z workspace root, żeby `@np-manager/shared` zbudował się przed frontendem
- **`README.md`** — nowa sekcja "Staging deployment (demo/QA)":
  - rekomendowana architektura (Railway + managed Postgres + Vercel)
  - tabele wymaganych env dla backendu i frontendu
  - kroki wdrożenia (DB → backend → seed → frontend → CORS)
  - smoke checklist (/health, /health/ready, login 5 ról, create FNP, DRAFT→SUBMITTED, cancel błędnej sprawy, /reports RBAC)
  - znane ograniczenia (PLI CBD STUB, email STUB, ephemeral uploads, brak CI)

## Audit findings (no code changes needed)

- Backend już słucha `0.0.0.0:env.PORT`, ma `/health` i `/health/ready`, CORS używa `FRONTEND_URL`, env walidowane Zod-em (`apps/backend/src/config/env.ts`).
- `apps/backend/package.json` ma `prebuild` z `prisma generate` i `db:migrate:prod` — gotowe do release flow Railway.
- Frontend to Vite static build, używa `VITE_API_URL`.
- `.env.example` (backend + frontend) — kompletne dla staging STUB-mode, nic nie dodawano.

## What was deliberately NOT done

- Brak realnego SMTP, brak realnego PLI CBD, brak deployu, brak nowej bazy, brak nowych migracji.
- Brak Dockerfile (Railway Nixpacks wystarcza dla monorepo z npm workspaces).
- Brak CI/CD/GitHub Actions (poza zakresem etapu, repo nie ma required checks).
- Brak zmian w kodzie runtime, workflow biznesowym, lifecycle, raportach, RBAC, PLI CBD ani notyfikacjach.
- Brak realnych sekretów w repo.

## Test plan

- [ ] Reviewer: zweryfikuj że `railway.json` build/start commands odpowiadają package scripts
- [ ] Reviewer: zweryfikuj że `vercel.json` rewrite obsługuje deep linki SPA
- [ ] Reviewer: README env tables zgodne z `apps/backend/src/config/env.ts` i `apps/frontend/.env.example`
- [ ] Po merge: rzeczywisty deploy staging na Railway/Vercel + smoke checklist z README

Buildów nie uruchamiano — zmiany tylko config/docs, package scripts nietknięte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)