### PR TITLE
fix(frontend): block localhost in prod build — guard against Vercel misconfiguration

### DIFF
--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,7 +1,15 @@
 # Adres backendu API (bez trailing slash, bez /api)
-# Dev (Vite proxy): zostaw puste lub ustaw http://localhost:3001
-# Prod (Railway):   VITE_API_URL=https://np-manager-production.up.railway.app
-VITE_API_URL="http://localhost:3001"
+# Dev (Vite proxy): zostaw puste — proxy przekieruje /api → localhost:3001
+# Prod (Railway):   WYMAGANE — ustaw w Vercel Environment Variables
+#
+# UWAGA: NIE ustawiaj http://localhost:3001 jako wartości w Vercel Production!
+#        Produkcyjny build zignoruje localhost i zaloguje błąd konfiguracji.
+#
+# Vercel Production / Preview / Development:
+#   VITE_API_URL=https://np-manager-production.up.railway.app
+#
+# Lokalne dev (opcjonalne — Vite proxy działa bez tej zmiennej):
+# VITE_API_URL=http://localhost:3001
 
 # Nazwa aplikacji (wyświetlana w UI)
 VITE_APP_NAME="NP-Manager"

--- a/apps/frontend/src/services/api.client.test.ts
+++ b/apps/frontend/src/services/api.client.test.ts
@@ -8,7 +8,7 @@ describe('getApiBaseUrl', () => {
     vi.unstubAllEnvs()
   })
 
-  it('returns /api when VITE_API_URL is not set', () => {
+  it('returns /api when VITE_API_URL is not set (dev)', () => {
     vi.stubEnv('VITE_API_URL', '')
     expect(getApiBaseUrl()).toBe('/api')
   })
@@ -21,5 +21,23 @@ describe('getApiBaseUrl', () => {
   it('strips trailing slash from VITE_API_URL', () => {
     vi.stubEnv('VITE_API_URL', 'https://np-manager-production.up.railway.app/')
     expect(getApiBaseUrl()).toBe('https://np-manager-production.up.railway.app/api')
+  })
+
+  it('returns /api and logs error when PROD=true and VITE_API_URL not set', () => {
+    vi.stubEnv('PROD', true)
+    vi.stubEnv('VITE_API_URL', '')
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(getApiBaseUrl()).toBe('/api')
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('VITE_API_URL'))
+    consoleSpy.mockRestore()
+  })
+
+  it('returns /api and logs error when PROD=true and VITE_API_URL is localhost', () => {
+    vi.stubEnv('PROD', true)
+    vi.stubEnv('VITE_API_URL', 'http://localhost:3001')
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(getApiBaseUrl()).toBe('/api')
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('VITE_API_URL'))
+    consoleSpy.mockRestore()
   })
 })

--- a/apps/frontend/src/services/api.client.ts
+++ b/apps/frontend/src/services/api.client.ts
@@ -4,10 +4,12 @@ import { useAuthStore } from '@/stores/auth.store'
 /**
  * Zwraca bazowy URL klienta HTTP.
  *
- * Prod/staging: VITE_API_URL=https://np-manager-production.up.railway.app
+ * Prod: VITE_API_URL=https://np-manager-production.up.railway.app (wymagane)
  *   → baseURL = 'https://np-manager-production.up.railway.app/api'
  *
- * Dev (brak VITE_API_URL): baseURL = '/api' — obsługiwany przez Vite proxy.
+ * Dev (brak VITE_API_URL lub localhost): baseURL = '/api' — Vite proxy → localhost:3001.
+ *
+ * Prod + brak VITE_API_URL lub localhost: blokuje wywołanie, loguje błąd, zwraca '/api'.
  *
  * Request interceptor: dołącza token JWT z auth store do każdego żądania.
  *
@@ -17,9 +19,24 @@ import { useAuthStore } from '@/stores/auth.store'
  * czyszczenia sesji i przekierowania.
  */
 export const getApiBaseUrl = (): string => {
-  const envUrl = import.meta.env.VITE_API_URL as string | undefined
-  if (!envUrl) return '/api'
-  return `${envUrl.replace(/\/$/, '')}/api`
+  const rawUrl = (import.meta.env.VITE_API_URL as string | undefined)?.trim()
+
+  const isLocalhost =
+    rawUrl?.startsWith('http://localhost') || rawUrl?.startsWith('http://127.0.0.1')
+
+  if (import.meta.env.PROD && (!rawUrl || isLocalhost)) {
+    console.error(
+      `[api.client] VITE_API_URL nie jest skonfigurowany dla produkcji` +
+        ` (wartość: "${rawUrl ?? 'undefined'}").` +
+        ` Ustaw VITE_API_URL=https://np-manager-production.up.railway.app` +
+        ` w Vercel Environment Variables.`,
+    )
+    return '/api'
+  }
+
+  if (!rawUrl) return '/api'
+
+  return `${rawUrl.replace(/\/$/, '')}/api`
 }
 
 export const apiClient = axios.create({


### PR DESCRIPTION
## Problem

Produkcja wywołuje `http://localhost:3001/api/auth/login` zamiast Railway.

**Root cause:** `VITE_API_URL=http://localhost:3001` był ustawiony w Vercel Environment Variables (prawdopodobnie skopiowany z `.env.example`). Poprzedni fix (PR #130) czytał `VITE_API_URL`, ale akceptował dowolną niepustą wartość — włącznie z localhost.

## Zmiany

| Plik | Co |
|---|---|
| `apps/frontend/src/services/api.client.ts` | `getApiBaseUrl()`: wykrywa `localhost`/`127.0.0.1` w trybie `PROD`, loguje błąd konfiguracji i zwraca `'/api'` zamiast wywoływać localhost |
| `apps/frontend/src/services/api.client.test.ts` | 2 nowe testy: `PROD+brak URL` i `PROD+localhost` → oba zwracają `/api` i triggerują `console.error` |
| `apps/frontend/.env.example` | Ostrzeżenie: NIE ustawiać localhost w Vercel Production |

## Wymagane działanie w Vercel Dashboard

**Zmień wartość zmiennej** w [Vercel → np-manager-frontend → Settings → Environment Variables](https://vercel.com/lukaszs-projects-d71b6aef/np-manager-frontend/settings/environment-variables):

```
VITE_API_URL = https://np-manager-production.up.railway.app
```

Environments: **Production**, Preview, Development

Bez tej zmiany kod nadal zwróci `/api` (żaden request nie pójdzie na localhost, ale Railway też nie zadziała).

## Testy

- ✅ 5/5 unit testy pass
- ✅ TypeScript clean