### PR TITLE
fix(deploy): remove duplicate npm ci from railway build

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -2,7 +2,7 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "npm ci && npm run build -w packages/shared && npm run build -w apps/backend"
+    "buildCommand": "npm run build -w packages/shared && npm run build -w apps/backend"
   },
   "deploy": {
     "startCommand": "npm run db:migrate:prod -w apps/backend && npm run start -w apps/backend",


### PR DESCRIPTION
Usuwa `npm ci` z `railway.json`, ponieważ Railway/Nixpacks wykonuje instalację zależności automatycznie przed buildCommand. Zapobiega błędowi EBUSY na cache node_modules.