### PR TITLE
fix(frontend): use VITE_API_URL for axios baseURL — fixes prod 405 on Vercel

### DIFF
--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,6 +1,6 @@
-# Adres backendu API
-# W trybie dev Vite proxy przekierowuje /api → VITE_API_URL
-# Możesz też wskazać bezpośrednio adres backendu
+# Adres backendu API (bez trailing slash, bez /api)
+# Dev (Vite proxy): zostaw puste lub ustaw http://localhost:3001
+# Prod (Railway):   VITE_API_URL=https://np-manager-production.up.railway.app
 VITE_API_URL="http://localhost:3001"
 
 # Nazwa aplikacji (wyświetlana w UI)

--- a/apps/frontend/src/services/api.client.test.ts
+++ b/apps/frontend/src/services/api.client.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// Import after env stub — module-level getApiBaseUrl() reads import.meta.env at call time
+import { getApiBaseUrl } from './api.client'
+
+describe('getApiBaseUrl', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns /api when VITE_API_URL is not set', () => {
+    vi.stubEnv('VITE_API_URL', '')
+    expect(getApiBaseUrl()).toBe('/api')
+  })
+
+  it('builds Railway URL when VITE_API_URL is set', () => {
+    vi.stubEnv('VITE_API_URL', 'https://np-manager-production.up.railway.app')
+    expect(getApiBaseUrl()).toBe('https://np-manager-production.up.railway.app/api')
+  })
+
+  it('strips trailing slash from VITE_API_URL', () => {
+    vi.stubEnv('VITE_API_URL', 'https://np-manager-production.up.railway.app/')
+    expect(getApiBaseUrl()).toBe('https://np-manager-production.up.railway.app/api')
+  })
+})

--- a/apps/frontend/src/services/api.client.ts
+++ b/apps/frontend/src/services/api.client.ts
@@ -2,9 +2,12 @@ import axios from 'axios'
 import { useAuthStore } from '@/stores/auth.store'
 
 /**
- * Klient HTTP dla całej aplikacji.
+ * Zwraca bazowy URL klienta HTTP.
  *
- * baseURL: '/api' — Vite proxy przekierowuje na http://localhost:3001/api
+ * Prod/staging: VITE_API_URL=https://np-manager-production.up.railway.app
+ *   → baseURL = 'https://np-manager-production.up.railway.app/api'
+ *
+ * Dev (brak VITE_API_URL): baseURL = '/api' — obsługiwany przez Vite proxy.
  *
  * Request interceptor: dołącza token JWT z auth store do każdego żądania.
  *
@@ -13,8 +16,14 @@ import { useAuthStore } from '@/stores/auth.store'
  * może normalnie obsłużyć błąd 401 (nieprawidłowe dane) bez niechcianego
  * czyszczenia sesji i przekierowania.
  */
+export const getApiBaseUrl = (): string => {
+  const envUrl = import.meta.env.VITE_API_URL as string | undefined
+  if (!envUrl) return '/api'
+  return `${envUrl.replace(/\/$/, '')}/api`
+}
+
 export const apiClient = axios.create({
-  baseURL: '/api',
+  baseURL: getApiBaseUrl(),
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## Problem

Po redeployu frontend na Vercel wysyłał login do własnego `/api/auth/login` zamiast do Railway. Zwracał 405.

**Root cause:** `api.client.ts` miał `baseURL: '/api'` hardcoded. Vite proxy przekierowuje `/api` → backend tylko w dev. W produkcji Vercel nie ma proxy, więc request trafiał na sam Vercel.

## Zmiany

| Plik | Co |
|---|---|
| `apps/frontend/src/services/api.client.ts` | Dodano `getApiBaseUrl()`: czyta `VITE_API_URL`, zwraca `{VITE_API_URL}/api`. Fallback `/api` tylko gdy brak zmiennej (dev). |
| `apps/frontend/src/services/api.client.test.ts` | 3 testy: brak env → `/api`, Railway URL, trailing slash strip. |
| `apps/frontend/.env.example` | Komentarz dev vs prod. |

## Wymagane działanie po merge

**Dodać zmienną w Vercel Dashboard** → Project Settings → Environment Variables:

```
Name:   VITE_API_URL
Value:  https://np-manager-production.up.railway.app
Environments: Production, Preview, Development
```

Bez tej zmiennej fix nie zadziała — `VITE_*` są wbudowywane w bundle podczas `vite build`.

## Testy

- ✅ 3/3 unit testy pass (`vitest run`)
- ✅ TypeScript clean (`tsc --noEmit`)
- ✅ Build OK (`vite build`)

## Ryzyka

Brak — zmiana tylko w `baseURL` init, interceptory i logika autoryzacji nieruszone. Dev flow bez `VITE_API_URL` działa tak samo jak przed zmianą.